### PR TITLE
Make internal snapshots generation based on experimental snapshot property

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -384,6 +384,7 @@ class EmergePlugin : Plugin<Project> {
   private fun applyMainSourceSetConfig(
     project: Project,
     appProject: Project,
+    extension: EmergePluginExtension,
   ) {
     val errorMessages = mutableListOf<String>()
     if (!project.plugins.hasPlugin(KSP_PLUGIN_ID)) {
@@ -411,11 +412,16 @@ class EmergePlugin : Plugin<Project> {
     // TODO: Ryan: Explore using variants API for finding proper ourput dir.
     val emergeSrcDir = "${project.buildDir}/$BUILD_OUTPUT_DIR_NAME/ksp/debugAndroidTest/kotlin"
 
+    val internalSnapshotsEnabled =
+      extension.snapshotOptions.experimentalInternalSnapshotsEnabled.getOrElse(false)
+    val internalEnabledArg = if (internalSnapshotsEnabled) "true" else "false"
+
     appProject.logger.info(
       "Configuring ${project.name} for Emerge snapshot testing, outputting to $emergeSrcDir"
     )
     project.extensions.getByType(KspExtension::class.java).apply {
       arg(OUTPUT_SRC_DIR_OPTION_NAME, emergeSrcDir)
+      arg(INTERNAL_ENABLED_OPTION_NAME, internalEnabledArg)
     }
 
     appProject.extensions.getByType(KotlinAndroidProjectExtension::class.java).apply {
@@ -535,6 +541,7 @@ class EmergePlugin : Plugin<Project> {
     const val EMERGE_JUNIT_RUNNER = "com.emergetools.test.EmergeJUnitRunner"
 
     private const val OUTPUT_SRC_DIR_OPTION_NAME = "emerge.outputDir"
+    private const val INTERNAL_ENABLED_OPTION_NAME = "emerge.experimentalInternalEnabled"
 
     private const val GENERATE_PERF_PROJECT_TASK_NAME = "emergeGeneratePerformanceProject"
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -90,7 +90,10 @@ class EmergePlugin : Plugin<Project> {
     emergeExtension: EmergePluginExtension,
   ) {
     appProject.afterEvaluate {
-      configureAppProjectSnapshots(appProject)
+      configureAppProjectSnapshots(
+        appProject = appProject,
+        emergeExtension = emergeExtension
+      )
     }
 
     appProject.pluginManager.withPlugin(ANDROID_APPLICATION_PLUGIN_ID) { _ ->
@@ -365,8 +368,15 @@ class EmergePlugin : Plugin<Project> {
     }
   }
 
-  private fun configureAppProjectSnapshots(appProject: Project) {
-    applyMainSourceSetConfig(appProject, appProject)
+  private fun configureAppProjectSnapshots(
+    appProject: Project,
+    emergeExtension: EmergePluginExtension,
+  ) {
+    applyMainSourceSetConfig(
+      project = appProject,
+      appProject = appProject,
+      emergeExtension = emergeExtension
+    )
 
     // Configure all dependent modules to apply the same configuration as the appProject so
     // generated snapshots don't run into compilation issues.
@@ -377,14 +387,20 @@ class EmergePlugin : Plugin<Project> {
       .distinct()
       .filter { !it.state.executed }
       .forEach { subproject ->
-        subproject.afterEvaluate { applyMainSourceSetConfig(it, appProject) }
+        subproject.afterEvaluate {
+          applyMainSourceSetConfig(
+            project = it,
+            appProject = appProject,
+            emergeExtension = emergeExtension
+          )
+        }
       }
   }
 
   private fun applyMainSourceSetConfig(
     project: Project,
     appProject: Project,
-    extension: EmergePluginExtension,
+    emergeExtension: EmergePluginExtension,
   ) {
     val errorMessages = mutableListOf<String>()
     if (!project.plugins.hasPlugin(KSP_PLUGIN_ID)) {
@@ -413,7 +429,7 @@ class EmergePlugin : Plugin<Project> {
     val emergeSrcDir = "${project.buildDir}/$BUILD_OUTPUT_DIR_NAME/ksp/debugAndroidTest/kotlin"
 
     val internalSnapshotsEnabled =
-      extension.snapshotOptions.experimentalInternalSnapshotsEnabled.getOrElse(false)
+      emergeExtension.snapshotOptions.experimentalInternalSnapshotsEnabled.getOrElse(false)
     val internalEnabledArg = if (internalSnapshotsEnabled) "true" else "false"
 
     appProject.logger.info(

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -135,4 +135,6 @@ abstract class PerfOptions : ProductOptions() {
 abstract class SnapshotOptions : ProductOptions() {
 
   abstract val snapshotsStorageDirectory: DirectoryProperty
+
+  abstract val experimentalInternalSnapshotsEnabled: Property<Boolean>
 }

--- a/snapshots/snapshots-processor-test/src/test/kotlin/com/emergetools/snapshots/processor/PreviewProcessorTest.kt
+++ b/snapshots/snapshots-processor-test/src/test/kotlin/com/emergetools/snapshots/processor/PreviewProcessorTest.kt
@@ -45,7 +45,11 @@ class PreviewProcessorTest {
   }
 
   @Test
-  fun `standalone preview function with internal preview produces one snapshot test`() {
+  fun `standalone preview function with internal preview produces no snapshot test without arg`() {
+    compileInputsAndVerifyOutputs()
+  }
+  @Test
+  fun `standalone preview function with internal preview produces one snapshot test with arg`() {
     compileInputsAndVerifyOutputs(
       mutableMapOf("emerge.experimentalInternalEnabled" to "true")
     )
@@ -57,7 +61,12 @@ class PreviewProcessorTest {
   }
 
   @Test
-  fun `multipreview internal function with two previews produces two snapshots`() {
+  fun `multipreview internal function with two previews produces no snapshots without arg`() {
+    compileInputsAndVerifyOutputs()
+  }
+
+  @Test
+  fun `multipreview internal function with two previews produces two snapshots with arg`() {
     compileInputsAndVerifyOutputs(
       mutableMapOf("emerge.experimentalInternalEnabled" to "true")
     )

--- a/snapshots/snapshots-processor-test/src/test/kotlin/com/emergetools/snapshots/processor/PreviewProcessorTest.kt
+++ b/snapshots/snapshots-processor-test/src/test/kotlin/com/emergetools/snapshots/processor/PreviewProcessorTest.kt
@@ -46,7 +46,9 @@ class PreviewProcessorTest {
 
   @Test
   fun `standalone preview function with internal preview produces one snapshot test`() {
-    compileInputsAndVerifyOutputs()
+    compileInputsAndVerifyOutputs(
+      mutableMapOf("emerge.experimentalInternalEnabled" to "true")
+    )
   }
 
   @Test
@@ -56,7 +58,9 @@ class PreviewProcessorTest {
 
   @Test
   fun `multipreview internal function with two previews produces two snapshots`() {
-    compileInputsAndVerifyOutputs()
+    compileInputsAndVerifyOutputs(
+      mutableMapOf("emerge.experimentalInternalEnabled" to "true")
+    )
   }
 
   @Test

--- a/snapshots/snapshots-processor-test/src/test/kotlin/com/emergetools/snapshots/processor/PreviewProcessorTest.kt
+++ b/snapshots/snapshots-processor-test/src/test/kotlin/com/emergetools/snapshots/processor/PreviewProcessorTest.kt
@@ -48,6 +48,7 @@ class PreviewProcessorTest {
   fun `standalone preview function with internal preview produces no snapshot test without arg`() {
     compileInputsAndVerifyOutputs()
   }
+
   @Test
   fun `standalone preview function with internal preview produces one snapshot test with arg`() {
     compileInputsAndVerifyOutputs(

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_no_snapshots_without_arg/input/FontScalePreviews.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_no_snapshots_without_arg/input/FontScalePreviews.kt
@@ -1,0 +1,13 @@
+package PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_no_snapshots_without_arg.input
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+  name = "Small font",
+  fontScale = 0.5f,
+)
+@Preview(
+  name = "Large font",
+  fontScale = 1.5f,
+)
+annotation class FontScalePreviews

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_no_snapshots_without_arg/input/MultiPreviewComposable.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_no_snapshots_without_arg/input/MultiPreviewComposable.kt
@@ -1,0 +1,8 @@
+package PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_no_snapshots_without_arg.input
+
+import androidx.compose.runtime.Composable
+
+@FontScalePreviews
+@Composable
+internal fun MultiPreviewComposable() {
+}

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_two_snapshots/input/MultiPreviewComposable.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_two_snapshots/input/MultiPreviewComposable.kt
@@ -1,9 +1,0 @@
-package com.emergetools.android.standalone_preview_function_compiles_ok
-
-import PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_two_snapshots.input.FontScalePreviews
-import androidx.compose.runtime.Composable
-
-@FontScalePreviews
-@Composable
-internal fun MultiPreviewComposable() {
-}

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg/input/FontScalePreviews.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg/input/FontScalePreviews.kt
@@ -1,4 +1,4 @@
-package PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_two_snapshots.input
+package PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg.input
 
 import androidx.compose.ui.tooling.preview.Preview
 

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg/input/MultiPreviewComposable.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg/input/MultiPreviewComposable.kt
@@ -1,0 +1,8 @@
+package PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg.input
+
+import androidx.compose.runtime.Composable
+
+@FontScalePreviews
+@Composable
+internal fun MultiPreviewComposable() {
+}

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg/output/MultiPreviewComposable_-1707151673_GenSnapshot.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg/output/MultiPreviewComposable_-1707151673_GenSnapshot.kt
@@ -1,10 +1,10 @@
-package com.emergetools.android.standalone_preview_function_compiles_ok
+package PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg.input
 
+import PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg.input.MultiPreviewComposable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.emergetools.android.standalone_preview_function_compiles_ok.MultiPreviewComposable
 import com.emergetools.snapshots.EmergeSnapshots
 import com.emergetools.snapshots.compose.SnapshotVariantProvider
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
@@ -13,14 +13,15 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-public class `MultiPreviewComposable_-849881519_GenSnapshot` {
+public class `MultiPreviewComposable_-1707151673_GenSnapshot` {
   @get:Rule
   public val composeRule: ComposeContentTestRule = createComposeRule()
 
   public val previewConfig: ComposePreviewSnapshotConfig = ComposePreviewSnapshotConfig(originalFqn
-      = "com.emergetools.android.standalone_preview_function_compiles_ok.MultiPreviewComposable",
-      name = "Small font",
-      fontScale = 0.5f)
+      =
+      "PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg.input.MultiPreviewComposable",
+      name = "Large font",
+      fontScale = 1.5f)
 
   @get:Rule
   public val snapshotRule: EmergeSnapshots = EmergeSnapshots()

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg/output/MultiPreviewComposable_140597883_GenSnapshot.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg/output/MultiPreviewComposable_140597883_GenSnapshot.kt
@@ -1,10 +1,10 @@
-package com.emergetools.android.standalone_preview_function_compiles_ok
+package PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg.input
 
+import PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg.input.MultiPreviewComposable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.emergetools.android.standalone_preview_function_compiles_ok.MultiPreviewComposable
 import com.emergetools.snapshots.EmergeSnapshots
 import com.emergetools.snapshots.compose.SnapshotVariantProvider
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
@@ -13,14 +13,15 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-public class MultiPreviewComposable_1597336221_GenSnapshot {
+public class MultiPreviewComposable_140597883_GenSnapshot {
   @get:Rule
   public val composeRule: ComposeContentTestRule = createComposeRule()
 
   public val previewConfig: ComposePreviewSnapshotConfig = ComposePreviewSnapshotConfig(originalFqn
-      = "com.emergetools.android.standalone_preview_function_compiles_ok.MultiPreviewComposable",
-      name = "Large font",
-      fontScale = 1.5f)
+      =
+      "PreviewProcessorTest.multipreview_internal_function_with_two_previews_produces_two_snapshots_with_arg.input.MultiPreviewComposable",
+      name = "Small font",
+      fontScale = 0.5f)
 
   @get:Rule
   public val snapshotRule: EmergeSnapshots = EmergeSnapshots()

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/standalone_preview_function_with_internal_preview_produces_no_snapshot_test_without_arg/input/TestComposable.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/standalone_preview_function_with_internal_preview_produces_no_snapshot_test_without_arg/input/TestComposable.kt
@@ -1,0 +1,9 @@
+package PreviewProcessorTest.standalone_preview_function_with_internal_preview_produces_no_snapshot_test_without_arg.input
+
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
+
+@Preview
+@Composable
+internal fun TestComposable() {
+}

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/standalone_preview_function_with_internal_preview_produces_one_snapshot_test_with_arg/input/TestComposable.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/standalone_preview_function_with_internal_preview_produces_one_snapshot_test_with_arg/input/TestComposable.kt
@@ -1,4 +1,4 @@
-package com.emergetools.android.standalone_preview_function_with_internal_preview_produces_one_snapshot_test
+package PreviewProcessorTest.standalone_preview_function_with_internal_preview_produces_one_snapshot_test_with_arg.input
 
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable

--- a/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/standalone_preview_function_with_internal_preview_produces_one_snapshot_test_with_arg/output/TestComposable_GenSnapshot.kt
+++ b/snapshots/snapshots-processor-test/src/test/resources/PreviewProcessorTest/standalone_preview_function_with_internal_preview_produces_one_snapshot_test_with_arg/output/TestComposable_GenSnapshot.kt
@@ -1,10 +1,10 @@
-package com.emergetools.android.standalone_preview_function_with_internal_preview_produces_one_snapshot_test
+package PreviewProcessorTest.standalone_preview_function_with_internal_preview_produces_one_snapshot_test_with_arg.input
 
+import PreviewProcessorTest.standalone_preview_function_with_internal_preview_produces_one_snapshot_test_with_arg.input.TestComposable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.emergetools.android.standalone_preview_function_with_internal_preview_produces_one_snapshot_test.TestComposable
 import com.emergetools.snapshots.EmergeSnapshots
 import com.emergetools.snapshots.compose.SnapshotVariantProvider
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
@@ -19,7 +19,7 @@ public class TestComposable_GenSnapshot {
 
   public val previewConfig: ComposePreviewSnapshotConfig = ComposePreviewSnapshotConfig(originalFqn
       =
-      "com.emergetools.android.standalone_preview_function_with_internal_preview_produces_one_snapshot_test.TestComposable")
+      "PreviewProcessorTest.standalone_preview_function_with_internal_preview_produces_one_snapshot_test_with_arg.input.TestComposable")
 
   @get:Rule
   public val snapshotRule: EmergeSnapshots = EmergeSnapshots()

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -78,7 +78,7 @@ class PreviewProcessor(
         return@flatMap emptyList()
       }
 
-      if (function.isInternal() && environment.options[INTERNAL_ENABLED_OPTION_NAME] != "true"){
+      if (function.isInternal() && environment.options[INTERNAL_ENABLED_OPTION_NAME] != "true") {
         logger.info("Skipping ${function.simpleName.asString()} as it is internal")
         return@flatMap emptyList()
       }

--- a/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
+++ b/snapshots/snapshots-processor/src/main/kotlin/com/emergetools/snapshots/processor/PreviewProcessor.kt
@@ -13,6 +13,7 @@ import com.emergetools.snapshots.processor.utils.putOrAppend
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.isAnnotationPresent
+import com.google.devtools.ksp.isInternal
 import com.google.devtools.ksp.isPrivate
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
@@ -74,6 +75,11 @@ class PreviewProcessor(
 
       if (function.isPrivate()) {
         logger.info("Skipping ${function.simpleName.asString()} as it is private")
+        return@flatMap emptyList()
+      }
+
+      if (function.isInternal() && environment.options[INTERNAL_ENABLED_OPTION_NAME] != "true"){
+        logger.info("Skipping ${function.simpleName.asString()} as it is internal")
         return@flatMap emptyList()
       }
 
@@ -208,6 +214,7 @@ class PreviewProcessor(
 
   companion object {
     private const val OUTPUT_SRC_DIR_OPTION_NAME = "emerge.outputDir"
+    private const val INTERNAL_ENABLED_OPTION_NAME = "emerge.experimentalInternalEnabled"
 
     private val ANDROID_JUNIT_RUNNER_CLASSNAME =
       ClassName("androidx.test.ext.junit.runners", "AndroidJUnit4")


### PR DESCRIPTION
Adds a new property on the `snapshots` block to enable internal previews as an experimental feature. For the most part, internal preview usage has been stable, but we've seen cases where it fails, so we want to make sure there's a failsafe mechanism in place so it won't unexpectedly break builds.