### PR TITLE
Add necessary dependencies as api dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ grgit = { id = "org.ajoberstar.grgit", version = "5.0.0" }
 [libraries]
 android-gradle-plugin = "com.android.tools.build:gradle:7.3.1"
 
-androidx-activity-activity = { module = "androidx.activity:activity", version.ref = "androidxactivity" }
+androidx-activity = { module = "androidx.activity:activity", version.ref = "androidxactivity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxactivity" }
 androidx-benchmark-common = { module = "androidx.benchmark:benchmark-common", version = "1.2.0-beta05" }
 androidx-benchmark-macro = { module = "androidx.benchmark:benchmark-macro", version = "1.2.0-beta05" }

--- a/performance/sample/app/build.gradle.kts
+++ b/performance/sample/app/build.gradle.kts
@@ -87,7 +87,7 @@ android {
 }
 
 dependencies {
-  implementation(libs.androidx.activity.activity)
+  implementation(libs.androidx.activity)
   implementation(libs.androidx.activity.compose)
 
   implementation(platform(libs.compose.bom))

--- a/snapshots/sample/app/build.gradle.kts
+++ b/snapshots/sample/app/build.gradle.kts
@@ -64,7 +64,7 @@ android {
 }
 
 dependencies {
-  implementation(libs.androidx.activity.activity)
+  implementation(libs.androidx.activity)
   implementation(libs.androidx.activity.compose)
 
   implementation(projects.snapshots.sample.uiModule)

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -45,7 +45,6 @@ android {
 dependencies {
 
   implementation(libs.junit)
-  implementation(libs.androidx.test.runner)
   implementation(libs.androidx.test.rules)
 
   implementation(platform(libs.compose.bom))
@@ -55,9 +54,11 @@ dependencies {
   implementation(libs.kotlinx.serialization)
 
   api(projects.snapshots.snapshotsShared)
+  api(libs.androidx.activity)
   api(libs.androidx.test.core)
   api(libs.androidx.test.core.ktx)
   api(libs.androidx.test.ext.junit)
+  api(libs.androidx.test.runner)
   api(libs.compose.ui.test.junit)
 
   testImplementation(libs.junit)


### PR DESCRIPTION
Was working to integrate with a potential customer today and we had to explicitly add these. Changing them to API dependencies to ensure consumers no longer need to explicitly add them themselves since we're reliant.