### PR TITLE
Emerge test SDK as an explicit import now

### DIFF
--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -297,6 +297,14 @@ plugins {
 }
 ```
 
+- Users must now add the Emerge perf test SDK dependency to their performance module:
+
+```kotlin
+dependencies {
+  implementation("com.emergetools.test:performance:{version}")
+}
+```
+
 #### Launch booster
 
 - Removal of `launchBooster` extension.

--- a/gradle-plugin/plugin/performance-project-template/build.gradle.kts
+++ b/gradle-plugin/plugin/performance-project-template/build.gradle.kts
@@ -2,7 +2,7 @@
 //
 // - The SDK version targets are automatically set to be identical to the app project.
 // - The same build types as your app project are automatically created.
-// - Test libraries like UI Automator and the Emerge SDK are automatically added as dependencies.
+// - Test libraries including UI Automator and Junit and are automatically added as dependencies.
 //
 // The configuration can be modified in this file as needed.
 

--- a/gradle-plugin/plugin/performance-project-template/build.gradle.kts
+++ b/gradle-plugin/plugin/performance-project-template/build.gradle.kts
@@ -11,7 +11,9 @@ plugins {
 }
 
 dependencies {
-    // Emerge's UIAutomator helper library (Alpha): https://github.com/EmergeTools/relax
+    // Emerge's Performance Testing SDK (Required):
+    implementation("com.emergetools.test:performance:2.0.0-beta01")
+    // Emerge's UIAutomator helper library (Optional): https://github.com/EmergeTools/relax
     implementation("com.emergetools.test:relax:0.1.0")
 
     // Add additional dependencies here as needed.

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -195,7 +195,7 @@ class EmergePlugin : Plugin<Project> {
     perfVariant: Variant,
   ) {
     registerUploadPerfBundleTask(rootProject, performanceProject, extension, perfVariant)
-    registerEmergeLocalTestTask(appProject, performanceProject, perfVariant)
+    registerEmergeLocalTestTask(rootProject, appProject, performanceProject, perfVariant)
   }
 
   private fun registerUploadPerfBundleTask(
@@ -243,6 +243,7 @@ class EmergePlugin : Plugin<Project> {
   }
 
   private fun registerEmergeLocalTestTask(
+    rootProject: Project,
     appProject: Project,
     performanceProject: Project,
     performanceVariant: Variant,
@@ -251,7 +252,7 @@ class EmergePlugin : Plugin<Project> {
     val perfVariantName = performanceVariant.name.capitalize()
 
     val taskName = "emergeLocal${perfVariantName}Test"
-    val task = performanceProject.tasks.register(taskName, LocalPerfTest::class.java) {
+    val task = rootProject.tasks.register(taskName, LocalPerfTest::class.java) {
       it.group = EMERGE_TASK_GROUP
       it.description = "Installs and runs tests for ${performanceVariant.name} on" +
         " connected devices. For testing and debugging."

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -456,7 +456,6 @@ class EmergePlugin : Plugin<Project> {
     private val PERFORMANCE_PROJECT_DEPENDENCIES = listOf(
       "androidx.test.ext:junit:1.1.3",
       "androidx.test.uiautomator:uiautomator:2.2.0",
-      "com.emergetools.test:performance:1.0.0"
     )
   }
 }

--- a/performance/sample/performance/build.gradle.kts
+++ b/performance/sample/performance/build.gradle.kts
@@ -1,0 +1,28 @@
+// This is a com.android.test project which is automatically configured by the Emerge Tools Gradle plugin:
+//
+// - The SDK version targets are automatically set to be identical to the app project.
+// - The same build types as your app project are automatically created.
+// - Test libraries like UI Automator and the Emerge SDK are automatically added as dependencies.
+//
+// The configuration can be modified in this file as needed.
+
+plugins {
+  id("org.jetbrains.kotlin.android")
+}
+
+dependencies {
+  // We're depending on the local project here
+  // In real-world impl, you'd use the Maven dependency
+  implementation(projects.performance.performance)
+  // Emerge's UIAutomator helper library (Optional): https://github.com/EmergeTools/relax
+  implementation("com.emergetools.test:relax:0.1.0")
+}
+
+/**
+ * Example code to disable build types other than "release"
+ */
+androidComponents {
+  beforeVariants(selector().all()) {
+    it.enable = it.buildType == "release"
+  }
+}

--- a/performance/sample/performance/src/main/AndroidManifest.xml
+++ b/performance/sample/performance/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.emergetools.performance.sample.test" />

--- a/performance/sample/performance/src/main/java/com/emergetools/performance/sample/test/ExamplePerformanceTest.kt
+++ b/performance/sample/performance/src/main/java/com/emergetools/performance/sample/test/ExamplePerformanceTest.kt
@@ -1,0 +1,70 @@
+package com.emergetools.performance.sample.test
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import com.emergetools.test.annotations.EmergeInit
+import com.emergetools.test.annotations.EmergeSetup
+import com.emergetools.test.annotations.EmergeTest
+
+private const val LAUNCH_TIMEOUT = 5000L
+private const val APP_PACKAGE_NAME = "com.emergetools.performance.sample"
+
+/**
+ * An example performance test class.
+ *
+ * Performance test classes can have multiple tests, but tests in a given class share @EmergeInit and @EmergeSetup
+ * methods. For tests that require a different init or setup multiple test classes are supported.
+ *
+ * Note that each test (ie. each method annotated with @EmergeTest) will be run on a separate device, they cannot
+ * impact each other in any way.
+ */
+class ExamplePerformanceTest {
+
+    @EmergeInit
+    fun init() {
+        // OPTIONAL
+        // Runs just once after installing the app on the test device before any other method.
+        // Typically this is used to log into the app, if needed.
+        // Only one @EmergeInit method per class is supported.
+    }
+
+    @EmergeSetup
+    fun setup() {
+        // OPTIONAL
+        // Runs once before each test iteration.
+        // Typically this is used to navigate through to the screen where the performance test is meant to begin.
+        // Only one @EmergeSetup method per class is supported.
+    }
+
+    @EmergeTest
+    fun myPerformanceTest() {
+        // REQUIRED
+        // The performance test. This is where the app should go through a short flow whose performance is critical.
+        // This might involve launching a screen or any other operation supported by UI Automator.
+        // As an example here we launch the application from the home screen.
+
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        device.pressHome()
+
+        // Wait for launcher
+        device.wait(Until.hasObject(By.pkg(device.launcherPackageName).depth(0)), LAUNCH_TIMEOUT)
+
+        // Launch the app
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val intent = checkNotNull(context.packageManager.getLaunchIntentForPackage(APP_PACKAGE_NAME)) {
+            "Could not get launch intent for package $APP_PACKAGE_NAME"
+        }
+        // Clear out any previous instances
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+
+        // Wait for the app to appear
+        device.wait(Until.hasObject(By.pkg(APP_PACKAGE_NAME).depth(0)), LAUNCH_TIMEOUT)
+    }
+}


### PR DESCRIPTION
Rather than implicitly including perf testing SDK on behalf of users, locking us into a version, we'll now make it an explicit import and add it as a dependency in the performance project template.

Noted the breaking changes in the migration section of the plugin readme.