### PR TITLE
Add snapshots-annotations and a new IgnoreEmergeSnapshot annotation which will ignore generating a snapshot test for a given preview

### DIFF
--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -19,7 +19,7 @@ formatting:
   FinalNewline:
     insertFinalNewLine: true
   MaximumLineLength:
-    maxLineLength: 100
+    maxLineLength: 120
 
 naming:
   FunctionNaming:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ include(
   ":performance:sample:perftesting",
   ":snapshots",
   ":snapshots:snapshots",
+  ":snapshots:snapshots-annotations",
   ":snapshots:snapshots-processor",
   ":snapshots:snapshots-shared",
   ":snapshots:sample",

--- a/snapshots/sample/app/build.gradle.kts
+++ b/snapshots/sample/app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
   implementation(libs.androidx.activity.compose)
 
   implementation(projects.snapshots.sample.uiModule)
+  implementation(projects.snapshots.snapshotsAnnotations)
 
   implementation(platform(libs.compose.bom))
   implementation(libs.compose.ui)

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.emergetools.snapshots.annotations.IgnoreEmergeSnapshot
 
 @Composable
 fun TextRowWithIcon(
@@ -22,7 +23,6 @@ fun TextRowWithIcon(
   }
 }
 
-// Should not be snapshotted as this is in the main source set
 @Preview
 @Preview(
   fontScale = 1.5f
@@ -32,5 +32,16 @@ fun TextRowWithIconPreviewFromMain() {
   TextRowWithIcon(
     titleText = "Title",
     subtitleText = "Subtitle"
+  )
+}
+
+// Should not be snapshotted as this is marked to be ignored
+@Preview
+@IgnoreEmergeSnapshot
+@Composable
+fun TextRowWithIconPreviewFromMainIgnored() {
+  TextRowWithIcon(
+    titleText = "Title (ignored)",
+    subtitleText = "Subtitle (ignored)"
   )
 }

--- a/snapshots/snapshots-annotations/build.gradle.kts
+++ b/snapshots/snapshots-annotations/build.gradle.kts
@@ -83,8 +83,8 @@ publishing {
       }
 
       pom {
-        name.set("Emerge Tools Snapshots shared dependencies")
-        description.set("Shared dependencies for Emerge Composable Preview snapshots.")
+        name.set("Emerge Tools Snapshots annotations")
+        description.set("Annotations for Emerge Composable Preview snapshots.")
         url.set("https://www.emergetools.com")
         licenses {
           license {

--- a/snapshots/snapshots-annotations/build.gradle.kts
+++ b/snapshots/snapshots-annotations/build.gradle.kts
@@ -31,15 +31,7 @@ tasks.withType<KotlinCompile> {
 }
 
 dependencies {
-  implementation(libs.kotlin.reflect)
-  implementation(libs.kotlinpoet)
-  implementation(libs.kotlinpoet.ksp)
   implementation(libs.kotlinx.serialization)
-  implementation(libs.ksp.api)
-  implementation(libs.junit)
-
-  api(projects.snapshots.snapshotsShared)
-  api(projects.snapshots.snapshotsAnnotations)
 }
 
 tasks.register("generateMetaInfVersion") {
@@ -84,15 +76,15 @@ publishing {
 
   publications {
     create<MavenPublication>("release") {
-      artifactId = "snapshots-processor"
+      artifactId = "snapshots-annotations"
 
       afterEvaluate {
         from(components["java"])
       }
 
       pom {
-        name.set("Emerge Tools Snapshots Annotation Processor")
-        description.set("Annotation processor for Emerge Composable Preview snapshots.")
+        name.set("Emerge Tools Snapshots shared dependencies")
+        description.set("Shared dependencies for Emerge Composable Preview snapshots.")
         url.set("https://www.emergetools.com")
         licenses {
           license {

--- a/snapshots/snapshots-annotations/src/main/kotlin/com/emergetools/snapshots/annotations/IgnoreEmergeSnapshot.kt
+++ b/snapshots/snapshots-annotations/src/main/kotlin/com/emergetools/snapshots/annotations/IgnoreEmergeSnapshot.kt
@@ -1,0 +1,7 @@
+package com.emergetools.snapshots.annotations
+
+/**
+ * Specifies the annotated function is a Preview that should be ignored by Emerge snapshotting.
+ */
+@Target(AnnotationTarget.FUNCTION)
+annotation class IgnoreEmergeSnapshot

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -188,9 +188,6 @@ class PreviewProcessor(
     private const val COMPOSE_PREVIEW_ANNOTATION_NAME =
       "androidx.compose.ui.tooling.preview.Preview"
 
-    private const val IGNORE_EMERGE_SNAPSHOT_ANNOTATION_NAME =
-      "com.emergetools.snapshots.annotations.IgnoreEmergeSnapshot"
-
     private val ANDROID_JUNIT_RUNNER_CLASSNAME =
       ClassName("androidx.test.ext.junit.runners", "AndroidJUnit4")
     private val JUNIT_TEST_ANNOTATION_CLASSNAME = ClassName("org.junit", "Test")

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -62,7 +62,7 @@ class PreviewProcessor(
 
       if (previewFunction.isAnnotationPresent(IgnoreEmergeSnapshot::class)) {
         logger.info(
-          "Skipping ${previewFunction.simpleName.asString()} as it is annotated with @IgnoreEmergeSnapshot"
+          "Skipping ${previewFunction.simpleName.asString()} as it's annotated with @IgnoreEmergeSnapshot"
         )
         return@forEach
       }

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -1,11 +1,14 @@
 package com.emergetools.snapshots.processor
 
+import com.emergetools.snapshots.annotations.IgnoreEmergeSnapshot
 import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuilder.addComposableSnapshotBlock
 import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuilder.addComposeRuleProperty
 import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuilder.addEmergeSnapshotRuleProperty
 import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuilder.addPreviewConfigProperty
 import com.emergetools.snapshots.processor.preview.ComposePreviewUtils.getUniqueSnapshotConfigsFromPreviewAnnotations
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.isAnnotationPresent
 import com.google.devtools.ksp.isPrivate
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
@@ -37,6 +40,7 @@ class PreviewProcessor(
 
   private val logger = environment.logger
 
+  @OptIn(KspExperimental::class)
   override fun process(resolver: Resolver): List<KSAnnotated> {
     val previewFunctions = resolver
       .getSymbolsWithAnnotation(COMPOSE_PREVIEW_ANNOTATION_NAME)
@@ -53,6 +57,13 @@ class PreviewProcessor(
 
       if (previewFunction.isPrivate()) {
         logger.info("Skipping ${previewFunction.simpleName.asString()} as it is private")
+        return@forEach
+      }
+
+      if (previewFunction.isAnnotationPresent(IgnoreEmergeSnapshot::class)) {
+        logger.info(
+          "Skipping ${previewFunction.simpleName.asString()} as it is annotated with @IgnoreEmergeSnapshot"
+        )
         return@forEach
       }
 
@@ -176,6 +187,9 @@ class PreviewProcessor(
 
     private const val COMPOSE_PREVIEW_ANNOTATION_NAME =
       "androidx.compose.ui.tooling.preview.Preview"
+
+    private const val IGNORE_EMERGE_SNAPSHOT_ANNOTATION_NAME =
+      "com.emergetools.snapshots.annotations.IgnoreEmergeSnapshot"
 
     private val ANDROID_JUNIT_RUNNER_CLASSNAME =
       ClassName("androidx.test.ext.junit.runners", "AndroidJUnit4")


### PR DESCRIPTION
- Adds `snapshots-annotations` module/dependency which will contain any annotations to be used from any source set.
- Adds `@IgnoreEmergeSnapshot` annotation which will tell our `snapshots-processor` to ignore the Preview when generating snapshots
- Adds handling for the new annotation to `snapshots-processor`

Deploy/version bump will be in follow up.

Resolves ET-2331