### PR TITLE
Fix configuration cache violation where we reference project from GeneratePerformanceProjectTask's TaskAction

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -248,6 +248,7 @@ class EmergePlugin : Plugin<Project> {
     appProject: Project,
     performanceProjectPath: Property<String>,
   ) {
+    val rootDir = appProject.rootDir
     appProject.tasks.register(GENERATE_PERF_PROJECT_TASK_NAME, GeneratePerfProject::class.java) {
       it.group = EMERGE_TASK_GROUP
       it.description = "Generates a new performance testing project."
@@ -260,6 +261,17 @@ class EmergePlugin : Plugin<Project> {
         }
       )
       it.performanceProjectPath.set(performanceProjectPath)
+      it.rootDir.set(rootDir)
+      rootDir.resolve("settings.gradle.kts").let {settingsKtsFile ->
+        if (settingsKtsFile.exists()) {
+          it.gradleSettingsFile.set(settingsKtsFile)
+        }
+      }
+      rootDir.resolve("settings.gradle").let {settingsFile ->
+        if (settingsFile.exists()) {
+          it.gradleSettingsFile.set(settingsFile)
+        }
+      }
     }
   }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/GeneratePerfProject.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/GeneratePerfProject.kt
@@ -6,9 +6,10 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
-import org.gradle.internal.enterprise.test.FileProperty
 import org.jetbrains.kotlin.gradle.internal.ensureParentDirsCreated
 import java.io.File
 import java.util.zip.ZipInputStream
@@ -32,10 +33,10 @@ abstract class GeneratePerfProject : DefaultTask() {
   @get:Input
   abstract val performanceProjectPath: Property<String>
 
-  @get:Input
+  @get:InputDirectory
   abstract val rootDir: DirectoryProperty
 
-  @get:Input
+  @get:InputFile
   abstract val gradleSettingsFile: RegularFileProperty
 
   @TaskAction

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/GeneratePerfProject.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/GeneratePerfProject.kt
@@ -2,10 +2,13 @@ package com.emergetools.android.gradle.tasks.perf
 
 import com.emergetools.android.gradle.util.property
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+import org.gradle.internal.enterprise.test.FileProperty
 import org.jetbrains.kotlin.gradle.internal.ensureParentDirsCreated
 import java.io.File
 import java.util.zip.ZipInputStream
@@ -29,6 +32,12 @@ abstract class GeneratePerfProject : DefaultTask() {
   @get:Input
   abstract val performanceProjectPath: Property<String>
 
+  @get:Input
+  abstract val rootDir: DirectoryProperty
+
+  @get:Input
+  abstract val gradleSettingsFile: RegularFileProperty
+
   @TaskAction
   fun execute() {
     val projectName = performanceProjectPath.get().removePrefix(":")
@@ -44,7 +53,7 @@ abstract class GeneratePerfProject : DefaultTask() {
     projectName: String,
     packageName: String,
   ) {
-    val projectDir = project.rootDir.resolve(projectName)
+    val projectDir = rootDir.asFile.get().resolve(projectName)
     check(!projectDir.exists()) {
       "Project $projectName already exists at location $projectDir"
     }
@@ -77,15 +86,16 @@ abstract class GeneratePerfProject : DefaultTask() {
   }
 
   private fun addProjectToRootProject(projectName: String) {
-    val groovySettings = project.rootDir.resolve("settings.gradle")
-    val kotlinSettings = project.rootDir.resolve("settings.gradle.kts")
+    val settingsFile = gradleSettingsFile.asFile.get()
 
-    if (groovySettings.exists()) {
-      groovySettings.appendText("\ninclude '$projectName'\n")
-    } else if (kotlinSettings.exists()) {
-      kotlinSettings.appendText("\ninclude(\":$projectName\")\n")
+    if (!settingsFile.exists()) {
+      logger.warn("Could not find ${settingsFile.name} file to add performance project")
+    }
+
+    if (settingsFile.extension == "kts") {
+      settingsFile.appendText("\ninclude(\":$projectName\")\n")
     } else {
-      logger.warn("Could not find setting.gradle(.kts) file to add performance project")
+      settingsFile.appendText("\ninclude '$projectName'\n")
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 gradle-publish = { id = "com.gradle.plugin-publish", version = "0.20.0" }
 grgit = { id = "org.ajoberstar.grgit", version = "5.0.0" }
+plugin-best-practices = { id = "com.autonomousapps.plugin-best-practices-plugin", version = "0.10" }
 
 [libraries]
 android-gradle-plugin = "com.android.tools.build:gradle:7.3.1"


### PR DESCRIPTION
Running https://github.com/autonomousapps/gradle-best-practices-plugin to identify issues raised this as a potential config cache violation. Moves all invokes of `getProject` to be done at configuration time instead of task invocation time. 

Confirmation run of the best practices after this change confirms we addressed the violation.