### PR TITLE
Automatically set sha/baseSha from GitHub event info if relevant

### DIFF
--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - gradle-plugin/**
 
+permissions:
+  checks: write
+
 jobs:
 
   build:

--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Run functional tests
         run: ./gradlew :gradle-plugin:plugin:functionalTest
       - name: Manually print test report
+        if: always() # always run even if the previous step fails
         run: cat /home/runner/work/emerge-android/emerge-android/gradle-plugin/plugin/build/reports/tests/functionalTest/index.html
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3.4.0

--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -52,13 +52,10 @@ jobs:
             17
       - name: Run functional tests
         run: ./gradlew :gradle-plugin:plugin:functionalTest
-      - name: Manually print test report
-        if: always() # always run even if the previous step fails
-        run: cat /home/runner/work/emerge-android/emerge-android/gradle-plugin/plugin/build/reports/tests/functionalTest/index.html
-      - name: Archive Test Report
+      - name: Archive test reports
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: Test Reports
+          name: Functional test reports
           path: '**/build/reports/tests/functionalTest'
 

--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -52,6 +52,8 @@ jobs:
             17
       - name: Run functional tests
         run: ./gradlew :gradle-plugin:plugin:functionalTest
+      - name: Manually print test report
+        run: cat /home/runner/work/emerge-android/emerge-android/gradle-plugin/plugin/build/reports/tests/functionalTest/index.html
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3.4.0
         if: always() # always run even if the previous step fails

--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -51,10 +51,10 @@ jobs:
             11
             17
       - name: Run functional tests
-        run: ./gradlew :gradle-plugin:plugin:functionalTest --stacktrace
+        run: ./gradlew :gradle-plugin:plugin:functionalTest
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3.4.0
         if: always() # always run even if the previous step fails
         with:
-          report_paths: '**/build/reports/tests/functionalTest/*.xml'
+          report_paths: '**/build/reports/tests/functionalTest/*.html'
 

--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -51,7 +51,7 @@ jobs:
             11
             17
       - name: Run functional tests
-        run: ./gradlew :gradle-plugin:plugin:functionalTest --info
+        run: ./gradlew :gradle-plugin:plugin:functionalTest --info --no-build-cache
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3.4.0
         if: always() # always run even if the previous step fails

--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -51,7 +51,7 @@ jobs:
             11
             17
       - name: Run functional tests
-        run: ./gradlew :gradle-plugin:plugin:functionalTest --info --no-build-cache
+        run: ./gradlew :gradle-plugin:plugin:functionalTest --stacktrace
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3.4.0
         if: always() # always run even if the previous step fails

--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -55,9 +55,10 @@ jobs:
       - name: Manually print test report
         if: always() # always run even if the previous step fails
         run: cat /home/runner/work/emerge-android/emerge-android/gradle-plugin/plugin/build/reports/tests/functionalTest/index.html
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3.4.0
-        if: always() # always run even if the previous step fails
+      - name: Archive Test Report
+        uses: actions/upload-artifact@v2
+        if: always()
         with:
-          report_paths: '**/build/reports/tests/functionalTest/*.html'
+          name: Test Reports
+          path: '**/build/reports/tests/functionalTest'
 

--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -10,9 +10,6 @@ on:
     paths:
       - gradle-plugin/**
 
-permissions:
-  checks: write
-
 jobs:
 
   build:
@@ -54,7 +51,7 @@ jobs:
             11
             17
       - name: Run functional tests
-        run: ./gradlew :gradle-plugin:plugin:functionalTest
+        run: ./gradlew :gradle-plugin:plugin:functionalTest --info
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3.4.0
         if: always() # always run even if the previous step fails

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -66,15 +66,30 @@ abstract class VCSOptions @Inject constructor(
 ) {
 
   val sha: Property<String> = objects.property(String::class.java)
-    .convention(providers.provider { Git.currentSha() })
+    .convention(providers.provider {
+      var sha = Git.currentSha()
+      // GitHub workflows for pull_requests are invoked on a merge commit rather than branch commit.
+      if (GitHub.isSupportedGitHubEvent()) {
+        GitHub.sha()?.let { sha = it }
+      }
+      return@provider sha
+    })
 
   val baseSha: Property<String> = objects.property(String::class.java)
-    .convention(providers.provider { Git.baseSha() })
+    .convention(providers.provider {
+      var baseSha = Git.baseSha()
+      // GitHub workflows for pull_requests are invoked on a merge commit rather than branch commit.
+      if (GitHub.isSupportedGitHubEvent()) {
+        GitHub.baseSha()?.let { baseSha = it }
+      }
+      return@provider baseSha
+    })
 
   val branchName: Property<String> = objects.property(String::class.java)
     .convention(providers.provider { Git.currentBranch() })
 
   val prNumber: Property<String> = objects.property(String::class.java)
+    .convention(providers.provider { GitHub.prNumber()?.toString() })
 
   @get:Nested
   abstract val gitHubOptions: GitHubOptions

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -72,7 +72,7 @@ abstract class VCSOptions @Inject constructor(
       if (GitHub.isSupportedGitHubEvent()) {
         GitHub.sha()?.let { sha = it }
       }
-      return@provider sha
+      sha
     })
 
   val baseSha: Property<String> = objects.property(String::class.java)
@@ -82,7 +82,7 @@ abstract class VCSOptions @Inject constructor(
       if (GitHub.isSupportedGitHubEvent()) {
         GitHub.baseSha()?.let { baseSha = it }
       }
-      return@provider baseSha
+      baseSha
     })
 
   val branchName: Property<String> = objects.property(String::class.java)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
@@ -62,7 +62,7 @@ abstract class BaseUploadTask : DefaultTask() {
 
   @get:Input
   @get:Optional
-  abstract val prNumber: Property<String>
+  abstract val prNumber: Property<Int>
 
   @get:Input
   @get:Optional
@@ -142,7 +142,7 @@ abstract class BaseUploadTask : DefaultTask() {
       baseSha = baseSha.get(),
       branch = branchName.get(),
       repoName = repoName,
-      prNumber = prNumber.orNull,
+      prNumber = prNumber.orNull?.toString(),
       buildType = buildType.orNull,
       gitlabProjectId = gitLabProjectId.orNull,
       androidSnapshotsEnabled = snapshotsEnabled.getOrElse(false),

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
@@ -62,7 +62,7 @@ abstract class BaseUploadTask : DefaultTask() {
 
   @get:Input
   @get:Optional
-  abstract val prNumber: Property<Int>
+  abstract val prNumber: Property<String>
 
   @get:Input
   @get:Optional
@@ -142,7 +142,7 @@ abstract class BaseUploadTask : DefaultTask() {
       baseSha = baseSha.get(),
       branch = branchName.get(),
       repoName = repoName,
-      prNumber = prNumber.orNull?.toString(),
+      prNumber = prNumber.orNull,
       buildType = buildType.orNull,
       gitlabProjectId = gitLabProjectId.orNull,
       androidSnapshotsEnabled = snapshotsEnabled.getOrElse(false),

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
@@ -7,10 +7,8 @@ import java.io.File
 
 internal object GitHub {
 
-  private val json by lazy {
-    Json {
-      ignoreUnknownKeys = true
-    }
+  private val json = Json {
+    ignoreUnknownKeys = true
   }
 
   private fun repoId(): String? {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
@@ -1,8 +1,19 @@
 package com.emergetools.android.gradle.util
 
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import java.io.File
+
 internal object GitHub {
 
-  fun repoId(): String? {
+  private val json by lazy {
+    Json {
+      ignoreUnknownKeys = true
+    }
+  }
+
+  private fun repoId(): String? {
     val remoteUrl = Git.remoteUrl() ?: return null
     val result = Regex("[/:]([^/]+/[^/.]+)\\.git$").find(remoteUrl) ?: return null
     return result.groupValues[1]
@@ -11,4 +22,78 @@ internal object GitHub {
   fun repoOwner() = repoId()?.split('/')?.get(0)
 
   fun repoName() = repoId()?.split('/')?.get(1)
+
+  private fun getEvent(): String? {
+    return System.getenv("GITHUB_EVENT_NAME")
+  }
+
+  fun isSupportedGitHubEvent(): Boolean {
+    return isPullRequest() || isPush()
+  }
+
+  private fun isPullRequest(): Boolean = getEvent() == GITHUB_EVENT_PR
+
+  private fun isPush(): Boolean = getEvent() == GITHUB_EVENT_PUSH
+
+  /**
+   * GitHub workflows for pull_requests are invoked on a merge commit rather than the branch commit.
+   * To ensure status checks work along with proper diffing on PRs, we'll attempt to get the sha
+   * and bas
+   */
+  fun sha(): String? {
+    return when {
+      isPush() -> System.getenv("GITHUB_SHA")
+      isPullRequest() -> getPullRequestEventData().pr.head.sha
+      else -> null
+    }
+  }
+
+  /**
+   * Similar to [sha], but returns the base sha for the PR based on GH event data.
+   */
+  fun baseSha(): String? {
+    return when {
+      isPullRequest() -> getPullRequestEventData().pr.base.sha
+      // By default, we don't set a base sha for push events as it could trigger unexpected
+      // main branch comparison.
+      else -> null
+    }
+  }
+
+  fun prNumber(): Int? {
+    if (!isPullRequest()) return null
+    return getPullRequestEventData().number
+  }
+
+  private fun getPullRequestEventData(): GitHubPullRequestEvent {
+    val gitHubEventPath = checkNotNull(System.getenv("GITHUB_EVENT_PATH")) {
+      "GITHUB_EVENT_PATH is not set"
+    }
+    val file = File(gitHubEventPath)
+    check(file.exists()) {
+      "File $gitHubEventPath doesn't exist"
+    }
+
+    return json.decodeFromStream(file.inputStream())
+  }
+
+  private const val GITHUB_EVENT_PR = "pull_request"
+  private const val GITHUB_EVENT_PUSH = "push"
+
+  @Serializable
+  data class GitHubPullRequestEvent(
+    val pr: GitHubPullRequest,
+    val number: Int,
+  )
+
+  @Serializable
+  data class GitHubPullRequest(
+    val base: GitHubPullRequestCommit,
+    val head: GitHubPullRequestCommit,
+  )
+
+  @Serializable
+  data class GitHubPullRequestCommit(
+    val sha: String,
+  )
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
@@ -1,5 +1,6 @@
 package com.emergetools.android.gradle.util
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
@@ -80,6 +81,7 @@ internal object GitHub {
 
   @Serializable
   data class GitHubPullRequestEvent(
+    @SerialName("pull_request")
     val pr: GitHubPullRequest,
     val number: Int,
   )


### PR DESCRIPTION
Adds support for automatic handling of GitHub event data. From internal testing and client experience, GitHub values for sha/baseSha are related to the merge commit/reliant on the checkout action to properly set respectively. This leads to issues calling the GitHub API and finding the proper build to compare against.

Rather than rely on users to set this, we can make some safe assumptions ourselves and go ahead and set the data if it's present. This should make GitHub CI integreations far easier.

Resolves ET-2264