### PR TITLE
Support async spans in local runner

### DIFF
--- a/performance/sample/app/src/main/kotlin/com/emergetools/performance/sample/MainActivity.kt
+++ b/performance/sample/app/src/main/kotlin/com/emergetools/performance/sample/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.emergetools.performance.sample
 
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.Trace
 import androidx.activity.ComponentActivity
@@ -11,6 +13,9 @@ class MainActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     Trace.beginSection("MainActivity.onCreate")
+    if (VERSION.SDK_INT >= VERSION_CODES.Q) {
+      Trace.beginAsyncSection("MainActivity.onCreateAsync", 1)
+    }
     super.onCreate(savedInstanceState)
 
     setContent {
@@ -23,5 +28,8 @@ class MainActivity : ComponentActivity() {
     }
 
     Trace.endSection()
+    if (VERSION.SDK_INT >= VERSION_CODES.Q) {
+      Trace.endAsyncSection("MainActivity.onCreateAsync", 1)
+    }
   }
 }

--- a/performance/sample/perfTesting/src/main/java/com/emergetools/performance/sample/test/ExamplePerformanceTest.kt
+++ b/performance/sample/perfTesting/src/main/java/com/emergetools/performance/sample/test/ExamplePerformanceTest.kt
@@ -31,7 +31,7 @@ class ExamplePerformanceTest {
    * app during the test. Each span will have a separate conclusion & flamegraph comparison
    * available in the Emerge UI.
    */
-  @EmergeTest(spans = ["MainActivity.onCreate"])
+  @EmergeTest(spans = ["MainActivity.onCreate", "MainActivity.onCreateAsync"])
   fun myDeeplinkStartupTest() {
     Relax(APP_PACKAGE_NAME) {
       launchWithLink("emg://emergetools.com/")


### PR DESCRIPTION
Adds support for async spans (`Trace.beginAsyncSection`/`Trace.endAsyncSection`) in local runner for debugging.

<img width="829" alt="Screen Shot 2023-09-13 at 11 47 50 AM" src="https://github.com/EmergeTools/emerge-android/assets/6821566/b947df8a-b7e2-41e3-8af9-13373572674a">

