### PR TITLE
Add tests for GitHub event sha/baseSha setting and respective infra for testing config

### DIFF
--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -138,8 +138,10 @@ dependencies {
 	testImplementation(libs.google.truth)
 	testRuntimeOnly(libs.junit.jupiter.engine)
 
+  "functionalTestImplementation"(projects.gradlePlugin.plugin)
 	"functionalTestImplementation"(libs.junit.jupiter.api)
 	"functionalTestImplementation"(libs.okhttp.mockwebserver)
+  "functionalTestImplementation"(libs.kotlinx.serialization)
 	"functionalTestRuntimeOnly"(libs.junit.jupiter.engine)
 
 	detektPlugins(libs.detekt.formatting)

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/NoVcsEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/NoVcsEmergePluginTest.kt
@@ -2,7 +2,15 @@ package com.emergetools.android.gradle
 
 import com.emergetools.android.gradle.base.EmergeGradleRunner
 import com.emergetools.android.gradle.mocks.assertSuccessfulUploadRequests
+import com.emergetools.android.gradle.tasks.internal.SaveExtensionConfigTask.Companion.EmergePluginExtensionData
+import com.emergetools.android.gradle.utils.EnvUtils.withGitHubPREvent
+import com.emergetools.android.gradle.utils.EnvUtils.withGitHubPushEvent
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.jupiter.api.Test
+import java.io.File
 
 class NoVcsEmergePluginTest : EmergePluginTest() {
 
@@ -65,5 +73,58 @@ class NoVcsEmergePluginTest : EmergePluginTest() {
       .withArguments("packageRelease")
       .build()
     result.assertSuccessfulTask(":packageRelease")
+  }
+
+  @Test
+  fun `Assert GitHub PR sha overwrites sha`() {
+    val runner = EmergeGradleRunner.create("no-vcs-params")
+    val configurationJson = File(runner.tempProjectDir, "emerge_config.json")
+
+    runner
+      .withArguments(
+        "saveExtensionConfig",
+        "--outputPath",
+        configurationJson.path,
+      )
+      .withDebugTasks()
+      .withGitHubPREvent()
+      .assert { result, _ ->
+        result.assertSuccessfulTask(":saveExtensionConfig")
+      }
+      .build()
+
+    val configuration = Json.decodeFromStream<EmergePluginExtensionData>(
+      configurationJson.inputStream()
+    )
+
+    assertEquals("github_head_sha", configuration.vcsOptions!!.sha)
+    assertEquals("github_base_sha", configuration.vcsOptions!!.baseSha)
+  }
+
+  @Test
+  fun `Assert GitHub push env sha overwrites sha`() {
+    val runner = EmergeGradleRunner.create("no-vcs-params")
+    val configurationJson = File(runner.tempProjectDir, "emerge_config.json")
+
+    runner
+      .withArguments(
+        "saveExtensionConfig",
+        "--outputPath",
+        configurationJson.path,
+      )
+      .withDebugTasks()
+      .withGitHubPushEvent()
+      .assert { result, _ ->
+        result.assertSuccessfulTask(":saveExtensionConfig")
+      }
+      .build()
+
+    val configuration = Json.decodeFromStream<EmergePluginExtensionData>(
+      configurationJson.inputStream()
+    )
+
+    assertEquals("github_env_sha", configuration.vcsOptions!!.sha)
+    // BaseSha not set by default
+    assertNull(configuration.vcsOptions!!.baseSha)
   }
 }

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/NoVcsEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/NoVcsEmergePluginTest.kt
@@ -99,6 +99,7 @@ class NoVcsEmergePluginTest : EmergePluginTest() {
 
     assertEquals("github_head_sha", configuration.vcsOptions!!.sha)
     assertEquals("github_base_sha", configuration.vcsOptions!!.baseSha)
+    assertEquals("123", configuration.vcsOptions!!.prNumber)
   }
 
   @Test

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/utils/EnvUtils.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/utils/EnvUtils.kt
@@ -1,0 +1,30 @@
+package com.emergetools.android.gradle.utils
+
+import com.emergetools.android.gradle.base.EmergeGradleRunner
+import java.io.File
+
+object EnvUtils {
+
+  fun EmergeGradleRunner.withGitHubPREvent(): EmergeGradleRunner {
+
+    val resource = this.javaClass.getResource("/github-event-mocks/mock_pr_event.json")
+    val jsonFile = File(resource.toURI())
+
+    return withEnvironment(
+      "GITHUB_EVENT_NAME" to "pull_request",
+      "GITHUB_EVENT_PATH" to jsonFile.path,
+    )
+  }
+
+  fun EmergeGradleRunner.withGitHubPushEvent(): EmergeGradleRunner {
+
+    val resource = this.javaClass.getResource("/github-event-mocks/mock_push_event.json")
+    val jsonFile = File(resource.toURI())
+
+    return withEnvironment(
+      "GITHUB_EVENT_NAME" to "push",
+      "GITHUB_EVENT_PATH" to jsonFile.path,
+      "GITHUB_SHA" to "github_env_sha",
+    )
+  }
+}

--- a/gradle-plugin/plugin/src/functionalTest/resources/github-event-mocks/mock_pr_event.json
+++ b/gradle-plugin/plugin/src/functionalTest/resources/github-event-mocks/mock_pr_event.json
@@ -1,0 +1,13 @@
+{
+  "number": 123,
+  "pull_request": {
+    "head": {
+      "ref": "feature",
+      "sha": "github_head_sha"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "github_base_sha"
+    }
+  }
+}

--- a/gradle-plugin/plugin/src/functionalTest/resources/github-event-mocks/mock_push_event.json
+++ b/gradle-plugin/plugin/src/functionalTest/resources/github-event-mocks/mock_push_event.json
@@ -1,0 +1,5 @@
+{
+  "push": {
+    "before": "github_before_sha"
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -10,6 +10,7 @@ import com.android.build.api.variant.Variant
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.android.build.gradle.internal.utils.KOTLIN_ANDROID_PLUGIN_ID
+import com.emergetools.android.gradle.tasks.internal.SaveExtensionConfigTask
 import com.emergetools.android.gradle.tasks.perf.GeneratePerfProject
 import com.emergetools.android.gradle.tasks.perf.LocalPerfTest
 import com.emergetools.android.gradle.tasks.perf.UploadPerfBundle
@@ -96,6 +97,10 @@ class EmergePlugin : Plugin<Project> {
           ?: return@onVariants
 
         registerSnapshotTasks(appProject, emergeExtension, variant, androidTest)
+
+        if (appProject.hasProperty(EMERGE_DEBUG_TASK_PROPERTY)) {
+          registerDebugTasks(appProject, emergeExtension)
+        }
       }
     }
   }
@@ -438,6 +443,24 @@ class EmergePlugin : Plugin<Project> {
     }
   }
 
+  private fun registerDebugTasks(
+    project: Project,
+    extension: EmergePluginExtension,
+  ) {
+    registerSaveExtensionConfigTask(project, extension)
+  }
+
+  private fun registerSaveExtensionConfigTask(
+    project: Project,
+    extension: EmergePluginExtension,
+  ) {
+    project.tasks.register("saveExtensionConfig", SaveExtensionConfigTask::class.java) {
+      it.group = EMERGE_TASK_GROUP
+      it.description = "Saves the Emerge extension configuration to a local file for debugging."
+      it.emergePluginExtension.set(extension)
+    }
+  }
+
   private fun logExtension(
     project: Project,
     extension: EmergePluginExtension,
@@ -480,6 +503,8 @@ class EmergePlugin : Plugin<Project> {
     private const val EMERGE_EXTENSION_NAME = "emerge"
     private const val EMERGE_TASK_PREFIX = "emerge"
     private const val EMERGE_TASK_GROUP = "Emerge"
+
+    private const val EMERGE_DEBUG_TASK_PROPERTY = "emergeDebug"
 
     private const val ANDROID_APPLICATION_PLUGIN_ID = "com.android.application"
     private const val ANDROID_TEST_PLUGIN_ID = "com.android.test"

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -78,6 +78,7 @@ abstract class VCSOptions @Inject constructor(
   val baseSha: Property<String> = objects.property(String::class.java)
     .convention(providers.provider {
       var baseSha = Git.baseSha()
+      println("baseSha: $baseSha")
       // GitHub workflows for pull_requests are invoked on a merge commit rather than branch commit.
       if (GitHub.isSupportedGitHubEvent()) {
         GitHub.baseSha()?.let { baseSha = it }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -78,7 +78,6 @@ abstract class VCSOptions @Inject constructor(
   val baseSha: Property<String> = objects.property(String::class.java)
     .convention(providers.provider {
       var baseSha = Git.baseSha()
-      println("baseSha: $baseSha")
       // GitHub workflows for pull_requests are invoked on a merge commit rather than branch commit.
       if (GitHub.isSupportedGitHubEvent()) {
         GitHub.baseSha()?.let { baseSha = it }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/internal/SaveExtensionConfigTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/internal/SaveExtensionConfigTask.kt
@@ -1,0 +1,155 @@
+package com.emergetools.android.gradle.tasks.internal
+
+import com.emergetools.android.gradle.EmergePluginExtension
+import com.emergetools.android.gradle.GitHubOptions
+import com.emergetools.android.gradle.GitLabOptions
+import com.emergetools.android.gradle.PerfOptions
+import com.emergetools.android.gradle.SizeOptions
+import com.emergetools.android.gradle.SnapshotOptions
+import com.emergetools.android.gradle.VCSOptions
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import java.io.File
+
+/**
+ * Internal-only debug task for saving the [EmergePluginExtension] to a json file for
+ * testing.
+ *
+ * The test runner itself has no way to inspect the extension, so this task is used
+ * as a workaround to write the extension to JSON, where we can later assert on the
+ * contents of the JSON file to ensure our config is handled properly.
+ */
+abstract class SaveExtensionConfigTask : DefaultTask() {
+
+  @get:Input
+  abstract val emergePluginExtension: Property<EmergePluginExtension>
+
+  private var outputPath: String? = null
+
+  @Option(option = "outputPath", description = "Output path for configuration JSON file")
+  fun setOutputPath(outputPath: String) {
+    check(outputPath.isNotBlank()) { "Output path cannot be blank" }
+    this.outputPath = outputPath
+  }
+
+  @TaskAction
+  fun saveConfig() {
+    val extensionData = emergePluginExtension.get().dataFromExtension()
+    val configJson = Json.encodeToString(extensionData)
+    val outputFile = File(outputPath).also {
+      it.createNewFile()
+      it.writeText(configJson)
+    }
+    logger.lifecycle("Saved extension config to $outputFile")
+  }
+
+  companion object {
+
+    @Serializable
+    data class EmergePluginExtensionData(
+      val apiToken: String?,
+      val sizeOptions: SizeOptionsData?,
+      val perfOptions: PerfOptionsData?,
+      val snapshotOptions: SnapshotOptionsData?,
+      val vcsOptions: VCSOptionsData?,
+    )
+
+    private fun EmergePluginExtension.dataFromExtension(): EmergePluginExtensionData {
+      return EmergePluginExtensionData(
+        apiToken = apiToken.orNull,
+        vcsOptions = vcsOptions.dataFromExtension(),
+        sizeOptions = sizeOptions.dataFromExtension(),
+        perfOptions = perfOptions.dataFromExtension(),
+        snapshotOptions = snapshotOptions.dataFromExtension(),
+      )
+    }
+
+    @Serializable
+    data class VCSOptionsData(
+      val sha: String?,
+      val baseSha: String?,
+      val branchName: String?,
+      val prNumber: String?,
+      val gitHubOptions: GitHubOptionsData?,
+      val gitLabOptions: GitLabOptionsData?,
+    )
+
+    private fun VCSOptions.dataFromExtension(): VCSOptionsData {
+      return VCSOptionsData(
+        sha = sha.orNull,
+        baseSha = baseSha.orNull,
+        branchName = branchName.orNull,
+        prNumber = prNumber.orNull,
+        gitHubOptions = gitHubOptions.dataFromExtension(),
+        gitLabOptions = gitLabOptions.dataFromExtension()
+      )
+    }
+
+    @Serializable
+    data class GitHubOptionsData(
+      val repoOwner: String?,
+      val repoName: String?,
+    )
+
+    private fun GitHubOptions.dataFromExtension(): GitHubOptionsData {
+      return GitHubOptionsData(
+        repoOwner = repoOwner.orNull,
+        repoName = repoName.orNull,
+      )
+    }
+
+    @Serializable
+    data class GitLabOptionsData(
+      val projectId: String?,
+    )
+
+    private fun GitLabOptions.dataFromExtension(): GitLabOptionsData {
+      return GitLabOptionsData(
+        projectId = projectId.orNull,
+      )
+    }
+
+    @Serializable
+    data class SizeOptionsData(
+      val buildType: String?,
+    )
+
+    private fun SizeOptions.dataFromExtension(): SizeOptionsData {
+      return SizeOptionsData(
+        buildType = buildType.orNull,
+      )
+    }
+
+    @Serializable
+    data class PerfOptionsData(
+      val buildType: String?,
+      val projectPath: String?,
+    )
+
+    private fun PerfOptions.dataFromExtension(): PerfOptionsData {
+      return PerfOptionsData(
+        buildType = buildType.orNull,
+        projectPath = projectPath.orNull,
+      )
+    }
+
+    @Serializable
+    data class SnapshotOptionsData(
+      val buildType: String?,
+      val snapshotsStorageDirectory: String?,
+    )
+
+    private fun SnapshotOptions.dataFromExtension(): SnapshotOptionsData {
+      return SnapshotOptionsData(
+        buildType = buildType.orNull,
+        snapshotsStorageDirectory = snapshotsStorageDirectory.orNull?.asFile?.path,
+      )
+    }
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
@@ -2,7 +2,6 @@ package com.emergetools.android.gradle.tasks.upload
 
 import com.emergetools.android.gradle.BuildConfig
 import com.emergetools.android.gradle.EmergePlugin
-import com.emergetools.android.gradle.EmergePlugin.Companion
 import com.emergetools.android.gradle.EmergePluginExtension
 import com.emergetools.android.gradle.util.AgpVersions
 import com.emergetools.android.gradle.util.network.EmergeUploadRequestData

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Git.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Git.kt
@@ -11,7 +11,10 @@ internal object Git {
   }
 
   fun baseSha(): String? {
-    return "git merge-base ${remoteHeadBranch()} ${currentBranch()}".execute().trimmedText
+    val baseSha = "git merge-base ${remoteHeadBranch()} ${currentBranch()}".execute().trimmedText
+    // Consider blank (empty or whitespace) base sha as null
+    if (baseSha?.isBlank() == true) return null
+    return baseSha
   }
 
   fun remoteUrl(remote: String? = primaryRemote()): String? {


### PR DESCRIPTION
Adds tests for recent addition of automatic GitHub PR info setting #42.

This approaches the test in a bit of a clever manner. In our functional Gradle tests, we have no way to “inspect” the emerge extension config as part of the test, as the gradle runner doesn’t expose it.

To get around this, I creataed a custom debug task (only created when a special debug flag is added) that would output the config as JSON to a location of our choosing passed through an arg. For testing, we’ll just enable the debug flag, write the file, then perform normal assertions on the contents. 