### PR TITLE
Fix locale not working

### DIFF
--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -40,8 +40,8 @@ fun TextRowWithIconPreviewFromMain() {
 @Composable
 fun TextRowWithIconPreviewFromMainJustMultiPreview() {
   TextRowWithIcon(
-    titleText = "Title",
-    subtitleText = "Subtitle"
+    titleText = stringResource(com.emergetools.snapshots.sample.R.string.sample_title),
+    subtitleText = stringResource(com.emergetools.snapshots.sample.R.string.sample_subtitle)
   )
 }
 

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
@@ -19,11 +20,12 @@ fun SnapshotVariantProvider(
 
   val localConfiguration = Configuration(LocalConfiguration.current).apply {
     config.uiMode?.let { uiMode = it }
-    config.locale?.let { setLocale(Locale(it)) }
+    val locale = config.locale?.let { Locale(it) } ?: Locale.getDefault()
+    setLocale(locale)
   }
 
   val providedValues = arrayOf(
-    LocalConfiguration provides localConfiguration,
+    LocalContext provides LocalContext.current.createConfigurationContext(localConfiguration),
     config.fontScale?.let { LocalDensity provides fontScaleDensity }
   )
   CompositionLocalProvider(


### PR DESCRIPTION
Our compositionLocal we use for snapshots didn't update the context used within it, meaning other locales wouldn't get picked up properly though resources. This sets the local context using the configuration which results in proper locale setting:

![com emergetools snapshots sample ui TextRowWithIconPreviewFromMain_loc_de](https://github.com/EmergeTools/emerge-android/assets/6821566/ced64fbd-774b-4482-a835-bc6bbb2bb9d3)
![com emergetools snapshots sample ui TextRowWithIconPreviewFromMain_loc_en](https://github.com/EmergeTools/emerge-android/assets/6821566/0557ab21-2d4b-4102-a3e5-9e9723f777ec)
