### PR TITLE
Support dependent module snapshot generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.android.application) apply false
@@ -11,6 +10,7 @@ plugins {
   alias(libs.plugins.kotlin.android) apply false
   alias(libs.plugins.kotlin.jvm) apply false
   alias(libs.plugins.kotlin.serialization) apply false
+  alias(libs.plugins.ksp) apply false
 }
 
 allprojects {

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -212,10 +212,6 @@ emerge {
   snapshots {
     buildType.set("snapshots") // Build type to use for grouping builds in the Emerge dashboard
 
-    includeFromMainSourceSet.set(
-      true
-    ) // Generate composable previews snapshots from the main source set, defaults to `false`
-
     snapshotsStorageDirectory.set(
       "/src/main/snapshots"
     ) // Path to local snapshot image storage, defaults to `/build/emerge/snapshots/outputs`
@@ -228,7 +224,6 @@ emerge {
 | Field                       | Type      | Default                           | Description                                                                  |
 |-----------------------------|-----------|-----------------------------------|------------------------------------------------------------------------------|
 | `buildType`                 | `String`  | `release`                         | The build type to use for grouping builds in the Emerge dashboard.           |
-| `includeFromMainSourceSet`  | `Boolean` | `false`                           | Enables composable `@Preview` snapshot generation from the main source set.  |
 | `snapshotsStorageDirectory` | `String`  | `/build/emerge/snapshots/outputs` | The path to local snapshot storage. Only used for local snapshot generation. |
 
 ## Full configuration
@@ -266,8 +261,6 @@ emerge {
   snapshots {
     // Optional, snapshots use debug builds, we recommend using separate build type.
     buildType.set("snapshots")
-    // Optional, for generating snapshot test from main source set, defaults to 'false'
-    includeFromMainSourceSet.set(true)
     snapshotsStorageDirectory.set("/src/main/snapshots") // Storage of locally generated snapshots
   }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -120,6 +120,4 @@ abstract class PerfOptions : ProductOptions() {
 abstract class SnapshotOptions : ProductOptions() {
 
   abstract val snapshotsStorageDirectory: DirectoryProperty
-
-  abstract val includeFromMainSourceSet: Property<Boolean>
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,6 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-lint = { id = "com.android.lint", version.ref = "agp" }
 android-test = { id = "com.android.test", version.ref = "agp" }
-anvil = { id = "com.squareup.anvil", version = "2.4.6" }
 buildconfig = "com.github.gmazzo.buildconfig:3.0.3"
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-lint = { id = "com.android.lint", version.ref = "agp" }
 android-test = { id = "com.android.test", version.ref = "agp" }
+anvil = { id = "com.squareup.anvil", version = "2.4.6" }
 buildconfig = "com.github.gmazzo.buildconfig:3.0.3"
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/snapshots/README.md
+++ b/snapshots/README.md
@@ -83,11 +83,6 @@ plugins {
 
 emerge {
   // ..
-
-  snapshots {
-    // Required for generating snapshots from main sourceSet
-    includeFromMainSourceSet.set(true)
-  }
 }
 
 dependencies {
@@ -97,11 +92,8 @@ dependencies {
 }
 ```
 
-`includeFromMainSourceSet` must be set when generating snapshots from the `main` source set,
-otherwise
-Kotlin compilation errors are likely to occur. Emerge relies on a custom source set that generated
-snapshot tests are moved to before compilation to get around KSP cross-source set generation
-restrictions.
+Emerge relies on a custom source set that generated snapshot tests are moved to before
+compilation to get around KSP cross-source set generation restrictions.
 
 ### Activities & View snapshotting
 

--- a/snapshots/sample/app/build.gradle.kts
+++ b/snapshots/sample/app/build.gradle.kts
@@ -7,10 +7,6 @@ plugins {
 
 emerge {
   apiToken.set(System.getenv("EMERGE_API_TOKEN"))
-
-  snapshots {
-    includeFromMainSourceSet.set(true)
-  }
 }
 
 android {
@@ -41,13 +37,7 @@ android {
   }
 
   sourceSets {
-    getByName("main") {
-      // Adds sources from submodules for generating snapshot tests
-      // ksp(..) with the snapshots-processor dependency must be used for test generation
-      // Additionally for main source set Preview generation, the snapshot.includeFromMainSourceSet
-      // Emerge Gradle plugin property must be set to true
-      kotlin.srcDir("../ui-module/src/main/kotlin")
-    }
+    // TODO: Ryan: See if we can workaround having to specify the sourceSets for submodule tests
     getByName("androidTest") {
       // Adds sources from submodules for including snapshot tests
       // kspAndroidTest(..) with the snapshots-processor dependency must be used for test generation
@@ -85,8 +75,7 @@ dependencies {
   implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.material)
 
-  // This will generate snapshots from Composable Previews in the main source set, with
-  // snapshots.includeFromMainSourceSet set to true from the Emerge Gradle plugin configuration block
+  // This will generate snapshots from Composable Previews in the main source set
   ksp(projects.snapshots.snapshotsProcessor)
   // This will generate snapshots from Composable Previews in the androidTest source set.
   kspAndroidTest(projects.snapshots.snapshotsProcessor)

--- a/snapshots/sample/ui-module/build.gradle.kts
+++ b/snapshots/sample/ui-module/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.ksp)
 }
 
 android {
@@ -37,6 +38,9 @@ dependencies {
   implementation(libs.compose.ui)
   implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.material)
+
+  ksp(projects.snapshots.snapshotsProcessor)
+  kspAndroidTest(projects.snapshots.snapshotsProcessor)
 
   androidTestImplementation(libs.compose.runtime)
   androidTestImplementation(libs.junit)


### PR DESCRIPTION
Supports/fixes submodule Composable snapshot generation. Kotlin compilation was failing for submodules as we didn't apply our workaround from #20 to generate snapshot tests from the main source set for modules other than the main app module.

This PR fixes that, as well as makes our workaround to move generated KSP tests to our own custom source location the default behavior as it actually works quite well. 

Since we're making this the default, I also removed `includeFromMainSourceSet` as it's no longer relevant.

Test cases:

- [x] Succeeds with Anvil (client repro)
- [x] Succeeds with both androidTest and main source set generation
- [x] Succeeds with only androidTest source set generation
- [x] Succeeds with only main source set generation
- [x] E2E with Hackernews