### PR TITLE
Set default API token value to be environment variable

### DIFF
--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -32,7 +32,8 @@ plugins {
 }
 
 emerge {
-  apiToken.set(System.getenv("EMERGE_API_TOKEN"))
+  // By default, Emerge will use the EMERGE_API_TOKEN environment variable
+  apiToken.set("...")
 }
 ```
 
@@ -40,7 +41,9 @@ _Gradle plugins are often applied and configured in the `build.gradle(.kts)` fil
 *It is highly recommended to apply the Emerge plugin to the root project, ie. the
 top-level `build.gradle(.kts)`.* This facilitates cross-project features like performance analysis._
 
-`appProjectPath` and `apiToken` are required. Other configuration properties are documented below.
+`appProjectPath` and `apiToken` are required. By default, without any property set, `apiToken` will
+attempt to use the `EMERGE_API_TOKEN` EMERGE_API_TOKEN. Other configuration properties are
+documented below.
 
 ### Obtain an API key
 
@@ -228,7 +231,7 @@ emerge {
 
 ```kotlin
 emerge {
-  apiToken.set(System.getenv("EMERGE_API_TOKEN")) // Required
+  apiToken.set("...") // By default, Emerge will use the EMERGE_API_TOKEN environment variable
 
   vcs {
     sha.set("..") // Optional, will be set automatically using Git information.

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -32,8 +32,8 @@ plugins {
 }
 
 emerge {
-  // By default, Emerge will use the EMERGE_API_TOKEN environment variable
-  apiToken.set("...")
+  // Emerge uses the EMERGE_API_TOKEN env variable by default, so no need to set env explicitly
+  apiToken.set(System.getenv("EMERGE_API_TOKEN"))
 }
 ```
 
@@ -231,7 +231,8 @@ emerge {
 
 ```kotlin
 emerge {
-  apiToken.set("...") // By default, Emerge will use the EMERGE_API_TOKEN environment variable
+  // Emerge uses the EMERGE_API_TOKEN env variable by default, so no need to set env explicitly
+  apiToken.set(System.getenv("EMERGE_API_TOKEN"))
 
   vcs {
     sha.set("..") // Optional, will be set automatically using Git information.

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -45,7 +45,6 @@ class EmergePlugin : Plugin<Project> {
       EmergePluginExtension::class.java
     )
 
-
     applyToAppProject(project, emergeExtension)
 
     // Perf project must be configured after application as the configuration is reliant on

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -1,5 +1,6 @@
 package com.emergetools.android.gradle
 
+import com.emergetools.android.gradle.tasks.upload.BaseUploadTask
 import com.emergetools.android.gradle.util.Git
 import com.emergetools.android.gradle.util.GitHub
 import com.emergetools.android.gradle.util.property
@@ -17,7 +18,8 @@ abstract class EmergePluginExtension @Inject constructor(objects: ObjectFactory)
    * Emerge API token generated from the Emerge profile page.
    * Required.
    */
-  abstract val apiToken: Property<String>
+  val apiToken: Property<String> = objects.property<String>()
+    .convention(System.getenv(BaseUploadTask.DEFAULT_API_TOKEN_ENV_KEY))
 
   @get:Nested
   abstract val sizeOptions: SizeOptions

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
@@ -75,9 +75,9 @@ abstract class BaseUploadTask : DefaultTask() {
   @get:Optional
   abstract val gitLabProjectId: Property<String>
 
-	@get:Input
-	@get:Optional
-	abstract val snapshotsEnabled: Property<Boolean>
+  @get:Input
+  @get:Optional
+  abstract val snapshotsEnabled: Property<Boolean>
 
   /**
    * Internal only for testing.
@@ -87,9 +87,10 @@ abstract class BaseUploadTask : DefaultTask() {
   abstract val baseUrl: Property<String>
 
   protected fun upload(artifactMetadata: ArtifactMetadata): EmergeUploadResponse? {
-    check(apiToken.get().isNotEmpty()) {
-      "Missing API token. Please set the 'apiToken' property in the emerge {} extension block." +
-        " See https://docs.emergetools.com/gradle-plugin/configuration for more information."
+    check(!apiToken.getOrElse(System.getenv(DEFAULT_API_TOKEN_ENV_KEY)).isNullOrBlank()) {
+      "Missing API token. Please set the 'apiToken' property in the emerge {} extension block or" +
+        " ensure an 'EMERGE_API_TOKEN' environment variable is set with a valid API token." +
+        " See https://docs.emergetools.com/docs/gradle-plugin for more information."
     }
 
     val outputDir = outputDir.get().asFile
@@ -143,7 +144,7 @@ abstract class BaseUploadTask : DefaultTask() {
       prNumber = prNumber.orNull,
       buildType = buildType.orNull,
       gitlabProjectId = gitLabProjectId.orNull,
-			androidSnapshotsEnabled = snapshotsEnabled.getOrElse(false),
+      androidSnapshotsEnabled = snapshotsEnabled.getOrElse(false),
       source = "${SOURCE_GRADLE_PLUGIN}_${BuildConfig.VERSION}"
     )
 
@@ -182,6 +183,7 @@ abstract class BaseUploadTask : DefaultTask() {
 
   companion object {
     const val OUTPUT_FILE_NAME = "emerge.zip"
+    const val DEFAULT_API_TOKEN_ENV_KEY = "EMERGE_API_TOKEN"
 
     private const val BASE_URL_ARG_KEY = "baseUrl"
 

--- a/performance/sample/app/build.gradle.kts
+++ b/performance/sample/app/build.gradle.kts
@@ -6,8 +6,6 @@ plugins {
 }
 
 emerge {
-  apiToken.set(System.getenv("EMERGE_API_TOKEN"))
-
   performance {
     // Note that this is the relative path from the rootProject
     projectPath.set(":performance:sample:perftesting")

--- a/performance/sample/app/src/main/res/values/strings.xml
+++ b/performance/sample/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-  <string name="app_name">Emerge snapshots sample</string>
+  <string name="app_name">Emerge performance sample</string>
 </resources>


### PR DESCRIPTION
Just a nice-to-have, by default sets the `apiToken` property to be the `EMERGE_API_TOKEN` environment variable.