### PR TITLE
Move local performance task to be registered on app module, add some debug logging

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -58,6 +58,9 @@ class EmergePlugin : Plugin<Project> {
       val rootProject = appProject.rootProject
       val perfProjectPath = emergeExtension.perfOptions.projectPath
       val performanceProject = rootProject.subprojects.find { subProject ->
+        appProject.logger.debug(
+          "Checking subproject ${subProject.path} from rootProject ${rootProject.path}, resolving perfProjectPath: ${perfProjectPath.orNull}"
+        )
         rootProject.absoluteProjectPath(subProject.path) == perfProjectPath.orNull
       }
       performanceProject?.let { perfProject ->
@@ -233,7 +236,7 @@ class EmergePlugin : Plugin<Project> {
     val perfVariantName = performanceVariant.name.capitalize()
 
     val taskName = "emergeLocal${perfVariantName}Test"
-    val task = performanceProject.tasks.register(taskName, LocalPerfTest::class.java) {
+    val task = appProject.tasks.register(taskName, LocalPerfTest::class.java) {
       it.group = EMERGE_TASK_GROUP
       it.description = "Installs and runs tests for ${performanceVariant.name} on" +
         " connected devices. For testing and debugging."


### PR DESCRIPTION
Moves the `emergeLocal<variant>Test` task onto the app module. Also adds some debug logging to help debug situations where we can't find the perf module.

Resolves ET-2482