### PR TITLE
Add recursive lookup for transitive preview annotations

### DIFF
--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/SnapshotTestingPreview.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/SnapshotTestingPreview.kt
@@ -1,0 +1,5 @@
+package com.emergetools.snapshots.sample.ui
+
+@LocalePreviews
+@FontScalePreviews
+annotation class SnapshotTestingPreview

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -25,8 +25,7 @@ fun TextRowWithIcon(
 }
 
 @Preview
-@FontScalePreviews
-@LocalePreviews
+@SnapshotTestingPreview
 @Composable
 fun TextRowWithIconPreviewFromMain() {
   TextRowWithIcon(
@@ -35,8 +34,7 @@ fun TextRowWithIconPreviewFromMain() {
   )
 }
 
-@FontScalePreviews
-@LocalePreviews
+@SnapshotTestingPreview
 @Composable
 fun TextRowWithIconPreviewFromMainJustMultiPreview() {
   TextRowWithIcon(

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -25,7 +25,8 @@ fun TextRowWithIcon(
 }
 
 @Preview
-@SnapshotTestingPreview
+@LocalePreviews
+@FontScalePreviews
 @Composable
 fun TextRowWithIconPreviewFromMain() {
   TextRowWithIcon(
@@ -34,12 +35,22 @@ fun TextRowWithIconPreviewFromMain() {
   )
 }
 
-@SnapshotTestingPreview
+@LocalePreviews
+@FontScalePreviews
 @Composable
-fun TextRowWithIconPreviewFromMainJustMultiPreview() {
+fun TextRowWithIconPreviewFromMainJustStackedMultiPreview() {
   TextRowWithIcon(
     titleText = stringResource(com.emergetools.snapshots.sample.R.string.sample_title),
     subtitleText = stringResource(com.emergetools.snapshots.sample.R.string.sample_subtitle)
+  )
+}
+
+@SnapshotTestingPreview
+@Composable
+fun TextRowWithIconPreviewFromMainJustSnapshotTestingPreview() {
+  TextRowWithIcon(
+    titleText = "Title SnapshotTestingPreview",
+    subtitleText = "Subtitle SnapshotTestingPreview"
   )
 }
 

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -50,7 +50,6 @@ class PreviewProcessor(
     val symbolsWithPreviewAnnotations = resolver
       .getSymbolsWithAnnotation(COMPOSE_PREVIEW_ANNOTATION_NAME)
       .toList()
-
     val symbolsWithMultiPreviewAnnotations = resolver.getSymbolsWithMultiPreviewAnnotations()
 
     val previewAnnotatedFunctions = symbolsWithPreviewAnnotations

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -51,14 +51,12 @@ class PreviewProcessor(
       .getSymbolsWithAnnotation(COMPOSE_PREVIEW_ANNOTATION_NAME)
       .toList()
 
-    val symbolsWithMultiPreviewAnnotations = resolver.getSymbolsWithMultiPreviewAnnotations(logger)
-    symbolsWithMultiPreviewAnnotations.forEach { logger.info("telkins found multipreview symbols ${it}")}
+    val symbolsWithMultiPreviewAnnotations = resolver.getSymbolsWithMultiPreviewAnnotations()
 
     val previewAnnotatedFunctions = symbolsWithPreviewAnnotations
       .functionsWithPreviewAnnotation()
     val multiPreviewAnnotatedFunctions = symbolsWithMultiPreviewAnnotations
-      .functionsWithMultiPreviewAnnotations(resolver, logger)
-    multiPreviewAnnotatedFunctions.forEach { logger.info("telkins found multipreview functions ${it}")}
+      .functionsWithMultiPreviewAnnotations(resolver)
 
     val previewFunctionMap = buildMap {
       putOrAppend(previewAnnotatedFunctions)

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -6,9 +6,9 @@ import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuil
 import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuilder.addEmergeSnapshotRuleProperty
 import com.emergetools.snapshots.processor.preview.ComposablePreviewSnapshotBuilder.addPreviewConfigProperty
 import com.emergetools.snapshots.processor.utils.COMPOSE_PREVIEW_ANNOTATION_NAME
-import com.emergetools.snapshots.processor.utils.functionsWithMultiPreviewAnnotation
+import com.emergetools.snapshots.processor.utils.functionsWithMultiPreviewAnnotations
 import com.emergetools.snapshots.processor.utils.functionsWithPreviewAnnotation
-import com.emergetools.snapshots.processor.utils.getMultiPreviewAnnotations
+import com.emergetools.snapshots.processor.utils.getSymbolsWithMultiPreviewAnnotations
 import com.emergetools.snapshots.processor.utils.putOrAppend
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import com.google.devtools.ksp.KspExperimental
@@ -50,13 +50,15 @@ class PreviewProcessor(
     val symbolsWithPreviewAnnotations = resolver
       .getSymbolsWithAnnotation(COMPOSE_PREVIEW_ANNOTATION_NAME)
       .toList()
-    val symbolsWithMultiPreviewAnnotations = resolver.getMultiPreviewAnnotations(logger)
-    symbolsWithMultiPreviewAnnotations.forEach { logger.info("telkins found multipreview annotation ${it.qualifiedName?.asString()}")}
+
+    val symbolsWithMultiPreviewAnnotations = resolver.getSymbolsWithMultiPreviewAnnotations(logger)
+    symbolsWithMultiPreviewAnnotations.forEach { logger.info("telkins found multipreview symbols ${it}")}
 
     val previewAnnotatedFunctions = symbolsWithPreviewAnnotations
       .functionsWithPreviewAnnotation()
     val multiPreviewAnnotatedFunctions = symbolsWithMultiPreviewAnnotations
-      .functionsWithMultiPreviewAnnotation(resolver)
+      .functionsWithMultiPreviewAnnotations(resolver, logger)
+    multiPreviewAnnotatedFunctions.forEach { logger.info("telkins found multipreview functions ${it}")}
 
     val previewFunctionMap = buildMap {
       putOrAppend(previewAnnotatedFunctions)

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -50,7 +50,8 @@ class PreviewProcessor(
     val symbolsWithPreviewAnnotations = resolver
       .getSymbolsWithAnnotation(COMPOSE_PREVIEW_ANNOTATION_NAME)
       .toList()
-    val symbolsWithMultiPreviewAnnotations = resolver.getMultiPreviewAnnotations()
+    val symbolsWithMultiPreviewAnnotations = resolver.getMultiPreviewAnnotations(logger)
+    symbolsWithMultiPreviewAnnotations.forEach { logger.info("telkins found multipreview annotation ${it.qualifiedName?.asString()}")}
 
     val previewAnnotatedFunctions = symbolsWithPreviewAnnotations
       .functionsWithPreviewAnnotation()

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/PreviewFinderUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/PreviewFinderUtils.kt
@@ -18,11 +18,15 @@ fun List<KSAnnotated>.functionsWithPreviewAnnotation(): Map<KSFunctionDeclaratio
 }
 
 fun List<KSAnnotated>.functionsWithMultiPreviewAnnotations(
-  resolver: Resolver
+  resolver: Resolver,
 ): Map<KSFunctionDeclaration, List<ComposePreviewSnapshotConfig>> {
   val uniqueSnapshotConfigs = filterIsInstance<KSFunctionDeclaration>()
     .map { function ->
-      val allPreviewAnnotations = function.annotations.flatMap { resolver.findAllDirectOrTransitivePreviewAnnotations(it) }.toList()
+      val allPreviewAnnotations = function.annotations.flatMap {
+        resolver.findAllDirectOrTransitivePreviewAnnotations(
+          it
+        )
+      }.toList()
       function to getUniqueSnapshotConfigsFromMultiPreviewAnnotation(
         annotations = allPreviewAnnotations,
         previewFunction = function,
@@ -54,19 +58,28 @@ fun Resolver.getMultiPreviewAnnotations(): List<KSAnnotation> {
     .toSet()
     .filter {
       val annotationQN = it.annotationType.resolve().declaration.qualifiedName
-      val annotationClassDecl = annotationQN?.let { qualifiedName -> getClassDeclarationByName(qualifiedName) }
-      annotationClassDecl?.let { classDecl -> hasDirectOrTransitivePreviewAnnotation(classDecl) } ?: false
+      val annotationClassDecl =
+        annotationQN?.let { qualifiedName -> getClassDeclarationByName(qualifiedName) }
+      annotationClassDecl?.let { classDecl -> hasDirectOrTransitivePreviewAnnotation(classDecl) }
+        ?: false
     }
     .toList()
     .sortedBy { it.shortName.asString() }
 }
 
-fun Resolver.hasDirectOrTransitivePreviewAnnotation(declaration: KSAnnotated, seenAnnotations: MutableSet<KSAnnotated> = mutableSetOf()): Boolean {
+fun Resolver.hasDirectOrTransitivePreviewAnnotation(
+  declaration: KSAnnotated,
+  seenAnnotations: MutableSet<KSAnnotated> = mutableSetOf(),
+): Boolean {
   if (declaration in seenAnnotations) {
     return false
   }
 
-  if (declaration.annotations.any { it.annotationType.resolve().declaration.qualifiedName?.asString() == COMPOSE_PREVIEW_ANNOTATION_NAME }) {
+  val hasPreviewAnnotation = declaration.annotations.any {
+    it.annotationType.resolve().declaration.qualifiedName?.asString() ==
+      COMPOSE_PREVIEW_ANNOTATION_NAME
+  }
+  if (hasPreviewAnnotation) {
     return true
   }
 
@@ -75,13 +88,23 @@ fun Resolver.hasDirectOrTransitivePreviewAnnotation(declaration: KSAnnotated, se
   return declaration.annotations.any { annotation ->
     val annotationQualifiedName = annotation.annotationType.resolve().declaration.qualifiedName
     val classDeclaration = annotationQualifiedName?.let { getClassDeclarationByName(it) }
-    classDeclaration?.let { hasDirectOrTransitivePreviewAnnotation(classDeclaration, seenAnnotations) } ?: false
+    classDeclaration?.let {
+      hasDirectOrTransitivePreviewAnnotation(classDeclaration, seenAnnotations)
+    } ?: false
   }
 }
 
-fun Resolver.findAllDirectOrTransitivePreviewAnnotations(annotation: KSAnnotation, seenAnnotations: MutableSet<KSClassDeclaration> = mutableSetOf()): List<KSAnnotation> {
-  val classDeclaration = annotation.annotationType.resolve().declaration.qualifiedName?.let { getClassDeclarationByName(it) }
-  val isPreviewAnnotation = classDeclaration?.qualifiedName?.asString() == COMPOSE_PREVIEW_ANNOTATION_NAME
+fun Resolver.findAllDirectOrTransitivePreviewAnnotations(
+  annotation: KSAnnotation,
+  seenAnnotations: MutableSet<KSClassDeclaration> = mutableSetOf(),
+): List<KSAnnotation> {
+  val classDeclaration = annotation.annotationType.resolve().declaration.qualifiedName?.let {
+    getClassDeclarationByName(
+      it
+    )
+  }
+  val isPreviewAnnotation =
+    classDeclaration?.qualifiedName?.asString() == COMPOSE_PREVIEW_ANNOTATION_NAME
 
   // Annotations can recursively reference each other so be sure to have a base recursion case
   // @Preview itself can't have a recursive relation so we can exclude them from our check
@@ -91,11 +114,12 @@ fun Resolver.findAllDirectOrTransitivePreviewAnnotations(annotation: KSAnnotatio
 
   seenAnnotations.add(classDeclaration)
 
-  val currentPreviewAnnotations = if (classDeclaration.qualifiedName?.asString() == COMPOSE_PREVIEW_ANNOTATION_NAME) {
-    listOf(annotation)
-  } else {
-    emptyList()
-  }
+  val currentPreviewAnnotations =
+    if (classDeclaration.qualifiedName?.asString() == COMPOSE_PREVIEW_ANNOTATION_NAME) {
+      listOf(annotation)
+    } else {
+      emptyList()
+    }
 
   val nestedPreviewAnnotations = classDeclaration.annotations.flatMap {
     findAllDirectOrTransitivePreviewAnnotations(it, seenAnnotations)

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/PreviewFinderUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/PreviewFinderUtils.kt
@@ -5,11 +5,10 @@ import com.emergetools.snapshots.processor.preview.ComposePreviewUtils.getUnique
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.squareup.kotlinpoet.ksp.toTypeName
 
 const val COMPOSE_PREVIEW_ANNOTATION_NAME =
   "androidx.compose.ui.tooling.preview.Preview"
@@ -19,26 +18,15 @@ fun List<KSAnnotated>.functionsWithPreviewAnnotation(): Map<KSFunctionDeclaratio
     .associateWith { getUniqueSnapshotConfigsFromPreviewAnnotations(it) }
 }
 
-fun List<KSAnnotated>.functionsWithMultiPreviewAnnotation(
-  resolver: Resolver,
-): Map<KSFunctionDeclaration, List<ComposePreviewSnapshotConfig>> {
-  val uniqueSnapshotConfigs = filterIsInstance<KSClassDeclaration>()
-    .filter { it.classKind == ClassKind.ANNOTATION_CLASS }
-    .flatMap { annotation ->
-      val multiPreviewAnnotationPreviewAnnotations = annotation.annotations.filter {
-        it.annotationType.resolve().declaration.qualifiedName?.asString() == COMPOSE_PREVIEW_ANNOTATION_NAME
-      }.toList()
-
-      val fqn = annotation.asType(emptyList()).toTypeName()
-      resolver
-        .getSymbolsWithAnnotation(fqn.toString())
-        .filterIsInstance<KSFunctionDeclaration>()
-        .map { function ->
-          function to getUniqueSnapshotConfigsFromMultiPreviewAnnotation(
-            annotations = multiPreviewAnnotationPreviewAnnotations,
-            previewFunction = function,
-          )
-        }
+fun List<KSAnnotated>.functionsWithMultiPreviewAnnotations(resolver: Resolver, logger: KSPLogger): Map<KSFunctionDeclaration, List<ComposePreviewSnapshotConfig>> {
+  val uniqueSnapshotConfigs = filterIsInstance<KSFunctionDeclaration>()
+    .map { function ->
+      val allPreviewAnnotations = function.annotations.flatMap { resolver.findPreviewAnnotations(it) }.toList()
+      logger.info("telkins function annotations ${allPreviewAnnotations}")
+      function to getUniqueSnapshotConfigsFromMultiPreviewAnnotation(
+        annotations = allPreviewAnnotations,
+        previewFunction = function,
+      )
     }
 
   // The same function declaration can show up multiple times, so ensure the values are merged together
@@ -50,47 +38,79 @@ fun List<KSAnnotated>.functionsWithMultiPreviewAnnotation(
   return mergedConfigs
 }
 
-fun Resolver.getMultiPreviewAnnotations(logger: KSPLogger): List<KSClassDeclaration> {
-  // Find all symbols with annotations and map to the annotation class declarations
-  val annotationClassDecls = getAllFiles()
-    .flatMap { it.declarations }
-    .filter { it.annotations.count() > 0 }
-    .flatMap { symbol ->
-      symbol.annotations.mapNotNull { annotation ->
-        val annotationQN = annotation.annotationType.resolve().declaration.qualifiedName
-        annotationQN?.let { qualifiedName ->
-          getClassDeclarationByName(qualifiedName)
-        }
-      }
+fun Resolver.getSymbolsWithMultiPreviewAnnotations(logger: KSPLogger): List<KSAnnotated> {
+  return getMultiPreviewAnnotations(logger)
+    .mapNotNull { annotation ->
+      val annotationQN = annotation.annotationType.resolve().declaration.qualifiedName
+      logger.info("telkins found multipreview annotation ${annotationQN?.asString()} ")
+      annotationQN?.let { getSymbolsWithAnnotation(it.asString()) }
     }
-    .filter { it.classKind == ClassKind.ANNOTATION_CLASS }
-    .toSet()
-
-  // Of the annotation classes we found, take those that themselves have a preview annotation.
-  // We can assume these are multi-preview annotations.
-  return annotationClassDecls
-    .filter { hasDirectOrTransitivePreviewAnnotation(logger, it) }
-    .toList()
-    .sortedBy { it.simpleName.asString() }
+    .flatMap { it }
 }
 
-fun Resolver.hasDirectOrTransitivePreviewAnnotation(logger: KSPLogger, declaration: KSClassDeclaration, seenAnnotations: MutableSet<KSClassDeclaration> = mutableSetOf()): Boolean {
+fun Resolver.getMultiPreviewAnnotations(logger: KSPLogger): List<KSAnnotation> {
+  return getAllFiles()
+    .flatMap { it.declarations }
+    .flatMap { it.annotations }
+    .toSet()
+    .filter {
+      val annotationQN = it.annotationType.resolve().declaration.qualifiedName
+      val annotationClassDecl = annotationQN?.let { qualifiedName -> getClassDeclarationByName(qualifiedName) }
+      annotationClassDecl?.let { classDecl -> hasDirectOrTransitivePreviewAnnotation(logger, classDecl) } ?: false
+    }
+    .toList()
+    .sortedBy { it.shortName.asString() }
+}
+
+fun Resolver.hasDirectOrTransitivePreviewAnnotation(logger: KSPLogger, declaration: KSAnnotated, seenAnnotations: MutableSet<KSAnnotated> = mutableSetOf()): Boolean {
   if (declaration in seenAnnotations) {
-    logger.info("telkins found declaration ${declaration.qualifiedName?.asString()} in seen")
     return false
   }
 
   if (declaration.annotations.any { it.annotationType.resolve().declaration.qualifiedName?.asString() == COMPOSE_PREVIEW_ANNOTATION_NAME }) {
-    logger.info("telkins declaration ${declaration.qualifiedName?.asString()} has @Preview annotation!")
     return true
   }
 
   seenAnnotations.add(declaration)
 
-  logger.info("telkins recursing for ${declaration.qualifiedName?.asString()}")
   return declaration.annotations.any { annotation ->
     val annotationQualifiedName = annotation.annotationType.resolve().declaration.qualifiedName
     val classDeclaration = annotationQualifiedName?.let { getClassDeclarationByName(it) }
     classDeclaration?.let { hasDirectOrTransitivePreviewAnnotation(logger, classDeclaration, seenAnnotations) } ?: false
   }
+}
+
+fun Resolver.findPreviewAnnotations2(annotation: KSAnnotation, seenAnnotations: MutableSet<KSClassDeclaration> = mutableSetOf()): List<KSAnnotation> {
+  val classDeclaration = annotation.annotationType.resolve().declaration.qualifiedName?.let { getClassDeclarationByName(it) }
+  if (classDeclaration == null) {
+    return emptyList()
+  }
+
+  val hasDirectAnnotation = annotation
+  return emptyList()
+}
+
+fun Resolver.findPreviewAnnotations(annotation: KSAnnotation, seenAnnotations: MutableSet<KSClassDeclaration> = mutableSetOf()): List<KSAnnotation> {
+  val classDeclaration = annotation.annotationType.resolve().declaration.qualifiedName?.let { getClassDeclarationByName(it) }
+
+  if (classDeclaration == null || classDeclaration in seenAnnotations) {
+    return emptyList()
+  }
+
+  seenAnnotations.add(classDeclaration) // mark the current declaration as seen
+
+  // Check if the current annotation declaration has a @Preview annotation
+  val hasPreview = classDeclaration.annotations.any {
+    it.annotationType.resolve().declaration.qualifiedName?.asString() == COMPOSE_PREVIEW_ANNOTATION_NAME
+  }
+  if (hasPreview) {
+    return listOf(annotation) // return the parent annotation
+  }
+
+  // Recursively check annotations of the current annotation
+  val nestedAnnotationsWithPreview = classDeclaration.annotations.flatMap {
+    findPreviewAnnotations(it, seenAnnotations)
+  }
+
+  return nestedAnnotationsWithPreview.toList()
 }

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/PreviewFinderUtils.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/utils/PreviewFinderUtils.kt
@@ -80,7 +80,7 @@ fun Resolver.hasDirectOrTransitivePreviewAnnotation(declaration: KSAnnotated, se
 
 fun Resolver.findPreviewAnnotations(annotation: KSAnnotation, seenAnnotations: MutableSet<KSClassDeclaration> = mutableSetOf()): List<KSAnnotation> {
   val classDeclaration = annotation.annotationType.resolve().declaration.qualifiedName?.let { getClassDeclarationByName(it) }
-  val isPreviewAnnotation = classDeclaration.qualifiedName?.asString() == COMPOSE_PREVIEW_ANNOTATION_NAME
+  val isPreviewAnnotation = classDeclaration?.qualifiedName?.asString() == COMPOSE_PREVIEW_ANNOTATION_NAME
 
   // Annotations can recursively reference each other so be sure to have a base recursion case
   // @Preview itself can't have a recursive relation so we can exclude them from our check


### PR DESCRIPTION
Second part of correctly resolving multi-previews, now we can resolve arbitrary levels of multi-preview annotations.

1. Finds all symbols that have a direct or transitive `@Preview` annotation by recursively checking annotation classes. Transitive `@Preview` annotations would be those from a multi-preview.
2. Once we know the symbols annotated with a preview annotation, a second step filters that down to only functions.
3. After we have the functions, we have to then fetch all direct or transitive preview annotations on the function and build up a list of unique snapshot configs. This bit was tricky and does repeat some of the step 1 work from earlier, but not too concerned about the perf impact here.
4. Snapshot generation then proceeds like normal.

**Testing:**
I created a new `@SnapshotTestingPreview` and updated some existing previews to use this new annotation. The snapshot output is still the same:
<img width="694" alt="Screenshot 2023-09-28 at 11 01 51 AM" src="https://github.com/EmergeTools/emerge-android/assets/1447798/d7b4af6b-8666-4c3c-85f9-68aae7798360">
