### PR TITLE
Add GH workflow for publishing gradle plugin

### DIFF
--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -1,0 +1,31 @@
+name: Gradle plugin release deploy
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  deploy-gradle-plugin:
+
+    runs-on: ubuntu-latest
+
+    # Only run when the tag begins with the string "gradle-plugin-"
+    if: ${{ startsWith(github.event.release.tag_name, 'gradle-plugin-') }}
+
+    env:
+      GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+      GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+
+    strategy:
+      matrix:
+        node-version: [ 18.x ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Deploy plugin
+        run: ./gradlew :gradle-plugin:plugin:publishPlugins

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -331,12 +331,6 @@ Additionally, `ANDROID_SDK_ROOT` must be set and point to the Android SDK locati
 
 ## Releasing
 
-### Prerequisites
-
-- The following Gradle properties must be set:
-  - `gradle.publish.key`
-  - `gradle.publish.secret`
-
 ### Releasing a new version
 
 1. Update the version in `build.gradle.kts`
@@ -345,7 +339,9 @@ Additionally, `ANDROID_SDK_ROOT` must be set and point to the Android SDK locati
 4. `gt ss`
 5. Get PR approved and merge
 6. Create a new release on GitHub
-7. Tag version `vX.Y.Z`
-8. Release title `vX.Y.Z`
+7. Tag version `gradle-plugin-vX.Y.Z`
+8. Release title `Gradle Plugin vX.Y.Z`
 9. Paste the content from `CHANGELOG.md` as the description
-10. `./gradlew publishPlugins`
+
+The `gradle-plugin-release` workflow will automatically publish the new version to the Gradle Plugin
+portal upon new release publish.


### PR DESCRIPTION
Standardize our publishing so we no longer have to run from local environments. Will add similar deploy workflows for the perf/snapshots SDKs in the near future.

Necessary secrets have been added.