### PR TITLE
Fix configuration cache violations

### DIFF
--- a/.github/workflows/snapshots-sample-app.yml
+++ b/.github/workflows/snapshots-sample-app.yml
@@ -5,7 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    paths: [ snapshots/** ]
+    paths:
+      - gradle-plugin/**
+      - snapshots/**
 
 jobs:
   build:

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -1,9 +1,13 @@
 package com.emergetools.android.gradle
 
 import com.emergetools.android.gradle.tasks.upload.BaseUploadTask
-import com.emergetools.android.gradle.util.Git
-import com.emergetools.android.gradle.util.GitHub
 import com.emergetools.android.gradle.util.property
+import com.emergetools.android.gradle.util.providers.GitBaseShaValueSource
+import com.emergetools.android.gradle.util.providers.GitCurrentBranchValueSource
+import com.emergetools.android.gradle.util.providers.GitHubPrNumberValueSource
+import com.emergetools.android.gradle.util.providers.GitHubRepoNameValueSource
+import com.emergetools.android.gradle.util.providers.GitHubRepoOwnerValueSource
+import com.emergetools.android.gradle.util.providers.GitShaValueSource
 import org.gradle.api.Action
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
@@ -66,30 +70,16 @@ abstract class VCSOptions @Inject constructor(
 ) {
 
   val sha: Property<String> = objects.property(String::class.java)
-    .convention(providers.provider {
-      var sha = Git.currentSha()
-      // GitHub workflows for pull_requests are invoked on a merge commit rather than branch commit.
-      if (GitHub.isSupportedGitHubEvent()) {
-        GitHub.sha()?.let { sha = it }
-      }
-      sha
-    })
+    .convention(providers.of(GitShaValueSource::class.java) {})
 
   val baseSha: Property<String> = objects.property(String::class.java)
-    .convention(providers.provider {
-      var baseSha = Git.baseSha()
-      // GitHub workflows for pull_requests are invoked on a merge commit rather than branch commit.
-      if (GitHub.isSupportedGitHubEvent()) {
-        GitHub.baseSha()?.let { baseSha = it }
-      }
-      baseSha
-    })
+    .convention(providers.of(GitBaseShaValueSource::class.java) {})
 
   val branchName: Property<String> = objects.property(String::class.java)
-    .convention(providers.provider { Git.currentBranch() })
+    .convention(providers.of(GitCurrentBranchValueSource::class.java) {})
 
   val prNumber: Property<String> = objects.property(String::class.java)
-    .convention(providers.provider { GitHub.prNumber()?.toString() })
+    .convention(providers.of(GitHubPrNumberValueSource::class.java) {})
 
   @get:Nested
   abstract val gitHubOptions: GitHubOptions
@@ -112,10 +102,10 @@ abstract class GitHubOptions @Inject constructor(
 ) {
 
   val repoOwner: Property<String> = objects.property(String::class.java)
-    .convention(providers.provider { GitHub.repoOwner() })
+    .convention(providers.of(GitHubRepoOwnerValueSource::class.java) {})
 
   val repoName: Property<String> = objects.property(String::class.java)
-    .convention(providers.provider { GitHub.repoName() })
+    .convention(providers.of(GitHubRepoNameValueSource::class.java) {})
 }
 
 abstract class GitLabOptions {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/LocalPerfTest.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/LocalPerfTest.kt
@@ -8,6 +8,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
 
 abstract class LocalPerfTest : DefaultTask() {
 
@@ -45,6 +47,9 @@ abstract class LocalPerfTest : DefaultTask() {
     arguments["notAnnotation"] = notAnnotation
   }
 
+  @get:Inject
+  abstract val execOperations: ExecOperations
+
   /**
    * Enables the local runner to force-stop the app and more closely mimic real testing behavior
    */
@@ -57,7 +62,7 @@ abstract class LocalPerfTest : DefaultTask() {
 
   @TaskAction
   fun execute() {
-    val adbHelper = AdbHelper(logger)
+    val adbHelper = AdbHelper(execOperations, logger)
 
     adbHelper.apply {
       shell("am", "force-stop", appPackageName.get())

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Git.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Git.kt
@@ -1,17 +1,19 @@
 package com.emergetools.android.gradle.util
 
-internal object Git {
+import org.gradle.process.ExecOperations
+
+internal class Git(private val execOperations: ExecOperations) {
 
   fun currentBranch(): String? {
-    return "git rev-parse --abbrev-ref HEAD".execute().trimmedText
+    return execOperations.execute("git rev-parse --abbrev-ref HEAD")
   }
 
   fun currentSha(): String? {
-    return "git rev-parse HEAD".execute().trimmedText
+    return execOperations.execute("git rev-parse HEAD")
   }
 
   fun baseSha(): String? {
-    val baseSha = "git merge-base ${remoteHeadBranch()} ${currentBranch()}".execute().trimmedText
+    val baseSha = execOperations.execute("git merge-base ${remoteHeadBranch()} ${currentBranch()}")
     // Consider blank (empty or whitespace) base sha as null
     if (baseSha?.isBlank() == true) return null
     return baseSha
@@ -19,11 +21,11 @@ internal object Git {
 
   fun remoteUrl(remote: String? = primaryRemote()): String? {
     if (remote == null) return null
-    return "git config --get remote.$remote.url".execute().trimmedText
+    return execOperations.execute("git config --get remote.$remote.url")
   }
 
   private fun remote(): List<String>? {
-    return "git remote".execute().trimmedText?.split("\n")
+    return execOperations.execute("git remote")?.split("\n")
   }
 
   private fun primaryRemote(): String? {
@@ -37,7 +39,7 @@ internal object Git {
 
   private fun remoteHeadBranch(remote: String? = primaryRemote()): String? {
     if (remote == null) return null
-    val show = "git remote show $remote".execute().trimmedText ?: return null
+    val show = execOperations.execute("git remote show $remote") ?: return null
     return show.split("\n").asSequence()
       .map { it.trim() }
       .firstOrNull { it.startsWith("HEAD branch: ") }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
@@ -3,16 +3,21 @@ package com.emergetools.android.gradle.util
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.gradle.process.ExecOperations
 import java.io.File
 
-internal object GitHub {
+internal class GitHub(private val execOperations: ExecOperations) {
+
+  private val git by lazy {
+    Git(execOperations)
+  }
 
   private val json = Json {
     ignoreUnknownKeys = true
   }
 
   private fun repoId(): String? {
-    val remoteUrl = Git.remoteUrl() ?: return null
+    val remoteUrl = git.remoteUrl() ?: return null
     val result = Regex("[/:]([^/]+/[^/.]+)\\.git$").find(remoteUrl) ?: return null
     return result.groupValues[1]
   }
@@ -76,9 +81,6 @@ internal object GitHub {
     return json.decodeFromString(fileContent)
   }
 
-  private const val GITHUB_EVENT_PR = "pull_request"
-  private const val GITHUB_EVENT_PUSH = "push"
-
   @Serializable
   data class GitHubPullRequestEvent(
     @SerialName("pull_request")
@@ -96,4 +98,9 @@ internal object GitHub {
   data class GitHubPullRequestCommit(
     val sha: String,
   )
+
+  companion object {
+    private const val GITHUB_EVENT_PR = "pull_request"
+    private const val GITHUB_EVENT_PUSH = "push"
+  }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Process.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Process.kt
@@ -1,16 +1,27 @@
 package com.emergetools.android.gradle.util
 
+import org.gradle.api.logging.Logging
 import org.gradle.process.ExecOperations
 import java.io.ByteArrayOutputStream
 
 fun ExecOperations.execute(command: String): String? {
+  val logger = Logging.getLogger(this::class.java)
   val outputStream = ByteArrayOutputStream()
+  val errorOutputStream = ByteArrayOutputStream()
   exec {
     it.commandLine(command.split(" "))
     it.standardOutput = outputStream
+    it.errorOutput = errorOutputStream
+    // Intentionally ignore exceptions and swallow to prevent plugin operations from hard failing
+    it.isIgnoreExitValue = true
   }
 
-  val output = String(outputStream.toByteArray(), Charsets.UTF_8).trimEnd()
+  val errorOutput = String(errorOutputStream.toByteArray()).trimEnd()
+  if (errorOutput.isNotBlank()) {
+    logger.warn("Error running $command: $errorOutput")
+  }
+
+  val output = String(outputStream.toByteArray()).trimEnd()
   if (output.isEmpty()) {
     return null
   }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Process.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Process.kt
@@ -1,7 +1,18 @@
 package com.emergetools.android.gradle.util
 
-import org.codehaus.groovy.runtime.ProcessGroovyMethods
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
 
-internal fun String.execute() = ProcessGroovyMethods.execute(this)
+fun ExecOperations.execute(command: String): String? {
+  val outputStream = ByteArrayOutputStream()
+  exec {
+    it.commandLine(command.split(" "))
+    it.standardOutput = outputStream
+  }
 
-internal val Process.trimmedText: String? get() = ProcessGroovyMethods.getText(this)?.trimEnd()
+  val output = String(outputStream.toByteArray(), Charsets.UTF_8).trimEnd()
+  if (output.isEmpty()) {
+    return null
+  }
+  return output
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/adb/AdbHelper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/adb/AdbHelper.kt
@@ -1,12 +1,13 @@
 package com.emergetools.android.gradle.util.adb
 
 import com.emergetools.android.gradle.util.execute
-import com.emergetools.android.gradle.util.trimmedText
 import org.gradle.api.logging.Logger
+import org.gradle.process.ExecOperations
 import java.nio.file.Files
 import java.nio.file.Path
 
 class AdbHelper(
+  private val execOperations: ExecOperations,
   private val logger: Logger,
   private val path: Path = Path.of("${System.getenv("ANDROID_HOME")}/platform-tools/adb"),
 ) {
@@ -44,6 +45,6 @@ class AdbHelper(
 
   fun exec(args: List<String>): String? {
     val command = "$path ${args.joinToString(" ")}"
-    return command.execute().trimmedText
+    return execOperations.execute(command)
   }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitBaseShaValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitBaseShaValueSource.kt
@@ -1,0 +1,27 @@
+package com.emergetools.android.gradle.util.providers
+
+import com.emergetools.android.gradle.util.Git
+import com.emergetools.android.gradle.util.GitHub
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters.None
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class GitBaseShaValueSource : ValueSource<String?, None> {
+
+  @get:Inject
+  abstract val execOperations: ExecOperations
+
+  override fun obtain(): String? {
+    val git = Git(execOperations)
+    val gitHub = GitHub(execOperations)
+
+    var baseSha = git.baseSha()
+    // GitHub workflows for pull_requests are invoked on a merge commit rather than branch commit.
+    if (gitHub.isSupportedGitHubEvent()) {
+      gitHub.baseSha()?.let { baseSha = it }
+    }
+
+    return baseSha
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitBaseShaValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitBaseShaValueSource.kt
@@ -16,10 +16,12 @@ abstract class GitBaseShaValueSource : ValueSource<String?, None> {
     val git = Git(execOperations)
     val gitHub = GitHub(execOperations)
 
-    var baseSha = git.baseSha()
+    var baseSha: String? = null
     // GitHub workflows for pull_requests are invoked on a merge commit rather than branch commit.
     if (gitHub.isSupportedGitHubEvent()) {
       gitHub.baseSha()?.let { baseSha = it }
+    } else {
+      baseSha = git.baseSha()
     }
 
     return baseSha

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitCurrentBranchValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitCurrentBranchValueSource.kt
@@ -1,0 +1,19 @@
+package com.emergetools.android.gradle.util.providers
+
+import com.emergetools.android.gradle.util.Git
+import com.emergetools.android.gradle.util.GitHub
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters.None
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class GitCurrentBranchValueSource : ValueSource<String?, None> {
+
+  @get:Inject
+  abstract val execOperations: ExecOperations
+
+  override fun obtain(): String? {
+    val git = Git(execOperations)
+    return git.currentBranch()
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubPrNumberValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubPrNumberValueSource.kt
@@ -1,0 +1,18 @@
+package com.emergetools.android.gradle.util.providers
+
+import com.emergetools.android.gradle.util.GitHub
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters.None
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class GitHubPrNumberValueSource : ValueSource<String?, None> {
+
+  @get:Inject
+  abstract val execOperations: ExecOperations
+
+  override fun obtain(): String? {
+    val gitHub = GitHub(execOperations)
+    return gitHub.prNumber().toString()
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoNameValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoNameValueSource.kt
@@ -1,0 +1,18 @@
+package com.emergetools.android.gradle.util.providers
+
+import com.emergetools.android.gradle.util.GitHub
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters.None
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class GitHubRepoNameValueSource : ValueSource<String?, None> {
+
+  @get:Inject
+  abstract val execOperations: ExecOperations
+
+  override fun obtain(): String? {
+    val gitHub = GitHub(execOperations)
+    return gitHub.repoName()
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoOwnerValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoOwnerValueSource.kt
@@ -1,0 +1,18 @@
+package com.emergetools.android.gradle.util.providers
+
+import com.emergetools.android.gradle.util.GitHub
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters.None
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class GitHubRepoOwnerValueSource : ValueSource<String?, None> {
+
+  @get:Inject
+  abstract val execOperations: ExecOperations
+
+  override fun obtain(): String? {
+    val gitHub = GitHub(execOperations)
+    return gitHub.repoOwner()
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitShaValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitShaValueSource.kt
@@ -1,0 +1,27 @@
+package com.emergetools.android.gradle.util.providers
+
+import com.emergetools.android.gradle.util.Git
+import com.emergetools.android.gradle.util.GitHub
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters.None
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class GitShaValueSource : ValueSource<String?, None> {
+
+  @get:Inject
+  abstract val execOperations: ExecOperations
+
+  override fun obtain(): String? {
+    val git = Git(execOperations)
+    val gitHub = GitHub(execOperations)
+
+    var sha = git.currentSha()
+    // GitHub workflows for pull_requests are invoked on a merge commit rather than branch commit.
+    if (gitHub.isSupportedGitHubEvent()) {
+      gitHub.sha()?.let { sha = it }
+    }
+
+    return sha
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitShaValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitShaValueSource.kt
@@ -16,10 +16,12 @@ abstract class GitShaValueSource : ValueSource<String?, None> {
     val git = Git(execOperations)
     val gitHub = GitHub(execOperations)
 
-    var sha = git.currentSha()
+    var sha: String? = null
     // GitHub workflows for pull_requests are invoked on a merge commit rather than branch commit.
     if (gitHub.isSupportedGitHubEvent()) {
       gitHub.sha()?.let { sha = it }
+    } else {
+      sha = git.currentSha()
     }
 
     return sha


### PR DESCRIPTION
Fixes remaining configuration cache violations from the gradle plugin. All stemmed from running external processes from the inputs: https://docs.gradle.org/8.2/userguide/configuration_cache.html#config_cache:requirements:external_processes

Followed best practice using `ValueSource` implementations to provide the proper git info for each.