### PR TITLE
Add multi-module snapshotting to sample, fix local perf test task output

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/LocalPerfTest.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/LocalPerfTest.kt
@@ -75,7 +75,8 @@ abstract class LocalPerfTest : DefaultTask() {
         }
         it.add("${testPackageName.get()}/${EmergePlugin.EMERGE_JUNIT_RUNNER}")
       }
-      shell(instrumentationArgs)
+      val output = shell(instrumentationArgs)
+      logger.lifecycle(output)
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ compose-bom = "2023.05.01"
 detekt = "1.22.0"
 kotlin = "1.8.21"
 kotlinpoet = "1.13.2"
-ksp = "1.8.20-1.0.11"
+ksp = "1.8.21-1.0.11"
 okhttp = "4.10.0"
 junit-jupiter = "5.8.2"
 

--- a/snapshots/sample/app/build.gradle.kts
+++ b/snapshots/sample/app/build.gradle.kts
@@ -28,11 +28,13 @@ android {
     }
     debug {
       applicationIdSuffix = ".debug"
-      sourceSets {
-        getByName("androidTest") {
-          java.srcDir("generated/ksp/debugAndroidTest/kotlin")
-        }
-      }
+    }
+  }
+
+  sourceSets {
+    getByName("androidTest") {
+      // Adds sources from submodules for including snapshot tests
+      kotlin.srcDir("../ui-module/src/androidTest/kotlin")
     }
   }
 
@@ -68,8 +70,10 @@ dependencies {
 
   kspAndroidTest(projects.snapshots.snapshotsProcessor)
 
-  debugImplementation(projects.snapshots.sample.uiModule)
   androidTestImplementation(projects.snapshots.snapshots)
   androidTestImplementation(libs.compose.runtime)
   androidTestImplementation(libs.junit)
+
+  // Necessary for multi-module snapshotting
+  androidTestImplementation(projects.snapshots.sample.uiModule)
 }

--- a/snapshots/sample/build.gradle.kts
+++ b/snapshots/sample/build.gradle.kts
@@ -1,9 +1,8 @@
 plugins {
-	id("com.emergetools.android")
+  id("com.emergetools.android")
 }
 
 emerge {
-	appProjectPath.set(":app")
-
-	apiToken.set(System.getenv("EMERGE_API_TOKEN"))
+  appProjectPath.set(":app")
+  apiToken.set(System.getenv("EMERGE_API_TOKEN"))
 }

--- a/snapshots/sample/ui-module/build.gradle.kts
+++ b/snapshots/sample/ui-module/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.android)
-  alias(libs.plugins.ksp)
 }
 
 android {

--- a/snapshots/sample/ui-module/build.gradle.kts
+++ b/snapshots/sample/ui-module/build.gradle.kts
@@ -8,6 +8,11 @@ android {
   namespace = "com.emergetools.snapshots.sample.ui"
   compileSdk = 33
 
+  defaultConfig {
+    minSdk = 23
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  }
+
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
@@ -17,27 +22,12 @@ android {
     jvmTarget = JavaVersion.VERSION_17.toString()
   }
 
-  defaultConfig {
-    minSdk = 23
-    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-  }
-
   buildFeatures {
     compose = true
   }
 
   composeOptions {
     kotlinCompilerExtensionVersion = "1.4.7"
-  }
-
-  buildTypes {
-    debug {
-      sourceSets {
-        getByName("androidTest") {
-          java.srcDir("generated/ksp/debugAndroidTest/kotlin")
-        }
-      }
-    }
   }
 }
 
@@ -49,8 +39,6 @@ dependencies {
   implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.material)
 
-  kspAndroidTest(projects.snapshots.snapshotsProcessor)
-  androidTestImplementation(projects.snapshots.snapshots)
   androidTestImplementation(libs.compose.runtime)
   androidTestImplementation(libs.junit)
 }


### PR DESCRIPTION
- Add support for multi-module snapshot testing to the `:snapshots:sample` project.
- Adds explicit import for composable function to generated snapshot tests.
- Fixes a bug in the gradle plugin where output of local perf test wasn't logged to user.
- Minor cleanups, increase KSP version to get rid of warning logs.