### PR TITLE
Update keys and displayName for better Compose support

### DIFF
--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -95,15 +95,9 @@ class PreviewProcessor(
       val testAnnotation = AnnotationSpec.builder(JUNIT_TEST_ANNOTATION_CLASSNAME)
         .build()
 
-      var snapshotName = functionName
-      val previewName = previewConfig.name
-      if (!previewName.isNullOrBlank()) {
-        snapshotName += " - $previewName"
-      }
-
       val testFunctionSpec = FunSpec.builder("${functionName}_GenSnapshot").apply {
         addAnnotation(testAnnotation)
-        addComposableSnapshotBlock(functionName, snapshotName)
+        addComposableSnapshotBlock(functionName)
       }.build()
 
       val testRunnerAnnotation = AnnotationSpec.builder(ClassName("org.junit.runner", "RunWith"))

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -164,7 +164,8 @@ class PreviewProcessor(
   ): String {
     var testFunctionName = composableFunctionName
     if (!previewConfig.isDefault()) {
-      // Function name can use hashcode and the saved image key will be the same.
+      // Function name can use hashcode as the saved image key will be
+      // the same regardless of test name.
       testFunctionName = "${testFunctionName}_${previewConfig.hashCode()}"
     }
     return "${testFunctionName}_GenSnapshot"

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -163,8 +163,9 @@ class PreviewProcessor(
     previewConfig: ComposePreviewSnapshotConfig,
   ): String {
     var testFunctionName = composableFunctionName
-    if (previewConfig.hashCode() != ComposePreviewSnapshotConfig.DEFAULT.hashCode()) {
-      testFunctionName += "_${previewConfig.hashCode()}"
+    if (!previewConfig.isDefault()) {
+      // Function name can use hashcode and the saved image key will be the same.
+      testFunctionName = "${testFunctionName}_${previewConfig.hashCode()}"
     }
     return "${testFunctionName}_GenSnapshot"
   }

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposablePreviewSnapshotBuilder.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposablePreviewSnapshotBuilder.kt
@@ -36,7 +36,7 @@ object ComposablePreviewSnapshotBuilder {
 
   fun TypeSpec.Builder.addPreviewConfigProperty(config: ComposePreviewSnapshotConfig) {
     val configInitializer = mutableListOf<String>().apply {
-      config.originalFqn?.let { add("originalFqn = \"$it\"") }
+      add("originalFqn = \"${config.originalFqn}\"")
       config.name?.let { add("name = \"$it\"") }
       config.group?.let { add("group = \"$it\"") }
       config.uiMode?.let { add("uiMode = $it") }

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposablePreviewSnapshotBuilder.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposablePreviewSnapshotBuilder.kt
@@ -76,20 +76,14 @@ object ComposablePreviewSnapshotBuilder {
    * Builds a compositionLocal that sets the Preview configuration for the passed snapshot as well
    * as the snapshotting code.
    */
-  fun FunSpec.Builder.addComposableSnapshotBlock(
-    functionName: String,
-    snapshotName: String,
-  ) {
+  fun FunSpec.Builder.addComposableSnapshotBlock(functionName: String) {
     val codeBlock = CodeBlock.builder().apply {
       addStatement("$COMPOSE_RULE_PROPERTY_NAME.setContent {")
       addStatement("  %T($PREVIEW_CONFIG_PROPERTY_NAME) {", SNAPSHOT_VARIANT_PROVIDER_CLASSNAME)
       addStatement("    $functionName()")
       addStatement("  }")
       addStatement("}")
-      addStatement(
-        "$SNAPSHOT_RULE_PROPERTY_NAME.take(\"$snapshotName\"," +
-          " composeRule, $PREVIEW_CONFIG_PROPERTY_NAME)"
-      )
+      addStatement("$SNAPSHOT_RULE_PROPERTY_NAME.take(composeRule, $PREVIEW_CONFIG_PROPERTY_NAME)")
     }.build()
 
     addCode(codeBlock)

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/shared/ComposePreviewSnapshotConfig.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 // Keep in sync with snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
 @Serializable
 data class ComposePreviewSnapshotConfig(
-  val originalFqn: String? = null,
+  val originalFqn: String,
   val name: String? = null,
   val group: String? = null,
   val uiMode: Int? = null,
@@ -16,7 +16,21 @@ data class ComposePreviewSnapshotConfig(
   val fontScale: Float? = null,
 ) {
 
-  companion object {
-    val DEFAULT = ComposePreviewSnapshotConfig()
+  fun isDefault(): Boolean {
+    return uiMode == null &&
+      locale == null &&
+      fontScale == null
+  }
+  fun keyName(): String {
+    if (isDefault()) {
+      return originalFqn
+    }
+
+    return buildString {
+      append(originalFqn)
+      uiMode?.let { append("_uim_$it") }
+      locale?.let { append("_loc_$it") }
+      fontScale?.let { append("_fsc_$it") }
+    }
   }
 }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/EmergeSnapshots.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/EmergeSnapshots.kt
@@ -45,13 +45,13 @@ class EmergeSnapshots : TestRule {
   )
 
   fun take(
-    name: String,
     composeTestRule: ComposeTestRule,
     composePreviewSnapshotConfig: ComposePreviewSnapshotConfig,
   ) {
     composeTestRule.waitForIdle()
     SnapshotSaver.save(
-      displayName = name,
+      // DisplayName not used for composables
+      displayName = null,
       bitmap = composeTestRule.onRoot().captureToImage().asAndroidBitmap(),
       fqn = fqn,
       type = SnapshotType.COMPOSABLE,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotImageMetadata.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotImageMetadata.kt
@@ -11,11 +11,15 @@ enum class SnapshotType {
 
 @Serializable
 internal data class SnapshotImageMetadata(
-  val keyName: String,
-  val displayName: String,
+  // Used as the primary key
+  val name: String,
+  // User defined name, or set to defaults by our backend
+  val displayName: String?,
+  // Filename of the outputted image
   val filename: String,
   // FQN of the test class
   val fqn: String,
   val type: SnapshotType,
+  // Compose-specific metadata, only set if type == COMPOSABLE
   val composePreviewSnapshotConfig: ComposePreviewSnapshotConfig? = null,
 )

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotImageMetadata.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotImageMetadata.kt
@@ -13,6 +13,8 @@ enum class SnapshotType {
 internal data class SnapshotImageMetadata(
   // Used as the primary key
   val name: String,
+  @Deprecated("Use name instead")
+  val keyName: String,
   // User defined name, or set to defaults by our backend
   val displayName: String?,
   // Filename of the outputted image

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
@@ -7,7 +7,8 @@ import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.test.platform.app.InstrumentationRegistry
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
-import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig.Companion.DEFAULT
+import com.emergetools.snapshots.shared.MAX_KEY_NAME_LENGTH
+import com.emergetools.snapshots.shared.normalize
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.File
@@ -31,7 +32,7 @@ internal object SnapshotSaver {
     get() = InstrumentationRegistry.getArguments()
 
   fun save(
-    displayName: String,
+    displayName: String?,
     bitmap: Bitmap,
     fqn: String,
     type: SnapshotType,
@@ -42,7 +43,14 @@ internal object SnapshotSaver {
       error("Unable to create snapshots storage directory.")
     }
 
-    val keyName = keyName(displayName, composePreviewSnapshotConfig)
+    // We need a stable key to use for the filename and comparison
+    // For composables, see [ComposePreviewSnapshotConfig.keyName]
+    // For non-composables, we use the normalized displayName
+    val keyName = keyName(
+      type = type,
+      displayName = displayName,
+      composePreviewSnapshotConfig = composePreviewSnapshotConfig,
+    )
     saveImage(
       snapshotsDir = snapshotsDir,
       keyName = keyName,
@@ -75,15 +83,15 @@ internal object SnapshotSaver {
 
   private fun saveMetadata(
     snapshotsDir: File,
-    displayName: String,
     keyName: String,
+    displayName: String?,
     fqn: String,
     type: SnapshotType,
     composePreviewSnapshotConfig: ComposePreviewSnapshotConfig? = null,
   ) {
     val metadata = SnapshotImageMetadata(
+      name = keyName,
       displayName = displayName,
-      keyName = keyName,
       filename = "$keyName$PNG_EXTENSION",
       fqn = fqn,
       type = type,
@@ -94,6 +102,25 @@ internal object SnapshotSaver {
 
     saveFile(snapshotsDir, "$keyName$JSON_EXTENSION") {
       write(jsonString.toByteArray(Charset.defaultCharset()))
+    }
+  }
+
+  @VisibleForTesting
+  fun keyName(
+    type: SnapshotType,
+    displayName: String?,
+    composePreviewSnapshotConfig: ComposePreviewSnapshotConfig? = null,
+  ): String {
+    return if (type == SnapshotType.COMPOSABLE) {
+      checkNotNull(composePreviewSnapshotConfig) {
+        "composePreviewSnapshotConfig must be set for COMPOSABLE snapshots"
+      }
+      composePreviewSnapshotConfig.keyName()
+    } else {
+      checkNotNull(displayName) {
+        "displayName must be set for non-COMPOSABLE snapshots"
+      }
+      displayName.normalize().take(MAX_KEY_NAME_LENGTH)
     }
   }
 
@@ -110,41 +137,6 @@ internal object SnapshotSaver {
     outputFile.outputStream().use { writer(it) }
   }
 
-  /**
-   * Normalize the user defined name to be used as a filename/key for comparisons.
-   * This ensures uniqueness across test classes and methods & user-defined names.
-   *
-   * We intentionally don't account for FQN here as we still want to diff an image if
-   * the test might move packages, which user-defined name ensures.
-   */
-  @VisibleForTesting
-  fun keyName(
-    displayName: String,
-    composePreviewSnapshotConfig: ComposePreviewSnapshotConfig? = null,
-  ): String {
-    val normalizedDisplayName = displayName.normalize()
-      .take(MAX_NAME_LENGTH)
-
-    return composePreviewSnapshotConfig?.let {
-      // If not default, we'll append the hashcode to the name to ensure uniqueness based on config
-      // Hashcode should preserve equality across field additions/removals in the future.
-      if (it.hashCode() != DEFAULT.hashCode()) {
-        "${normalizedDisplayName}_${it.hashCode()}"
-      } else {
-        normalizedDisplayName
-      }
-    } ?: normalizedDisplayName
-  }
-
-  @VisibleForTesting
-  fun String.normalize(): String {
-    return replace(Regex("[ .-]"), "_")
-      //  lowercase the string
-      .lowercase()
-  }
-
-  @VisibleForTesting
-  const val MAX_NAME_LENGTH = 128
   private const val PNG_EXTENSION = ".png"
   private const val JSON_EXTENSION = ".json"
 }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
@@ -91,6 +91,8 @@ internal object SnapshotSaver {
   ) {
     val metadata = SnapshotImageMetadata(
       name = keyName,
+      // TODO: Ryan remove in future
+      keyName = keyName,
       displayName = displayName,
       filename = "$keyName$PNG_EXTENSION",
       fqn = fqn,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -23,9 +23,9 @@ data class ComposePreviewSnapshotConfig(
    */
   @VisibleForTesting
   fun isDefault(): Boolean {
-    return uiMode == null
-      && locale == null
-      && fontScale == null
+    return uiMode == null &&
+      locale == null &&
+      fontScale == null
   }
 
   /**

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -1,5 +1,6 @@
 package com.emergetools.snapshots.shared
 
+import androidx.annotation.VisibleForTesting
 import kotlinx.serialization.Serializable
 
 // Keep parity with
@@ -9,7 +10,7 @@ import kotlinx.serialization.Serializable
 // Keep in sync with snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/shared/ComposePreviewSnapshotConfig.kt
 @Serializable
 data class ComposePreviewSnapshotConfig(
-  val originalFqn: String? = null,
+  val originalFqn: String,
   val name: String? = null,
   val group: String? = null,
   val uiMode: Int? = null,
@@ -17,7 +18,29 @@ data class ComposePreviewSnapshotConfig(
   val fontScale: Float? = null,
 ) {
 
-  companion object {
-    val DEFAULT = ComposePreviewSnapshotConfig()
+  /**
+   * We consider the "default" config to be one where no variants are set.
+   */
+  @VisibleForTesting
+  fun isDefault(): Boolean {
+    return uiMode == null
+      && locale == null
+      && fontScale == null
+  }
+
+  /**
+   * Stable key name generation that takes into account all diff-relevant variants.
+   */
+  fun keyName(): String {
+    if (isDefault()) {
+      return originalFqn
+    }
+
+    return buildString {
+      append(originalFqn)
+      uiMode?.let { append("_uim_$it") }
+      locale?.let { append("_loc_$it") }
+      fontScale?.let { append("_fsc_$it") }
+    }
   }
 }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/shared/Utils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/shared/Utils.kt
@@ -1,0 +1,12 @@
+package com.emergetools.snapshots.shared
+
+import androidx.annotation.VisibleForTesting
+
+fun String.normalize(): String {
+  return replace(Regex("[ .-]"), "_")
+    //  lowercase the string
+    .lowercase()
+}
+
+@VisibleForTesting
+const val MAX_KEY_NAME_LENGTH = 128

--- a/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/KeyNameTest.kt
+++ b/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/KeyNameTest.kt
@@ -23,14 +23,14 @@ class KeyNameTest {
   }
 
   @Test
-  fun `keyName for COMPOSABLE snapshot with default ComposePreviewSnapshotConfig returns originalFqn`() {
+  fun `keyName for default COMPOSABLE snapshot with returns originalFqn`() {
     val config = ComposePreviewSnapshotConfig("com.example.test.Composable")
     val result = keyName(SnapshotType.COMPOSABLE, null, config)
     assertEquals("com.example.test.Composable", result)
   }
 
   @Test
-  fun `keyName for COMPOSABLE snapshot with non-default ComposePreviewSnapshotConfig returns concatenated name`() {
+  fun `keyName for variant COMPOSABLE snapshot returns concatenated name`() {
     val config = ComposePreviewSnapshotConfig(
       "com.example.test.Composable",
       uiMode = 1,
@@ -44,7 +44,6 @@ class KeyNameTest {
   @Test
   fun `keyName for non-COMPOSABLE snapshot returns normalized displayName`() {
     val result = keyName(SnapshotType.VIEW, "testDisplayName")
-    // Assuming normalization doesn't alter "testDisplayName" and MAX_KEY_NAME_LENGTH is large enough
     assertEquals("testdisplayname", result)
   }
 }

--- a/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/SnapshotSaverTests.kt
+++ b/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/SnapshotSaverTests.kt
@@ -1,109 +1,50 @@
 package com.emergetools.snapshots
 
-import com.emergetools.snapshots.SnapshotSaver.MAX_NAME_LENGTH
-import com.emergetools.snapshots.SnapshotSaver.normalize
+import com.emergetools.snapshots.SnapshotSaver.keyName
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
-class SnapshotSaverTests {
+class KeyNameTest {
 
-  // keyName
   @Test
-  fun `test keyName with null ComposePreviewSnapshotConfig`() {
-    val displayName = "TestName"
-    val expected = displayName.normalize().take(MAX_NAME_LENGTH)
-
-    val actual = SnapshotSaver.keyName(displayName)
-
-    assertEquals(expected, actual)
+  fun `keyName for COMPOSABLE snapshot without ComposePreviewSnapshotConfig throws exception`() {
+    assertThrows(IllegalStateException::class.java) {
+      keyName(SnapshotType.COMPOSABLE, null)
+    }
   }
 
   @Test
-  fun `test keyName with non-default ComposePreviewSnapshotConfig with name and group set`() {
-    val displayName = "TestName"
-    val config = ComposePreviewSnapshotConfig(name = "Test", group = "Group")
-
-    val expected = "${displayName.normalize().take(MAX_NAME_LENGTH)}_${config.hashCode()}"
-
-    val actual = SnapshotSaver.keyName(displayName, config)
-
-    assertEquals(expected, actual)
+  fun `keyName for non-COMPOSABLE snapshot without displayName throws exception`() {
+    assertThrows(IllegalStateException::class.java) {
+      keyName(SnapshotType.VIEW, null)
+    }
   }
 
   @Test
-  fun `test keyName with non-default ComposePreviewSnapshotConfig with uiMode and fontScale set`() {
-    val displayName = "TestName"
-    val config = ComposePreviewSnapshotConfig(uiMode = 1, fontScale = 1.5f)
-
-    val expected = "${displayName.normalize().take(MAX_NAME_LENGTH)}_${config.hashCode()}"
-
-    val actual = SnapshotSaver.keyName(displayName, config)
-
-    assertEquals(expected, actual)
+  fun `keyName for COMPOSABLE snapshot with default ComposePreviewSnapshotConfig returns originalFqn`() {
+    val config = ComposePreviewSnapshotConfig("com.example.test.Composable")
+    val result = keyName(SnapshotType.COMPOSABLE, null, config)
+    assertEquals("com.example.test.Composable", result)
   }
 
   @Test
-  fun `test keyName with long displayName`() {
-    val displayName = "TestName".repeat(15) // Assuming this is longer than MAX_NAME_LENGTH
-    val expected = displayName.normalize().take(MAX_NAME_LENGTH)
-
-    val actual = SnapshotSaver.keyName(displayName)
-
-    assertEquals(expected, actual)
+  fun `keyName for COMPOSABLE snapshot with non-default ComposePreviewSnapshotConfig returns concatenated name`() {
+    val config = ComposePreviewSnapshotConfig(
+      "com.example.test.Composable",
+      uiMode = 1,
+      locale = "en_US",
+      fontScale = 1.5f
+    )
+    val result = keyName(SnapshotType.COMPOSABLE, null, config)
+    assertEquals("com.example.test.Composable_uim_1_loc_en_US_fsc_1.5", result)
   }
 
   @Test
-  fun `test keyName with default ComposePreviewSnapshotConfig`() {
-    val displayName = "TestName"
-    val config = ComposePreviewSnapshotConfig.DEFAULT
-
-    val expected = displayName.normalize().take(MAX_NAME_LENGTH)
-
-    val actual = SnapshotSaver.keyName(displayName, config)
-
-    assertEquals(expected, actual)
-  }
-
-  // normalize
-
-  @Test
-  fun `test normalize with simple string`() {
-    val input = "TestName"
-    val expected = "testname" // lower case, no symbols to replace
-
-    val actual = input.normalize()
-
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  fun `test normalize with string containing symbols`() {
-    val input = "Test Name-1.0"
-    val expected = "test_name_1_0" // lower case, symbols replaced
-
-    val actual = input.normalize()
-
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  fun `test normalize with empty string`() {
-    val input = ""
-    val expected = "" // empty string remains the same
-
-    val actual = input.normalize()
-
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  fun `test normalize with string containing only symbols`() {
-    val input = " .-"
-    val expected = "___" // symbols replaced
-
-    val actual = input.normalize()
-
-    assertEquals(expected, actual)
+  fun `keyName for non-COMPOSABLE snapshot returns normalized displayName`() {
+    val result = keyName(SnapshotType.VIEW, "testDisplayName")
+    // Assuming normalization doesn't alter "testDisplayName" and MAX_KEY_NAME_LENGTH is large enough
+    assertEquals("testdisplayname", result)
   }
 }


### PR DESCRIPTION
We want our backend to be responsible for determining what information to show in our UI, so this PR will change up both our keys and how displayName is handled. KeyName is intended to be opaque to the user and stable across test runs.

## For composables (generated tests):
- KeyName is a combination of fqn of the composable, along with a concatenated variant postfix.
  - This could potentially break when new variants are added in the future, but that's intentional/ok since those would technically be different snapshots which could cause a flaky diff.
- `functionName`, taken from the `originalFqn` will be used as the title in our UI
- User defined name from the `@Preview` annotation, set as `name` in `ComposePreviewSnapshotConfig` will be used as subtitle if present. This matches iOS behavior.
- Additional variant information can also be fronted in UI from `ComposePreviewSnapshotConfig`

## For activities & views (user-written tests):
- KeyName is a normalized `displayName` that the user provides.
- `displayName` will be used as title in our UI
- `fqn.TestClass.functionName` will be used as the subtitle.

This will break composable comparisons, but given we're still in beta, this is acceptable imo at our stage 