### PR TITLE
Support localSnapshots task for new reflective invoking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ captures/
 
 # Any perfetto traces left around
 *.perfetto-trace
+
+# Metadata used for plugin testing
+**/emerge_config.json

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -85,6 +85,8 @@ val functionalTest: SourceSet by sourceSets.creating {
 		srcDir(agpClasspathDir)
 		srcDir(kgpClasspathDir)
 	}
+  compileClasspath += sourceSets.main.get().output + configurations.testRuntimeClasspath.get()
+  runtimeClasspath += output + compileClasspath
 }
 
 val functionalTestTask = tasks.register<Test>("functionalTest") {
@@ -127,9 +129,12 @@ dependencies {
 	compileOnly(libs.kotlin.gradle.plugin)
 
   implementation(libs.dexlib2)
-	implementation(libs.okhttp)
 	implementation(libs.kotlinx.datetime)
 	implementation(libs.kotlinx.serialization)
+	implementation(libs.okhttp)
+  // Needed for the GradleRunner in the functional tests. We've had issues with the version of Guava
+  // from one dependency conflicting with that of dexlib2, so we'll use the same version here.
+  implementation(libs.guava)
 
   // Needs to be impl as users might not always have the plugin applied, which compileOnly
   // would require.

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -85,8 +85,6 @@ val functionalTest: SourceSet by sourceSets.creating {
 		srcDir(agpClasspathDir)
 		srcDir(kgpClasspathDir)
 	}
-  compileClasspath += sourceSets.main.get().output + configurations.testRuntimeClasspath.get()
-  runtimeClasspath += output + compileClasspath
 }
 
 val functionalTestTask = tasks.register<Test>("functionalTest") {

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -126,6 +126,7 @@ dependencies {
 	compileOnly(libs.android.gradle.plugin)
 	compileOnly(libs.kotlin.gradle.plugin)
 
+  implementation(libs.dexlib2)
 	implementation(libs.okhttp)
 	implementation(libs.kotlinx.datetime)
 	implementation(libs.kotlinx.serialization)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -376,6 +376,7 @@ class EmergePlugin : Plugin<Project> {
         " Requires a device or emulator connected."
       it.packageDir.set(packageTask.flatMap { packageTask -> packageTask.outputDirectory })
       it.snapshotStorageDirectory.set(snapshotStorageDirectory)
+      it.previewExtractDir.set(appProject.layout.buildDirectory.dir("${BUILD_OUTPUT_DIR_NAME}/previews"))
       it.targetAppId.set(targetAppId)
       it.testAppId.set(testAppId)
       it.testInstrumentationRunner.set(testInstrumentationRunner)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -361,8 +361,9 @@ class EmergePlugin : Plugin<Project> {
   ) {
     val variantName = variant.name.capitalize()
 
+    val buildDirectory = appProject.layout.buildDirectory
     val snapshotStorageDirectory = extension.snapshotOptions.snapshotsStorageDirectory.orElse(
-      appProject.layout.buildDirectory.dir("${BUILD_OUTPUT_DIR_NAME}/snapshots/outputs")
+      buildDirectory.dir("${BUILD_OUTPUT_DIR_NAME}/snapshots/outputs")
     )
 
     val targetAppId = variant.applicationId
@@ -376,7 +377,7 @@ class EmergePlugin : Plugin<Project> {
         " Requires a device or emulator connected."
       it.packageDir.set(packageTask.flatMap { packageTask -> packageTask.outputDirectory })
       it.snapshotStorageDirectory.set(snapshotStorageDirectory)
-      it.previewExtractDir.set(appProject.layout.buildDirectory.dir("${BUILD_OUTPUT_DIR_NAME}/previews"))
+      it.previewExtractDir.set(buildDirectory.dir("${BUILD_OUTPUT_DIR_NAME}/previews"))
       it.targetAppId.set(targetAppId)
       it.testAppId.set(testAppId)
       it.testInstrumentationRunner.set(testInstrumentationRunner)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
@@ -1,6 +1,6 @@
 package com.emergetools.android.gradle.tasks.snapshots
 
-import com.emergetools.android.gradle.tasks.snapshots.utils.findPreviews
+import com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils
 import com.emergetools.android.gradle.tasks.upload.ArtifactMetadata
 import com.emergetools.android.gradle.util.adb.AdbHelper
 import kotlinx.serialization.encodeToString
@@ -36,15 +36,15 @@ abstract class LocalSnapshots : DefaultTask() {
     arguments["class"] = clazz
   }
 
-  @get:OutputDirectory
-  abstract val previewExtractDir: DirectoryProperty
-
   @get:Inject
   abstract val execOperations: ExecOperations
 
   @get:InputDirectory
   @get:PathSensitive(PathSensitivity.NAME_ONLY)
   abstract val packageDir: DirectoryProperty
+
+  @get:OutputDirectory
+  abstract val previewExtractDir: DirectoryProperty
 
   @get:OutputDirectory
   abstract val snapshotStorageDirectory: DirectoryProperty
@@ -94,7 +94,7 @@ abstract class LocalSnapshots : DefaultTask() {
       outputDir = extractedApkDir
     )
 
-    val composeSnapshots = findPreviews(extractedApkDir, logger)
+    val composeSnapshots = PreviewUtils.findPreviews(extractedApkDir, logger)
     logger.info("Found ${composeSnapshots.snapshots.size} Compose Preview snapshots")
     val composeSnapshotsJson = File(previewExtractionDir, COMPOSE_SNAPSHOTS_FILENAME)
     composeSnapshotsJson.writeText(Json.encodeToString(composeSnapshots))

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/ComposeSnapshots.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/ComposeSnapshots.kt
@@ -1,0 +1,20 @@
+package com.emergetools.android.gradle.tasks.snapshots.utils
+
+import kotlinx.serialization.Serializable
+
+// TODO: (ryan) leverage snapshots-shared for data models once 1.0 published
+@Serializable
+data class ComposeSnapshots(
+  val snapshots: List<ComposePreviewSnapshotConfig>,
+)
+
+@Serializable
+data class ComposePreviewSnapshotConfig(
+  val originalFqn: String,
+  val fullyQualifiedClassName: String,
+  val name: String?,
+  val group: String?,
+  val uiMode: Int?,
+  val locale: String?,
+  val fontScale: Float?,
+)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/PreviewUtils.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/PreviewUtils.kt
@@ -14,167 +14,170 @@ import org.jf.dexlib2.iface.value.StringEncodedValue
 import org.slf4j.Logger
 import java.io.File
 
-const val PREVIEW_ANNOTATION = "Landroidx/compose/ui/tooling/preview/Preview;"
-const val PREVIEW_CONTAINER_ANNOTATION = "Landroidx/compose/ui/tooling/preview/Preview\$Container;"
-const val IGNORE_SNAPSHOT_ANNOTATION =
-  "Lcom/emergetools/snapshots/annotations/IgnoreEmergeSnapshot;"
+object PreviewUtils {
 
-const val COMPOSER_SIGNATURE = "Landroidx/compose/runtime/Composer;"
+  const val PREVIEW_ANNOTATION = "Landroidx/compose/ui/tooling/preview/Preview;"
+  const val PREVIEW_CONTAINER_ANNOTATION =
+    "Landroidx/compose/ui/tooling/preview/Preview\$Container;"
+  const val IGNORE_SNAPSHOT_ANNOTATION =
+    "Lcom/emergetools/snapshots/annotations/IgnoreEmergeSnapshot;"
 
-val previewSignatures = listOf(PREVIEW_ANNOTATION, PREVIEW_CONTAINER_ANNOTATION)
+  const val COMPOSER_SIGNATURE = "Landroidx/compose/runtime/Composer;"
 
-fun findPreviews(
-  extractedApkDirectory: File,
-  logger: Logger,
-): ComposeSnapshots {
+  val previewSignatures = listOf(PREVIEW_ANNOTATION, PREVIEW_CONTAINER_ANNOTATION)
 
-  val classSignatureMap = mutableMapOf<String, DexBackedClassDef>()
-  extractedApkDirectory.listFiles { file -> file.extension == "dex" }?.forEach { dexFile ->
-    val dexBackedDexFile: DexFile = DexFileFactory.loadDexFile(dexFile, null)
-    dexBackedDexFile.classes.forEach { classDef ->
-      // A quick performance optimization so we don't need to re-iterate through all classes later
-      // when handling multipreviews
-      classSignatureMap[classDef.type] = classDef as DexBackedClassDef
+  fun findPreviews(
+    extractedApkDirectory: File,
+    logger: Logger,
+  ): ComposeSnapshots {
+
+    val classSignatureMap = mutableMapOf<String, DexBackedClassDef>()
+    extractedApkDirectory.listFiles { file -> file.extension == "dex" }?.forEach { dexFile ->
+      val dexBackedDexFile: DexFile = DexFileFactory.loadDexFile(dexFile, null)
+      dexBackedDexFile.classes.forEach { classDef ->
+        // A quick performance optimization so we don't need to re-iterate through all classes later
+        // when handling multipreviews
+        classSignatureMap[classDef.type] = classDef as DexBackedClassDef
+      }
     }
-  }
 
-  val methodsWithConfigs = mutableMapOf<String, List<ComposePreviewSnapshotConfig>>()
+    val methodsWithConfigs = mutableMapOf<String, List<ComposePreviewSnapshotConfig>>()
 
-  classSignatureMap.values.forEach { classDef ->
-    classDef.methods.forEach { method ->
-      val classFqn = classSignatureToFqn(method.definingClass)
-      val methodKey = "$classFqn.${method.name}"
+    classSignatureMap.values.forEach { classDef ->
+      classDef.methods.forEach { method ->
+        val classFqn = classSignatureToFqn(method.definingClass)
+        val methodKey = "$classFqn.${method.name}"
 
-      val previewAnnotations = method.annotations.flatMap { annotation ->
-        findAllDirectOrTransitivePreviewAnnotations(classSignatureMap, annotation)
+        val previewAnnotations = method.annotations.flatMap { annotation ->
+          findAllDirectOrTransitivePreviewAnnotations(classSignatureMap, annotation)
+        }
+
+        if (previewAnnotations.isEmpty()) {
+          return@forEach
+        }
+
+        if (method.annotations.any { it.type == IGNORE_SNAPSHOT_ANNOTATION }) {
+          logger.info(
+            "Ignoring snapshot for method: $methodKey as it has the @IgnoreEmergeSnapshot annotation"
+          )
+          return@forEach
+        }
+
+        if (method.parameters.size != 2 || method.parameters.map { it.type } != listOf(
+            COMPOSER_SIGNATURE, "I"
+          )) {
+          logger.info(
+            "Ignoring snapshot for method: $methodKey as it does not have a no-arg signature"
+          )
+          return@forEach
+        }
+
+        if ((method.accessFlags and AccessFlags.PRIVATE.value) != 0) {
+          logger.info("Ignoring snapshot for method: $methodKey as it is private")
+          return@forEach
+        }
+
+        val configs = previewAnnotations.flatMap { previewAnnotation ->
+          composePreviewSnapshotConfigsFromPreviewAnnotation(method, previewAnnotation)
+        }
+
+        methodsWithConfigs[methodKey] = configs
       }
-
-      if (previewAnnotations.isEmpty()) {
-        return@forEach
-      }
-
-      if (method.annotations.any { it.type == IGNORE_SNAPSHOT_ANNOTATION }) {
-        logger.info(
-          "Ignoring snapshot for method: $methodKey as it has the @IgnoreEmergeSnapshot annotation"
-        )
-        return@forEach
-      }
-
-      if (method.parameters.size != 2 || method.parameters.map { it.type } != listOf(
-          COMPOSER_SIGNATURE, "I"
-        )) {
-        logger.info(
-          "Ignoring snapshot for method: $methodKey as it does not have a no-arg signature"
-        )
-        return@forEach
-      }
-
-      if ((method.accessFlags and AccessFlags.PRIVATE.value) != 0) {
-        logger.info("Ignoring snapshot for method: $methodKey as it is private")
-        return@forEach
-      }
-
-      val configs = previewAnnotations.flatMap { previewAnnotation ->
-        composePreviewSnapshotConfigsFromPreviewAnnotation(method, previewAnnotation)
-      }
-
-      methodsWithConfigs[methodKey] = configs
     }
-  }
 
-  return ComposeSnapshots(
-    snapshots = methodsWithConfigs.values.flatten()
-  )
-}
-
-private fun classSignatureToFqn(signature: String): String {
-  return signature.replace('/', '.').substring(1, signature.length - 1)
-}
-
-/**
- * Strip Kt synthetic suffix from class name if it exists to ensure FQN matches the source package.
- */
-private fun fqnForPreviewMethod(method: DexBackedMethod): String {
-  val classFqn = classSignatureToFqn(method.definingClass)
-  val splits = classFqn.split('.')
-  val className = splits.last()
-
-  return if (className.endsWith("Kt")) {
-    "${splits.dropLast(1).joinToString(".")}.${method.name}"
-  } else {
-    "$classFqn.${method.name}"
-  }
-}
-
-private fun findAllDirectOrTransitivePreviewAnnotations(
-  classSignatureMap: Map<String, DexBackedClassDef>,
-  annotation: Annotation,
-  seenAnnotations: MutableSet<String> = mutableSetOf(),
-): List<Annotation> {
-  val annotationClassDef = classSignatureMap[annotation.type]
-  val isPreviewAnnotation = previewSignatures.contains(annotation.type)
-
-  if (annotationClassDef == null || (seenAnnotations.contains(
-      annotation.type
-    ) && !isPreviewAnnotation)
-  ) {
-    return emptyList()
-  }
-
-  seenAnnotations.add(annotation.type)
-
-  val currentPreviewAnnotations = if (previewSignatures.contains(annotationClassDef.type)) {
-    listOf(annotation)
-  } else {
-    emptyList()
-  }
-
-  val nestedPreviewAnnotations = annotationClassDef.annotations.flatMap { nestedAnnotation ->
-    findAllDirectOrTransitivePreviewAnnotations(
-      classSignatureMap, nestedAnnotation, seenAnnotations
+    return ComposeSnapshots(
+      snapshots = methodsWithConfigs.values.flatten()
     )
   }
 
-  return currentPreviewAnnotations + nestedPreviewAnnotations
-}
+  private fun classSignatureToFqn(signature: String): String {
+    return signature.replace('/', '.').substring(1, signature.length - 1)
+  }
 
-private fun composePreviewSnapshotConfigsFromPreviewAnnotation(
-  method: DexBackedMethod,
-  annotation: Annotation,
-): List<ComposePreviewSnapshotConfig> {
-  val className = classSignatureToFqn(method.definingClass)
-  val originalFqn = fqnForPreviewMethod(method)
+  /**
+   * Strip Kt synthetic suffix from class name if it exists to ensure FQN matches the source package.
+   */
+  private fun fqnForPreviewMethod(method: DexBackedMethod): String {
+    val classFqn = classSignatureToFqn(method.definingClass)
+    val splits = classFqn.split('.')
+    val className = splits.last()
 
-  return when (annotation.type) {
-    PREVIEW_ANNOTATION -> listOf(
-      ComposePreviewSnapshotConfig(
-        originalFqn = originalFqn,
-        fullyQualifiedClassName = className,
-        name = (annotation.elements.firstOrNull { it.name == "name" }?.value as? StringEncodedValue)?.value,
-        group = (annotation.elements.firstOrNull { it.name == "group" }?.value as? StringEncodedValue)?.value,
-        uiMode = (annotation.elements.firstOrNull { it.name == "uiMode" }?.value as? IntEncodedValue)?.value,
-        locale = (annotation.elements.firstOrNull { it.name == "locale" }?.value as? StringEncodedValue)?.value,
-        fontScale = (annotation.elements.firstOrNull { it.name == "fontScale" }?.value as? FloatEncodedValue)?.value,
+    return if (className.endsWith("Kt")) {
+      "${splits.dropLast(1).joinToString(".")}.${method.name}"
+    } else {
+      "$classFqn.${method.name}"
+    }
+  }
+
+  private fun findAllDirectOrTransitivePreviewAnnotations(
+    classSignatureMap: Map<String, DexBackedClassDef>,
+    annotation: Annotation,
+    seenAnnotations: MutableSet<String> = mutableSetOf(),
+  ): List<Annotation> {
+    val annotationClassDef = classSignatureMap[annotation.type]
+    val isPreviewAnnotation = previewSignatures.contains(annotation.type)
+
+    if (annotationClassDef == null || (seenAnnotations.contains(
+        annotation.type
+      ) && !isPreviewAnnotation)
+    ) {
+      return emptyList()
+    }
+
+    seenAnnotations.add(annotation.type)
+
+    val currentPreviewAnnotations = if (previewSignatures.contains(annotationClassDef.type)) {
+      listOf(annotation)
+    } else {
+      emptyList()
+    }
+
+    val nestedPreviewAnnotations = annotationClassDef.annotations.flatMap { nestedAnnotation ->
+      findAllDirectOrTransitivePreviewAnnotations(
+        classSignatureMap, nestedAnnotation, seenAnnotations
       )
-    )
+    }
 
-    PREVIEW_CONTAINER_ANNOTATION -> {
-      val arrayEncodedValue =
-        annotation.elements.firstOrNull { it.name == "value" }?.value as? ArrayEncodedValue
-      arrayEncodedValue?.value?.mapNotNull { it as? AnnotationEncodedValue }?.map { preview ->
+    return currentPreviewAnnotations + nestedPreviewAnnotations
+  }
+
+  private fun composePreviewSnapshotConfigsFromPreviewAnnotation(
+    method: DexBackedMethod,
+    annotation: Annotation,
+  ): List<ComposePreviewSnapshotConfig> {
+    val className = classSignatureToFqn(method.definingClass)
+    val originalFqn = fqnForPreviewMethod(method)
+
+    return when (annotation.type) {
+      PREVIEW_ANNOTATION -> listOf(
         ComposePreviewSnapshotConfig(
           originalFqn = originalFqn,
           fullyQualifiedClassName = className,
-          name = (preview.elements.firstOrNull { it.name == "name" }?.value as? StringEncodedValue)?.value,
-          group = (preview.elements.firstOrNull { it.name == "group" }?.value as? StringEncodedValue)?.value,
-          uiMode = (preview.elements.firstOrNull { it.name == "uiMode" }?.value as? IntEncodedValue)?.value,
-          locale = (preview.elements.firstOrNull { it.name == "locale" }?.value as? StringEncodedValue)?.value,
-          fontScale = (preview.elements.firstOrNull { it.name == "fontScale" }?.value as? FloatEncodedValue)?.value,
+          name = (annotation.elements.firstOrNull { it.name == "name" }?.value as? StringEncodedValue)?.value,
+          group = (annotation.elements.firstOrNull { it.name == "group" }?.value as? StringEncodedValue)?.value,
+          uiMode = (annotation.elements.firstOrNull { it.name == "uiMode" }?.value as? IntEncodedValue)?.value,
+          locale = (annotation.elements.firstOrNull { it.name == "locale" }?.value as? StringEncodedValue)?.value,
+          fontScale = (annotation.elements.firstOrNull { it.name == "fontScale" }?.value as? FloatEncodedValue)?.value,
         )
-      }.orEmpty()
-    }
+      )
 
-    else -> emptyList()
+      PREVIEW_CONTAINER_ANNOTATION -> {
+        val arrayEncodedValue =
+          annotation.elements.firstOrNull { it.name == "value" }?.value as? ArrayEncodedValue
+        arrayEncodedValue?.value?.mapNotNull { it as? AnnotationEncodedValue }?.map { preview ->
+          ComposePreviewSnapshotConfig(
+            originalFqn = originalFqn,
+            fullyQualifiedClassName = className,
+            name = (preview.elements.firstOrNull { it.name == "name" }?.value as? StringEncodedValue)?.value,
+            group = (preview.elements.firstOrNull { it.name == "group" }?.value as? StringEncodedValue)?.value,
+            uiMode = (preview.elements.firstOrNull { it.name == "uiMode" }?.value as? IntEncodedValue)?.value,
+            locale = (preview.elements.firstOrNull { it.name == "locale" }?.value as? StringEncodedValue)?.value,
+            fontScale = (preview.elements.firstOrNull { it.name == "fontScale" }?.value as? FloatEncodedValue)?.value,
+          )
+        }.orEmpty()
+      }
+
+      else -> emptyList()
+    }
   }
 }
-

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/PreviewUtils.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/PreviewUtils.kt
@@ -1,0 +1,180 @@
+package com.emergetools.android.gradle.tasks.snapshots.utils
+
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.DexFileFactory
+import org.jf.dexlib2.dexbacked.DexBackedClassDef
+import org.jf.dexlib2.dexbacked.DexBackedMethod
+import org.jf.dexlib2.iface.Annotation
+import org.jf.dexlib2.iface.DexFile
+import org.jf.dexlib2.iface.value.AnnotationEncodedValue
+import org.jf.dexlib2.iface.value.ArrayEncodedValue
+import org.jf.dexlib2.iface.value.FloatEncodedValue
+import org.jf.dexlib2.iface.value.IntEncodedValue
+import org.jf.dexlib2.iface.value.StringEncodedValue
+import org.slf4j.Logger
+import java.io.File
+
+const val PREVIEW_ANNOTATION = "Landroidx/compose/ui/tooling/preview/Preview;"
+const val PREVIEW_CONTAINER_ANNOTATION = "Landroidx/compose/ui/tooling/preview/Preview\$Container;"
+const val IGNORE_SNAPSHOT_ANNOTATION =
+  "Lcom/emergetools/snapshots/annotations/IgnoreEmergeSnapshot;"
+
+const val COMPOSER_SIGNATURE = "Landroidx/compose/runtime/Composer;"
+
+val previewSignatures = listOf(PREVIEW_ANNOTATION, PREVIEW_CONTAINER_ANNOTATION)
+
+fun findPreviews(
+  extractedApkDirectory: File,
+  logger: Logger,
+): ComposeSnapshots {
+
+  val classSignatureMap = mutableMapOf<String, DexBackedClassDef>()
+  extractedApkDirectory.listFiles { file -> file.extension == "dex" }?.forEach { dexFile ->
+    val dexBackedDexFile: DexFile = DexFileFactory.loadDexFile(dexFile, null)
+    dexBackedDexFile.classes.forEach { classDef ->
+      // A quick performance optimization so we don't need to re-iterate through all classes later
+      // when handling multipreviews
+      classSignatureMap[classDef.type] = classDef as DexBackedClassDef
+    }
+  }
+
+  val methodsWithConfigs = mutableMapOf<String, List<ComposePreviewSnapshotConfig>>()
+
+  classSignatureMap.values.forEach { classDef ->
+    classDef.methods.forEach { method ->
+      val classFqn = classSignatureToFqn(method.definingClass)
+      val methodKey = "$classFqn.${method.name}"
+
+      val previewAnnotations = method.annotations.flatMap { annotation ->
+        findAllDirectOrTransitivePreviewAnnotations(classSignatureMap, annotation)
+      }
+
+      if (previewAnnotations.isEmpty()) {
+        return@forEach
+      }
+
+      if (method.annotations.any { it.type == IGNORE_SNAPSHOT_ANNOTATION }) {
+        logger.info(
+          "Ignoring snapshot for method: $methodKey as it has the @IgnoreEmergeSnapshot annotation"
+        )
+        return@forEach
+      }
+
+      if (method.parameters.size != 2 || method.parameters.map { it.type } != listOf(
+          COMPOSER_SIGNATURE, "I"
+        )) {
+        logger.info(
+          "Ignoring snapshot for method: $methodKey as it does not have a no-arg signature"
+        )
+        return@forEach
+      }
+
+      if ((method.accessFlags and AccessFlags.PRIVATE.value) != 0) {
+        logger.info("Ignoring snapshot for method: $methodKey as it is private")
+        return@forEach
+      }
+
+      val configs = previewAnnotations.flatMap { previewAnnotation ->
+        composePreviewSnapshotConfigsFromPreviewAnnotation(method, previewAnnotation)
+      }
+
+      methodsWithConfigs[methodKey] = configs
+    }
+  }
+
+  return ComposeSnapshots(
+    snapshots = methodsWithConfigs.values.flatten()
+  )
+}
+
+private fun classSignatureToFqn(signature: String): String {
+  return signature.replace('/', '.').substring(1, signature.length - 1)
+}
+
+/**
+ * Strip Kt synthetic suffix from class name if it exists to ensure FQN matches the source package.
+ */
+private fun fqnForPreviewMethod(method: DexBackedMethod): String {
+  val classFqn = classSignatureToFqn(method.definingClass)
+  val splits = classFqn.split('.')
+  val className = splits.last()
+
+  return if (className.endsWith("Kt")) {
+    "${splits.dropLast(1).joinToString(".")}.${method.name}"
+  } else {
+    "$classFqn.${method.name}"
+  }
+}
+
+private fun findAllDirectOrTransitivePreviewAnnotations(
+  classSignatureMap: Map<String, DexBackedClassDef>,
+  annotation: Annotation,
+  seenAnnotations: MutableSet<String> = mutableSetOf(),
+): List<Annotation> {
+  val annotationClassDef = classSignatureMap[annotation.type]
+  val isPreviewAnnotation = previewSignatures.contains(annotation.type)
+
+  if (annotationClassDef == null || (seenAnnotations.contains(
+      annotation.type
+    ) && !isPreviewAnnotation)
+  ) {
+    return emptyList()
+  }
+
+  seenAnnotations.add(annotation.type)
+
+  val currentPreviewAnnotations = if (previewSignatures.contains(annotationClassDef.type)) {
+    listOf(annotation)
+  } else {
+    emptyList()
+  }
+
+  val nestedPreviewAnnotations = annotationClassDef.annotations.flatMap { nestedAnnotation ->
+    findAllDirectOrTransitivePreviewAnnotations(
+      classSignatureMap, nestedAnnotation, seenAnnotations
+    )
+  }
+
+  return currentPreviewAnnotations + nestedPreviewAnnotations
+}
+
+private fun composePreviewSnapshotConfigsFromPreviewAnnotation(
+  method: DexBackedMethod,
+  annotation: Annotation,
+): List<ComposePreviewSnapshotConfig> {
+  val className = classSignatureToFqn(method.definingClass)
+  val originalFqn = fqnForPreviewMethod(method)
+
+  return when (annotation.type) {
+    PREVIEW_ANNOTATION -> listOf(
+      ComposePreviewSnapshotConfig(
+        originalFqn = originalFqn,
+        fullyQualifiedClassName = className,
+        name = (annotation.elements.firstOrNull { it.name == "name" }?.value as? StringEncodedValue)?.value,
+        group = (annotation.elements.firstOrNull { it.name == "group" }?.value as? StringEncodedValue)?.value,
+        uiMode = (annotation.elements.firstOrNull { it.name == "uiMode" }?.value as? IntEncodedValue)?.value,
+        locale = (annotation.elements.firstOrNull { it.name == "locale" }?.value as? StringEncodedValue)?.value,
+        fontScale = (annotation.elements.firstOrNull { it.name == "fontScale" }?.value as? FloatEncodedValue)?.value,
+      )
+    )
+
+    PREVIEW_CONTAINER_ANNOTATION -> {
+      val arrayEncodedValue =
+        annotation.elements.firstOrNull { it.name == "value" }?.value as? ArrayEncodedValue
+      arrayEncodedValue?.value?.mapNotNull { it as? AnnotationEncodedValue }?.map { preview ->
+        ComposePreviewSnapshotConfig(
+          originalFqn = originalFqn,
+          fullyQualifiedClassName = className,
+          name = (preview.elements.firstOrNull { it.name == "name" }?.value as? StringEncodedValue)?.value,
+          group = (preview.elements.firstOrNull { it.name == "group" }?.value as? StringEncodedValue)?.value,
+          uiMode = (preview.elements.firstOrNull { it.name == "uiMode" }?.value as? IntEncodedValue)?.value,
+          locale = (preview.elements.firstOrNull { it.name == "locale" }?.value as? StringEncodedValue)?.value,
+          fontScale = (preview.elements.firstOrNull { it.name == "fontScale" }?.value as? FloatEncodedValue)?.value,
+        )
+      }.orEmpty()
+    }
+
+    else -> emptyList()
+  }
+}
+

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/adb/AdbHelper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/adb/AdbHelper.kt
@@ -36,6 +36,11 @@ class AdbHelper(
 
   fun shell(arguments: List<String>) = exec(listOf("shell") + arguments)
 
+  fun push(
+    localFile: String,
+    deviceDir: String,
+  ) = exec(listOf("push", localFile, deviceDir))
+
   fun pull(
     deviceDir: String,
     localDir: String,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,8 @@ compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling
 
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 
+dexlib2 = "org.smali:dexlib2:2.5.2"
+
 google-truth = "com.google.truth:truth:1.1.3"
 
 guava = "com.google.guava:guava:30.1.1-jre"


### PR DESCRIPTION
Adds support for our new KSP-less snapshot invoking to the LocalSnapshots task, allowing us (and users) to remove KSP entirely!

Runs by finding all previews/multipreviews directly from the instrumented dex, then passing JSON to reflective invoker test.

<img width="893" alt="Screenshot 2024-05-22 at 2 17 44 PM" src="https://github.com/EmergeTools/emerge-android/assets/6821566/8282668b-08ce-48db-9677-c90e493f70f4">
