### PR TITLE
Skip internal functions for time being

### DIFF
--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -9,6 +9,7 @@ import com.emergetools.snapshots.processor.preview.ComposePreviewUtils.getUnique
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.isAnnotationPresent
+import com.google.devtools.ksp.isInternal
 import com.google.devtools.ksp.isPrivate
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
@@ -58,6 +59,11 @@ class PreviewProcessor(
 
       if (previewFunction.isPrivate()) {
         logger.info("Skipping ${previewFunction.simpleName.asString()} as it is private")
+        return@flatMap emptyList()
+      }
+
+      if (previewFunction.isInternal()) {
+        logger.info("Skipping ${previewFunction.simpleName.asString()} as it is internal")
         return@flatMap emptyList()
       }
 


### PR DESCRIPTION
Seems compilation will fail for some setups if internals are referenced from generated snapshots. This temporarily skips them, with plans for supporting private and internal functions in the future.

Resolves ET-2408