### PR TITLE
Add gitLab vcs config block to match docs

### DIFF
--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -107,7 +107,7 @@ emerge {
   vcs {
     // ..
 
-    gitLabOptions {
+    gitLab {
       projectId.set("..")
     }
   }
@@ -116,15 +116,15 @@ emerge {
 
 ##### Properties
 
-| Field                     | Type     | Default                | Description                                       |
-|---------------------------|----------|------------------------|---------------------------------------------------|
-| `sha`                     | `String` | HEAD branch commit sha | The Git sha of the HEAD build.                    |
-| `baseSha`                 | `String` | base branch commit sha | The Git sha of the base build to compare against. |
-| `branchName`              | `String` | Current branch name    | The name of the branch being built.               |
-| `prNumber`                | `String` |                        | The number of the pull request being built.       |
-| `gitHub.repoOwner`        | `String` | Repo ID before '/'     | The owner of the GitHub repository.               |
-| `gitHub.repoName`         | `String` | Repo ID after '/'      | The name of the GitHub repository.                |
-| `gitLabOptions.projectId` | `String` |                        | The ID of the GitLab repository.                  |
+| Field              | Type     | Default                | Description                                       |
+|--------------------|----------|------------------------|---------------------------------------------------|
+| `sha`              | `String` | HEAD branch commit sha | The Git sha of the HEAD build.                    |
+| `baseSha`          | `String` | base branch commit sha | The Git sha of the base build to compare against. |
+| `branchName`       | `String` | Current branch name    | The name of the branch being built.               |
+| `prNumber`         | `String` |                        | The number of the pull request being built.       |
+| `gitHub.repoOwner` | `String` | Repo ID before '/'     | The owner of the GitHub repository.               |
+| `gitHub.repoName`  | `String` | Repo ID after '/'      | The name of the GitHub repository.                |
+| `gitLab.projectId` | `String` |                        | The ID of the GitLab repository.                  |
 
 ## App size
 
@@ -254,7 +254,7 @@ emerge {
       repoName.set("..") // Required for CI status checks (only if using GitHub)
     }
 
-    gitLabOptions {
+    gitLab {
       projectId.set("..") // Required for CI status checks (only if using GitLab)
     }
   }
@@ -301,7 +301,7 @@ Breaking changes:
 
 - `vcsOptions` has become `vcs`.
 - `vcsOptions.gitHubOptions` has become `vcs.gitHub`.
-- `vcsOptions.gitLabOptions` has become `vcs.gitLabOptions`.
+- `vcsOptions.gitLabOptions` has become `vcs.gitLab`.
 
 #### Performance
 

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -107,7 +107,7 @@ emerge {
   vcs {
     // ..
 
-    gitLab {
+    gitLabOptions {
       projectId.set("..")
     }
   }
@@ -116,15 +116,15 @@ emerge {
 
 ##### Properties
 
-| Field              | Type     | Default                | Description                                       |
-|--------------------|----------|------------------------|---------------------------------------------------|
-| `sha`              | `String` | HEAD branch commit sha | The Git sha of the HEAD build.                    |
-| `baseSha`          | `String` | base branch commit sha | The Git sha of the base build to compare against. |
-| `branchName`       | `String` | Current branch name    | The name of the branch being built.               |
-| `prNumber`         | `String` |                        | The number of the pull request being built.       |
-| `gitHub.repoOwner` | `String` | Repo ID before '/'     | The owner of the GitHub repository.               |
-| `gitHub.repoName`  | `String` | Repo ID after '/'      | The name of the GitHub repository.                |
-| `gitLab.projectId` | `String` |                        | The ID of the GitLab repository.                  |
+| Field                     | Type     | Default                | Description                                       |
+|---------------------------|----------|------------------------|---------------------------------------------------|
+| `sha`                     | `String` | HEAD branch commit sha | The Git sha of the HEAD build.                    |
+| `baseSha`                 | `String` | base branch commit sha | The Git sha of the base build to compare against. |
+| `branchName`              | `String` | Current branch name    | The name of the branch being built.               |
+| `prNumber`                | `String` |                        | The number of the pull request being built.       |
+| `gitHub.repoOwner`        | `String` | Repo ID before '/'     | The owner of the GitHub repository.               |
+| `gitHub.repoName`         | `String` | Repo ID after '/'      | The name of the GitHub repository.                |
+| `gitLabOptions.projectId` | `String` |                        | The ID of the GitLab repository.                  |
 
 ## App size
 
@@ -254,7 +254,7 @@ emerge {
       repoName.set("..") // Required for CI status checks (only if using GitHub)
     }
 
-    gitLab {
+    gitLabOptions {
       projectId.set("..") // Required for CI status checks (only if using GitLab)
     }
   }
@@ -301,7 +301,7 @@ Breaking changes:
 
 - `vcsOptions` has become `vcs`.
 - `vcsOptions.gitHubOptions` has become `vcs.gitHub`.
-- `vcsOptions.gitLabOptions` has become `vcs.gitLab`.
+- `vcsOptions.gitLabOptions` has become `vcs.gitLabOptions`.
 
 #### Performance
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -91,7 +91,12 @@ abstract class VCSOptions @Inject constructor(
   @get:Nested
   abstract val gitLabOptions: GitLabOptions
 
+  // TODO: Remove in future major version release
   fun gitLabOptions(action: Action<GitLabOptions>) {
+    action.execute(gitLabOptions)
+  }
+  
+  fun gitLab(action: Action<GitLabOptions>) {
     action.execute(gitLabOptions)
   }
 }


### PR DESCRIPTION
A client pointed out that `gitLabOptions` is the only available gitLab configuration in vcs options, which our docs incorrectly use `gitLab`. To match longer term conventions, this introduces the expected `gitLab` configuration block and keeps `gitLabOptions` around to prevent breaking existing integrations. I'll remove `gitLabOptions` in a future major release as it'll be a breaking change.