### PR TITLE
Add original composable name to compose configuration for showing in UI

### DIFF
--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposablePreviewSnapshotBuilder.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposablePreviewSnapshotBuilder.kt
@@ -36,6 +36,7 @@ object ComposablePreviewSnapshotBuilder {
 
   fun TypeSpec.Builder.addPreviewConfigProperty(config: ComposePreviewSnapshotConfig) {
     val configInitializer = mutableListOf<String>().apply {
+      config.originalComposableName?.let { add("originalComposableName = \"$it\"") }
       config.name?.let { add("name = \"$it\"") }
       config.group?.let { add("group = \"$it\"") }
       config.uiMode?.let { add("uiMode = $it") }

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposablePreviewSnapshotBuilder.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposablePreviewSnapshotBuilder.kt
@@ -36,7 +36,7 @@ object ComposablePreviewSnapshotBuilder {
 
   fun TypeSpec.Builder.addPreviewConfigProperty(config: ComposePreviewSnapshotConfig) {
     val configInitializer = mutableListOf<String>().apply {
-      config.originalComposableName?.let { add("originalComposableName = \"$it\"") }
+      config.originalFqn?.let { add("originalFqn = \"$it\"") }
       config.name?.let { add("name = \"$it\"") }
       config.group?.let { add("group = \"$it\"") }
       config.uiMode?.let { add("uiMode = $it") }

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposePreviewUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposePreviewUtils.kt
@@ -54,8 +54,11 @@ object ComposePreviewUtils {
     val uiModeArgument = previewAnnotation.argumentForName(PREVIEW_UI_MODE_ARGUMENT_NAME)
     val uiModeValue = uiModeArgument?.value?.takeIf { (it as? Int) != 0 }?.let { it as Int }
 
+    val originalFqn = previewFunction.qualifiedName?.asString()
+      ?: "${previewFunction.packageName.asString()}.${previewFunction.simpleName.asString()}}"
+
     return ComposePreviewSnapshotConfig(
-      originalComposableName = previewFunction.simpleName.asString(),
+      originalFqn = originalFqn,
       name = nameValue,
       group = groupValue,
       locale = localeValue,

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposePreviewUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposePreviewUtils.kt
@@ -24,10 +24,12 @@ object ComposePreviewUtils {
     previewFunction: KSFunctionDeclaration,
   ): Sequence<ComposePreviewSnapshotConfig> = previewFunction.annotations.filter {
     it.shortName.asString() == PREVIEW_ANNOTATION_SIMPLE_NAME
-  }.map(::composePreviewShapshotConfigFromPreviewAnnotation)
-    .distinct()
+  }.map {
+    composePreviewShapshotConfigFromPreviewAnnotation(previewFunction, it)
+  }.distinct()
 
   private fun composePreviewShapshotConfigFromPreviewAnnotation(
+    previewFunction: KSFunctionDeclaration,
     previewAnnotation: KSAnnotation,
   ): ComposePreviewSnapshotConfig {
     // We need to explicitly check for nulls here so we don't set a default unintentionally and
@@ -53,6 +55,7 @@ object ComposePreviewUtils {
     val uiModeValue = uiModeArgument?.value?.takeIf { (it as? Int) != 0 }?.let { it as Int }
 
     return ComposePreviewSnapshotConfig(
+      originalComposableName = previewFunction.simpleName.asString(),
       name = nameValue,
       group = groupValue,
       locale = localeValue,

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/shared/ComposePreviewSnapshotConfig.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 // Keep in sync with snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
 @Serializable
 data class ComposePreviewSnapshotConfig(
-  val originalComposableName: String? = null,
+  val originalFqn: String? = null,
   val name: String? = null,
   val group: String? = null,
   val uiMode: Int? = null,

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/shared/ComposePreviewSnapshotConfig.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
 // Keep in sync with snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
 @Serializable
 data class ComposePreviewSnapshotConfig(
+  val originalComposableName: String? = null,
   val name: String? = null,
   val group: String? = null,
   val uiMode: Int? = null,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotImageMetadata.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotImageMetadata.kt
@@ -14,6 +14,7 @@ internal data class SnapshotImageMetadata(
   val keyName: String,
   val displayName: String,
   val filename: String,
+  // FQN of the test class
   val fqn: String,
   val type: SnapshotType,
   val composePreviewSnapshotConfig: ComposePreviewSnapshotConfig? = null,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.Serializable
 // Keep in sync with snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/shared/ComposePreviewSnapshotConfig.kt
 @Serializable
 data class ComposePreviewSnapshotConfig(
+  val originalComposableName: String? = null,
   val name: String? = null,
   val group: String? = null,
   val uiMode: Int? = null,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 // Keep in sync with snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/shared/ComposePreviewSnapshotConfig.kt
 @Serializable
 data class ComposePreviewSnapshotConfig(
-  val originalComposableName: String? = null,
+  val originalFqn: String? = null,
   val name: String? = null,
   val group: String? = null,
   val uiMode: Int? = null,


### PR DESCRIPTION
The fqn is respective of the test, not the composable. So to show the proper fqn of the composable in our UI, we'll need to add it to metadata.

This sets that and updates the processor to fill it in based on the `@Preview` annotate function's fqn, or packageName + simpleName