### PR TITLE
Create SnapshotsPreviewRuntimeRetentionTransform to change Previews to runtime retention

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -53,6 +53,13 @@ abstract class EmergePluginExtension @Inject constructor(objects: ObjectFactory)
     action.execute(vcsOptions)
   }
 
+  @get:Nested
+  abstract val debugOptions: DebugOptions
+
+  fun debug(action: Action<DebugOptions>) {
+    action.execute(debugOptions)
+  }
+
   /**
    * Optional inputs.
    */
@@ -140,5 +147,11 @@ abstract class SnapshotOptions : ProductOptions() {
 
   abstract val experimentalInternalSnapshotsEnabled: Property<Boolean>
 
+  abstract val experimentalTransformEnabled: Property<Boolean>
+
   abstract val apiVersion: Property<Int>
+}
+
+abstract class DebugOptions : ProductOptions() {
+  abstract val forceInstrumentation: Property<Boolean>
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/instrumentation/snapshots/SnapshotsPreviewRuntimeRetentionTransform.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/instrumentation/snapshots/SnapshotsPreviewRuntimeRetentionTransform.kt
@@ -1,0 +1,102 @@
+package com.emergetools.android.gradle.instrumentation.snapshots
+
+import com.android.build.api.instrumentation.AsmClassVisitorFactory
+import com.android.build.api.instrumentation.ClassContext
+import com.android.build.api.instrumentation.ClassData
+import com.android.build.api.instrumentation.InstrumentationParameters
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.objectweb.asm.AnnotationVisitor
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+abstract class SnapshotsPreviewRuntimeRetentionTransformFactory : AsmClassVisitorFactory<SnapshotsPreviewRuntimeRetentionTransformFactory.Params> {
+
+  interface Params : InstrumentationParameters {
+    @get:Input
+    val invalidate: Property<Long>
+  }
+
+  companion object {
+    private val logger by lazy {
+      LoggerFactory.getLogger(SnapshotsPreviewRuntimeRetentionTransformFactory::class.java)
+    }
+  }
+
+  override fun createClassVisitor(
+    classContext: ClassContext,
+    nextClassVisitor: ClassVisitor,
+  ): ClassVisitor {
+    return SnapshotsPreviewRuntimeRetentionTransform(
+      instrumentationContext.apiVersion.get(),
+      nextClassVisitor,
+      logger,
+    )
+  }
+
+  override fun isInstrumentable(classData: ClassData): Boolean {
+    // Need to instrument all classes to ensure that the annotations are visible at runtime
+    return true
+  }
+}
+
+class SnapshotsPreviewRuntimeRetentionTransform(
+  api: Int,
+  classVisitor: ClassVisitor?,
+  private val logger: Logger,
+) : ClassVisitor(api, classVisitor) {
+
+  companion object {
+    const val TAG = "SnapshotRuntimePreviewClassVisitor"
+
+    const val PREVIEW_ANNOTATION_DESC = "Landroidx/compose/ui/tooling/preview/Preview;"
+    const val PREVIEW_CONTAINER_ANNOTATION_DESC =
+      "Landroidx/compose/ui/tooling/preview/Preview\$Container;"
+  }
+
+  override fun visitMethod(
+    access: Int,
+    name: String,
+    descriptor: String,
+    signature: String?,
+    exceptions: Array<String>?,
+  ): MethodVisitor {
+    val mv = super.visitMethod(access, name, descriptor, signature, exceptions)
+
+    return object : MethodVisitor(api, mv) {
+      override fun visitAnnotation(
+        desc: String,
+        visible: Boolean,
+      ): AnnotationVisitor? {
+        if (desc == PREVIEW_ANNOTATION_DESC || desc == PREVIEW_CONTAINER_ANNOTATION_DESC) {
+          logger.info(
+            "$TAG: Modifying method annotation visible at runtime to true for annotation $desc $visible"
+          )
+
+          // Force the annotation to be visible at runtime
+          return super.visitAnnotation(desc, true)
+        }
+
+        return super.visitAnnotation(desc, visible)
+      }
+    }
+  }
+
+  override fun visitAnnotation(
+    desc: String,
+    visible: Boolean,
+  ): AnnotationVisitor? {
+    if (desc == PREVIEW_ANNOTATION_DESC || desc == PREVIEW_CONTAINER_ANNOTATION_DESC) {
+      logger.info(
+        "$TAG: Modifying class annotation visible at runtime to true for annotation $desc $visible"
+      )
+
+      // Force the annotation to be visible at runtime
+      return super.visitAnnotation(desc, true)
+    }
+
+    return super.visitAnnotation(desc, visible)
+  }
+}


### PR DESCRIPTION
Creates an instrumentation/transform that finds all `Preview`/`Preview.Container` (repeatable) annotations and forces them to be runtime visible. This is a workaround to https://issuetracker.google.com/issues/168524920, as D8 will unexpectedly strip Binary/Class annotations.

Also:
- adds `debugOptions` and the ability to force invalidate a transform using a system time to make sure transforms aren't cached (taken from [here](https://arc.net/l/quote/xcfypmfs)).
- Adds `snapshots.experimentalTransformEnabled` which can act as an opt-in to this behavior until we've fully tested and are ready for 1.0
