### PR TITLE
Output upload response data to file for users to ingest JSON

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -498,7 +498,7 @@ class EmergePlugin : Plugin<Project> {
   }
 
   companion object {
-    const val BUILD_OUTPUT_DIR_NAME = "emerge"
+    const val BUILD_OUTPUT_DIR_NAME = "emergetools"
 
     private const val EMERGE_EXTENSION_NAME = "emerge"
     private const val EMERGE_TASK_PREFIX = "emerge"

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
@@ -113,7 +113,15 @@ abstract class BaseUploadTask : DefaultTask() {
       }
     }
 
-    return uploadFile(zipFile, outputDir)
+    // Write the upload response to a file so it can be read by clients should they want to ingest
+    // the buildId or url
+    val response = uploadFile(zipFile, outputDir)
+    File(outputDir, UPLOAD_RESPONSE_FILE_NAME).also {
+      it.createNewFile()
+      it.writeText(Json.encodeToString(response))
+    }
+
+    return response
   }
 
   /**
@@ -183,6 +191,7 @@ abstract class BaseUploadTask : DefaultTask() {
 
   companion object {
     const val OUTPUT_FILE_NAME = "emerge.zip"
+    const val UPLOAD_RESPONSE_FILE_NAME = "upload_response.json"
     const val DEFAULT_API_TOKEN_ENV_KEY = "EMERGE_API_TOKEN"
     private const val ARTIFACT_OUTPUT_DIR = "${EmergePlugin.BUILD_OUTPUT_DIR_NAME}/artifacts"
 


### PR DESCRIPTION
Outputs the response json from the `/upload` endpoint to a file, `upload_response.json` that will be saved into the `build/emergetools` folder. This handles a client request to programmatically handle the URL/uploadId so they can ingest into their internal dashboards without tailing/parsing logs.

Resolves ET-2280