### PR TITLE
Add Ktor as dependency for perf test projects

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -493,6 +493,7 @@ class EmergePlugin : Plugin<Project> {
     private val PERFORMANCE_PROJECT_DEPENDENCIES = listOf(
       "androidx.test.ext:junit:1.1.3",
       "androidx.test.uiautomator:uiautomator:2.2.0",
+      "io.ktor:ktor-network:2.1.1"
     )
   }
 }


### PR DESCRIPTION
Used for communication from our perf test orchestrator to the test runner. This will automatically apply for the perf module so clients don't have to.