### PR TITLE
Add Kotlin language support for 1.7+

### DIFF
--- a/snapshots/snapshots-annotations/build.gradle.kts
+++ b/snapshots/snapshots-annotations/build.gradle.kts
@@ -27,6 +27,7 @@ java {
 tasks.withType<KotlinCompile> {
   kotlinOptions {
     jvmTarget = JavaVersion.VERSION_11.toString()
+    languageVersion = "1.7"
   }
 }
 

--- a/snapshots/snapshots-shared/build.gradle.kts
+++ b/snapshots/snapshots-shared/build.gradle.kts
@@ -28,6 +28,7 @@ java {
 tasks.withType<KotlinCompile> {
   kotlinOptions {
     jvmTarget = JavaVersion.VERSION_11.toString()
+    languageVersion = "1.7"
   }
 }
 

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -27,6 +27,7 @@ android {
 
   kotlinOptions {
     jvmTarget = JavaVersion.VERSION_11.toString()
+    languageVersion = "1.7"
   }
 
   defaultConfig {


### PR DESCRIPTION
Some clients have hit issues when using Kotlin 1.7 as we compile with Kotlin 1.9. This adds language support for 1.7+, which upon testing in a repro project, fixes issues running on apps with 1.7.

From the `languageVersion` docs:
```
/**
  * Provide source compatibility with the specified version of Kotlin
  * Possible values: "1.4 (deprecated)", "1.5 (deprecated)", "1.6", "1.7", "1.8", "1.9", "2.0 (experimental)", "2.1 (experimental)"
  * Default value: null
*/
```
