### PR TITLE
Multipreview support

### DIFF
--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/FontScalePreviews.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/FontScalePreviews.kt
@@ -1,0 +1,13 @@
+package com.emergetools.snapshots.sample.ui
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+  name = "Small font",
+  fontScale = 0.5f,
+)
+@Preview(
+  name = "Large font",
+  fontScale = 1.5f,
+)
+annotation class FontScalePreviews

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -24,11 +24,18 @@ fun TextRowWithIcon(
 }
 
 @Preview
-@Preview(
-  fontScale = 1.5f
-)
+@FontScalePreviews
 @Composable
 fun TextRowWithIconPreviewFromMain() {
+  TextRowWithIcon(
+    titleText = "Title",
+    subtitleText = "Subtitle"
+  )
+}
+
+@FontScalePreviews
+@Composable
+fun TextRowWithIconPreviewFromMainJustMultiPreview() {
   TextRowWithIcon(
     titleText = "Title",
     subtitleText = "Subtitle"

--- a/snapshots/snapshots-processor-test/src/test/kotlin/com/emergetools/snapshots/processor/PreviewProcessorTest.kt
+++ b/snapshots/snapshots-processor-test/src/test/kotlin/com/emergetools/snapshots/processor/PreviewProcessorTest.kt
@@ -44,6 +44,11 @@ class PreviewProcessorTest {
     compileInputsAndVerifyOutputs()
   }
 
+  @Test
+  fun `multipreview function with two previews and additional preview produces three snapshots`() {
+    compileInputsAndVerifyOutputs()
+  }
+
   private fun compileInputs(
     options: MutableMap<String, String> = mutableMapOf(),
     onCompilation: (compilation: KotlinCompilation, result: KotlinCompilation.Result) -> Unit,

--- a/snapshots/snapshots-processor-test/src/test/kotlin/com/emergetools/snapshots/processor/PreviewProcessorTest.kt
+++ b/snapshots/snapshots-processor-test/src/test/kotlin/com/emergetools/snapshots/processor/PreviewProcessorTest.kt
@@ -39,6 +39,11 @@ class PreviewProcessorTest {
     compileInputsAndVerifyOutputs()
   }
 
+  @Test
+  fun `multipreview function with two previews produces two snapshots`() {
+    compileInputsAndVerifyOutputs()
+  }
+
   private fun compileInputs(
     options: MutableMap<String, String> = mutableMapOf(),
     onCompilation: (compilation: KotlinCompilation, result: KotlinCompilation.Result) -> Unit,

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots/input/FontScalePreviews.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots/input/FontScalePreviews.kt
@@ -1,0 +1,13 @@
+package PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+  name = "Small font",
+  fontScale = 0.5f,
+)
+@Preview(
+  name = "Large font",
+  fontScale = 1.5f,
+)
+annotation class FontScalePreviews

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots/input/MultiPreviewComposable.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots/input/MultiPreviewComposable.kt
@@ -1,0 +1,11 @@
+package PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input
+
+import PreviewProcessorTest.multipreview_function_with_two_previews_produces_two_snapshots.input.FontScalePreviews
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
+
+@Preview
+@FontScalePreviews
+@Composable
+fun MultiPreviewComposable() {
+}

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots/output/MultiPreviewComposable_-1121164302_GenSnapshot.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots/output/MultiPreviewComposable_-1121164302_GenSnapshot.kt
@@ -1,0 +1,38 @@
+package PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input
+
+import PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input.MultiPreviewComposable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.emergetools.snapshots.EmergeSnapshots
+import com.emergetools.snapshots.compose.SnapshotVariantProvider
+import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+public class `MultiPreviewComposable_-1121164302_GenSnapshot` {
+  @get:Rule
+  public val composeRule: ComposeContentTestRule = createComposeRule()
+
+  public val previewConfig: ComposePreviewSnapshotConfig = ComposePreviewSnapshotConfig(originalFqn
+      =
+      "PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input.MultiPreviewComposable",
+      name = "Small font",
+      fontScale = 0.5f)
+
+  @get:Rule
+  public val snapshotRule: EmergeSnapshots = EmergeSnapshots()
+
+  @Test
+  public fun MultiPreviewComposable_GenSnapshot() {
+    composeRule.setContent {
+      SnapshotVariantProvider(previewConfig) {
+        MultiPreviewComposable()
+      }
+    }
+    snapshotRule.take(composeRule, previewConfig)
+  }
+}

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots/output/MultiPreviewComposable_1326053438_GenSnapshot.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots/output/MultiPreviewComposable_1326053438_GenSnapshot.kt
@@ -1,0 +1,38 @@
+package PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input
+
+import PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input.MultiPreviewComposable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.emergetools.snapshots.EmergeSnapshots
+import com.emergetools.snapshots.compose.SnapshotVariantProvider
+import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+public class MultiPreviewComposable_1326053438_GenSnapshot {
+  @get:Rule
+  public val composeRule: ComposeContentTestRule = createComposeRule()
+
+  public val previewConfig: ComposePreviewSnapshotConfig = ComposePreviewSnapshotConfig(originalFqn
+      =
+      "PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input.MultiPreviewComposable",
+      name = "Large font",
+      fontScale = 1.5f)
+
+  @get:Rule
+  public val snapshotRule: EmergeSnapshots = EmergeSnapshots()
+
+  @Test
+  public fun MultiPreviewComposable_GenSnapshot() {
+    composeRule.setContent {
+      SnapshotVariantProvider(previewConfig) {
+        MultiPreviewComposable()
+      }
+    }
+    snapshotRule.take(composeRule, previewConfig)
+  }
+}

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots/output/MultiPreviewComposable_GenSnapshot.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots/output/MultiPreviewComposable_GenSnapshot.kt
@@ -1,0 +1,36 @@
+package PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input
+
+import PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input.MultiPreviewComposable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.emergetools.snapshots.EmergeSnapshots
+import com.emergetools.snapshots.compose.SnapshotVariantProvider
+import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+public class MultiPreviewComposable_GenSnapshot {
+  @get:Rule
+  public val composeRule: ComposeContentTestRule = createComposeRule()
+
+  public val previewConfig: ComposePreviewSnapshotConfig = ComposePreviewSnapshotConfig(originalFqn
+      =
+      "PreviewProcessorTest.multipreview_function_with_two_previews_and_additional_preview_produces_three_snapshots.input.MultiPreviewComposable")
+
+  @get:Rule
+  public val snapshotRule: EmergeSnapshots = EmergeSnapshots()
+
+  @Test
+  public fun MultiPreviewComposable_GenSnapshot() {
+    composeRule.setContent {
+      SnapshotVariantProvider(previewConfig) {
+        MultiPreviewComposable()
+      }
+    }
+    snapshotRule.take(composeRule, previewConfig)
+  }
+}

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_produces_two_snapshots/input/FontScalePreviews.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_produces_two_snapshots/input/FontScalePreviews.kt
@@ -1,0 +1,13 @@
+package PreviewProcessorTest.multipreview_function_with_two_previews_produces_two_snapshots.input
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+  name = "Small font",
+  fontScale = 0.5f,
+)
+@Preview(
+  name = "Large font",
+  fontScale = 1.5f,
+)
+annotation class FontScalePreviews

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_produces_two_snapshots/input/MultiPreviewComposable.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_produces_two_snapshots/input/MultiPreviewComposable.kt
@@ -1,0 +1,9 @@
+package com.emergetools.android.standalone_preview_function_compiles_ok
+
+import PreviewProcessorTest.multipreview_function_with_two_previews_produces_two_snapshots.input.FontScalePreviews
+import androidx.compose.runtime.Composable
+
+@FontScalePreviews
+@Composable
+fun MultiPreviewComposable() {
+}

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_produces_two_snapshots/output/MultiPreviewComposable_-849881519_GenSnapshot.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_produces_two_snapshots/output/MultiPreviewComposable_-849881519_GenSnapshot.kt
@@ -1,0 +1,37 @@
+package com.emergetools.android.standalone_preview_function_compiles_ok
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.emergetools.android.standalone_preview_function_compiles_ok.MultiPreviewComposable
+import com.emergetools.snapshots.EmergeSnapshots
+import com.emergetools.snapshots.compose.SnapshotVariantProvider
+import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+public class `MultiPreviewComposable_-849881519_GenSnapshot` {
+  @get:Rule
+  public val composeRule: ComposeContentTestRule = createComposeRule()
+
+  public val previewConfig: ComposePreviewSnapshotConfig = ComposePreviewSnapshotConfig(originalFqn
+      = "com.emergetools.android.standalone_preview_function_compiles_ok.MultiPreviewComposable",
+      name = "Small font",
+      fontScale = 0.5f)
+
+  @get:Rule
+  public val snapshotRule: EmergeSnapshots = EmergeSnapshots()
+
+  @Test
+  public fun MultiPreviewComposable_GenSnapshot() {
+    composeRule.setContent {
+      SnapshotVariantProvider(previewConfig) {
+        MultiPreviewComposable()
+      }
+    }
+    snapshotRule.take(composeRule, previewConfig)
+  }
+}

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_produces_two_snapshots/output/MultiPreviewComposable_1597336221_GenSnapshot.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_function_with_two_previews_produces_two_snapshots/output/MultiPreviewComposable_1597336221_GenSnapshot.kt
@@ -1,0 +1,37 @@
+package com.emergetools.android.standalone_preview_function_compiles_ok
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.emergetools.android.standalone_preview_function_compiles_ok.MultiPreviewComposable
+import com.emergetools.snapshots.EmergeSnapshots
+import com.emergetools.snapshots.compose.SnapshotVariantProvider
+import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+public class MultiPreviewComposable_1597336221_GenSnapshot {
+  @get:Rule
+  public val composeRule: ComposeContentTestRule = createComposeRule()
+
+  public val previewConfig: ComposePreviewSnapshotConfig = ComposePreviewSnapshotConfig(originalFqn
+      = "com.emergetools.android.standalone_preview_function_compiles_ok.MultiPreviewComposable",
+      name = "Large font",
+      fontScale = 1.5f)
+
+  @get:Rule
+  public val snapshotRule: EmergeSnapshots = EmergeSnapshots()
+
+  @Test
+  public fun MultiPreviewComposable_GenSnapshot() {
+    composeRule.setContent {
+      SnapshotVariantProvider(previewConfig) {
+        MultiPreviewComposable()
+      }
+    }
+    snapshotRule.take(composeRule, previewConfig)
+  }
+}

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -5,6 +5,7 @@ import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuil
 import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuilder.addComposeRuleProperty
 import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuilder.addEmergeSnapshotRuleProperty
 import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuilder.addPreviewConfigProperty
+import com.emergetools.snapshots.processor.utils.COMPOSE_PREVIEW_ANNOTATION_NAME
 import com.emergetools.snapshots.processor.utils.functionsWithMultiPreviewAnnotation
 import com.emergetools.snapshots.processor.utils.functionsWithPreviewAnnotation
 import com.emergetools.snapshots.processor.utils.putOrAppend
@@ -211,9 +212,6 @@ class PreviewProcessor(
 
   companion object {
     private const val OUTPUT_SRC_DIR_OPTION_NAME = "emerge.outputDir"
-
-    private const val COMPOSE_PREVIEW_ANNOTATION_NAME =
-      "androidx.compose.ui.tooling.preview.Preview"
 
     private val ANDROID_JUNIT_RUNNER_CLASSNAME =
       ClassName("androidx.test.ext.junit.runners", "AndroidJUnit4")

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposePreviewUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposePreviewUtils.kt
@@ -19,8 +19,6 @@ object ComposePreviewUtils {
    * A unique preview annotation is one that has a unique combination of name, group, locale,
    * fontScale and uiMode, the current supported arguments for Emerge snapshots of the @Preview
    * annotation.
-   *
-   * TODO: Also needs to find multipreviews
    */
   fun getUniqueSnapshotConfigsFromPreviewAnnotations(
     previewFunction: KSFunctionDeclaration,

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposePreviewUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/preview/ComposePreviewUtils.kt
@@ -19,6 +19,8 @@ object ComposePreviewUtils {
    * A unique preview annotation is one that has a unique combination of name, group, locale,
    * fontScale and uiMode, the current supported arguments for Emerge snapshots of the @Preview
    * annotation.
+   *
+   * TODO: Also needs to find multipreviews
    */
   fun getUniqueSnapshotConfigsFromPreviewAnnotations(
     previewFunction: KSFunctionDeclaration,
@@ -27,6 +29,16 @@ object ComposePreviewUtils {
   }.map { composePreviewShapshotConfigFromPreviewAnnotation(previewFunction, it) }
     .distinct()
     .toList()
+
+  fun getUniqueSnapshotConfigsFromMultiPreviewAnnotation(
+    annotations: List<KSAnnotation>,
+    previewFunction: KSFunctionDeclaration,
+  ): List<ComposePreviewSnapshotConfig> {
+    return annotations.map {
+      composePreviewShapshotConfigFromPreviewAnnotation(previewFunction, it)
+    }.distinct()
+      .toList()
+  }
 
   private fun composePreviewShapshotConfigFromPreviewAnnotation(
     previewFunction: KSFunctionDeclaration,

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/MapUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/MapUtils.kt
@@ -1,0 +1,16 @@
+package com.emergetools.snapshots.processor.utils
+
+// TODO: TEst
+fun <K, V> MutableMap<K, List<V>>.putOrAppend(
+  key: K,
+  values: List<V>,
+  appendOnlyDistinct: Boolean = true,
+) = get(key)?.let { value ->
+  val newList = value + values
+  put(key, if (appendOnlyDistinct) newList.distinct() else newList)
+} ?: put(key, values)
+
+// TODO: Test
+fun <K, V> MutableMap<K, List<V>>.putOrAppend(map: Map<K, List<V>>) {
+  map.forEach(::putOrAppend)
+}

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/MapUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/MapUtils.kt
@@ -1,6 +1,5 @@
 package com.emergetools.snapshots.processor.utils
 
-// TODO: TEst
 fun <K, V> MutableMap<K, List<V>>.putOrAppend(
   key: K,
   values: List<V>,
@@ -10,7 +9,6 @@ fun <K, V> MutableMap<K, List<V>>.putOrAppend(
   put(key, if (appendOnlyDistinct) newList.distinct() else newList)
 } ?: put(key, values)
 
-// TODO: Test
 fun <K, V> MutableMap<K, List<V>>.putOrAppend(map: Map<K, List<V>>) {
   map.forEach(::putOrAppend)
 }

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/PreviewFinderUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/PreviewFinderUtils.kt
@@ -35,7 +35,8 @@ fun List<KSAnnotated>.functionsWithMultiPreviewAnnotation(
         .filterIsInstance<KSFunctionDeclaration>()
         .map { function ->
           function to getUniqueSnapshotConfigsFromMultiPreviewAnnotation(
-            multiPreviewAnnotationPreviewAnnotations, function
+            annotations = multiPreviewAnnotationPreviewAnnotations,
+            previewFunction = function
           )
         }
     }

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/PreviewFinderUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/PreviewFinderUtils.kt
@@ -1,0 +1,45 @@
+package com.emergetools.snapshots.processor.utils
+
+import com.emergetools.snapshots.processor.preview.ComposePreviewUtils
+import com.emergetools.snapshots.processor.preview.ComposePreviewUtils.getUniqueSnapshotConfigsFromPreviewAnnotations
+import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.squareup.kotlinpoet.ksp.toTypeName
+
+// TODO: Tests
+fun List<KSAnnotated>.functionsWithPreviewAnnotation(): Map<KSFunctionDeclaration, List<ComposePreviewSnapshotConfig>> {
+  return filterIsInstance<KSFunctionDeclaration>()
+    .associateWith { getUniqueSnapshotConfigsFromPreviewAnnotations(it) }
+}
+
+// TODO: Test
+fun List<KSAnnotated>.functionsWithMultiPreviewAnnotation(
+  resolver: Resolver,
+): Map<KSFunctionDeclaration, List<ComposePreviewSnapshotConfig>> {
+  return filterIsInstance<KSClassDeclaration>()
+    .filter { it.classKind == ClassKind.ANNOTATION_CLASS }
+    .flatMap { annotation ->
+
+      val multiPreviewAnnotationPreviewAnnotations = annotation.annotations.filter {
+        it.shortName.asString() == "Preview" // TODO: Const
+      }.toList()
+
+      val fqn = annotation.asType(emptyList()).toTypeName()
+      resolver.getSymbolsWithAnnotation(fqn.toString())
+        // TODO: Nested multipreviews?
+        // We'd get KSClassDeclarations, then we'd need to process/add
+
+        .filterIsInstance<KSFunctionDeclaration>()
+        .toList()
+        .map { function ->
+          function to ComposePreviewUtils.getUniqueSnapshotConfigsFromMultiPreviewAnnotation(
+            multiPreviewAnnotationPreviewAnnotations, function
+          )
+        }
+    }
+    .toMap()
+}

--- a/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -12,6 +12,7 @@ data class ComposePreviewSnapshotConfig(
   val uiMode: Int? = null,
   val locale: String? = null,
   val fontScale: Float? = null,
+  // TODO: Multipreview metadata
 ) {
 
   /**

--- a/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -12,7 +12,6 @@ data class ComposePreviewSnapshotConfig(
   val uiMode: Int? = null,
   val locale: String? = null,
   val fontScale: Float? = null,
-  // TODO: Multipreview metadata
 ) {
 
   /**


### PR DESCRIPTION
Adds MultiPreview annotation support ([Android docs](https://developer.android.com/jetpack/compose/tooling/previews#preview-multipreview)). This currently only supports one-level of multipreview support, i.e. currently you can't "chain" multipreviews together. This acceptable for the time being per client requests.

Resolves ET-2318