### PR TITLE
Show stack trace for errors in performance tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ junit-jupiter = "5.8.2"
 
 # internal
 emerge-gradle-plugin = "2.2.2"
-emerge-peformance = "2.1.1"
+emerge-peformance = "2.1.2"
 emerge-snapshots = "0.8.5"
 
 [plugins]

--- a/performance/CHANGELOG.md
+++ b/performance/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.2 - 2024-05-07
+
+### Fixed
+
+- Show stack trace when local performance tests throw errors. [#134](https://github.com/EmergeTools/emerge-android/pull/134).
+
+
 ## 2.1.1 - 2023-09-13
 
 ### Fixed

--- a/performance/performance/src/main/java/com/emergetools/test/EmergeLocalJUnit4ClassRunner.kt
+++ b/performance/performance/src/main/java/com/emergetools/test/EmergeLocalJUnit4ClassRunner.kt
@@ -170,7 +170,7 @@ class EmergeLocalJUnit4ClassRunner(testClass: Class<*>) : AndroidJUnit4ClassRunn
           }
         } catch (e: Throwable) {
           summary.result = MethodResult.FAILURE
-          summary.messages.add("Failed with an exception: $e")
+          summary.messages.add("Failed with an exception: ${e.stackTraceToString()}")
           throw e
         }
       }
@@ -204,7 +204,7 @@ class EmergeLocalJUnit4ClassRunner(testClass: Class<*>) : AndroidJUnit4ClassRunn
           }
         } catch (e: Throwable) {
           summary.result = MethodResult.FAILURE
-          summary.messages.add("Failed with an exception: $e")
+          summary.messages.add("Failed with an exception: ${e.stackTraceToString()}")
           throw e
         }
       }
@@ -312,7 +312,7 @@ class EmergeLocalJUnit4ClassRunner(testClass: Class<*>) : AndroidJUnit4ClassRunn
           }
         } catch (e: Throwable) {
           annotationSummary.result = MethodResult.FAILURE
-          annotationSummary.messages.add("Failed with an exception: $e")
+          annotationSummary.messages.add("Failed with an exception: ${e.stackTraceToString()}")
         }
       }
     }


### PR DESCRIPTION
After this change errors looks like this:
<img width="1102" alt="Screenshot 2024-05-07 at 15 19 58" src="https://github.com/EmergeTools/emerge-android/assets/351085/d37d0a30-8ca9-4f9e-882e-2bcd7b01a496">
