### PR TITLE
Disable mainClock autoAdvance to ensure animations are stable

### DIFF
--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/EmergeSnapshots.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/EmergeSnapshots.kt
@@ -49,6 +49,7 @@ class EmergeSnapshots : TestRule {
     composePreviewSnapshotConfig: ComposePreviewSnapshotConfig,
   ) {
     composeTestRule.waitForIdle()
+    composeTestRule.mainClock.autoAdvance = false
     SnapshotSaver.save(
       // DisplayName not used for composables
       displayName = null,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/EmergeSnapshots.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/EmergeSnapshots.kt
@@ -48,8 +48,8 @@ class EmergeSnapshots : TestRule {
     composeTestRule: ComposeTestRule,
     composePreviewSnapshotConfig: ComposePreviewSnapshotConfig,
   ) {
-    composeTestRule.waitForIdle()
     composeTestRule.mainClock.autoAdvance = false
+    composeTestRule.waitForIdle()
     SnapshotSaver.save(
       // DisplayName not used for composables
       displayName = null,


### PR DESCRIPTION
Per https://developer.android.com/jetpack/compose/animation/testing, it appears this should provide stability when animations are running to ensure the clock isn't advancing.