### PR TITLE
Handle snapshoting private preview methods and improve parameterized test naming

### DIFF
--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -54,7 +54,6 @@ internal fun TextRowWithIconPreviewFromMainInternalFunctionMultiPreview() {
   )
 }
 
-
 @SnapshotTestingPreview
 @Composable
 private fun TextRowWithIconPreviewFromMainPrivateFunctionMultiPreview() {

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -54,6 +54,16 @@ internal fun TextRowWithIconPreviewFromMainInternalFunctionMultiPreview() {
   )
 }
 
+
+@SnapshotTestingPreview
+@Composable
+private fun TextRowWithIconPreviewFromMainPrivateFunctionMultiPreview() {
+  TextRowWithIcon(
+    titleText = stringResource(com.emergetools.snapshots.sample.R.string.sample_title),
+    subtitleText = stringResource(com.emergetools.snapshots.sample.R.string.sample_subtitle)
+  )
+}
+
 @LocalePreviews
 @FontScalePreviews
 @Composable
@@ -61,15 +71,6 @@ fun TextRowWithIconPreviewFromMainJustStackedMultiPreview() {
   TextRowWithIcon(
     titleText = stringResource(com.emergetools.snapshots.sample.R.string.sample_title),
     subtitleText = stringResource(com.emergetools.snapshots.sample.R.string.sample_subtitle)
-  )
-}
-
-@SnapshotTestingPreview
-@Composable
-fun TextRowWithIconPreviewFromMainJustSnapshotTestingPreview() {
-  TextRowWithIcon(
-    titleText = "Title SnapshotTestingPreview2",
-    subtitleText = "Subtitle SnapshotTestingPreview"
   )
 }
 

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -54,6 +54,7 @@ internal fun TextRowWithIconPreviewFromMainInternalFunctionMultiPreview() {
   )
 }
 
+@Suppress("UnusedPrivateMember")
 @SnapshotTestingPreview
 @Composable
 private fun TextRowWithIconPreviewFromMainPrivateFunctionMultiPreview() {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -18,7 +18,9 @@ import org.junit.runners.Parameterized
 import java.io.File
 
 @RunWith(Parameterized::class)
-class EmergeComposeSnapshotReflectiveParameterizedInvoker(private val parameter: EmergeComposeSnapshotReflectiveParameters) {
+class EmergeComposeSnapshotReflectiveParameterizedInvoker(
+  private val parameter: EmergeComposeSnapshotReflectiveParameters
+) {
 
   // Wrapper class to give us better parameterized test naming
   data class EmergeComposeSnapshotReflectiveParameters(

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -1,6 +1,7 @@
 package com.emergetools.snapshots.compose
 
 import android.util.Log
+import androidx.compose.runtime.Composer
 import androidx.compose.runtime.currentComposer
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -17,14 +18,22 @@ import org.junit.runners.Parameterized
 import java.io.File
 
 @RunWith(Parameterized::class)
-class EmergeComposeSnapshotReflectiveParameterizedInvoker(private val previewConfig: ComposePreviewSnapshotConfig) {
+class EmergeComposeSnapshotReflectiveParameterizedInvoker(private val parameter: EmergeComposeSnapshotReflectiveParameters) {
+
+  // Wrapper class to give us better parameterized test naming
+  data class EmergeComposeSnapshotReflectiveParameters(
+    val previewConfig: ComposePreviewSnapshotConfig
+  ) {
+    override fun toString(): String = previewConfig.keyName()
+  }
+
   companion object {
     const val TAG = "EmergeComposeSnapshotReflectiveParameterizedInvoker"
     const val ARG_REFLECTIVE_INVOKE_DATA_PATH = "invoke_data_path"
 
     @JvmStatic
-    @Parameterized.Parameters
-    fun data(): Iterable<ComposePreviewSnapshotConfig> {
+    @Parameterized.Parameters(name = "{index} {0}")
+    fun data(): Iterable<EmergeComposeSnapshotReflectiveParameters> {
       val args = InstrumentationRegistry.getArguments()
 
       val invokeDataPath = args.getString(ARG_REFLECTIVE_INVOKE_DATA_PATH) ?: run {
@@ -41,7 +50,9 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(private val previewCon
         ignoreUnknownKeys = true
       }
 
-      return json.decodeFromString<ComposeSnapshots>(invokeDataFile.readText()).snapshots
+      return json.decodeFromString<ComposeSnapshots>(invokeDataFile.readText()).snapshots.map {
+        EmergeComposeSnapshotReflectiveParameters(it)
+      }
     }
   }
 
@@ -54,14 +65,23 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(private val previewCon
   @Test
   @Suppress("TooGenericExceptionCaught")
   fun reflectiveComposableInvoker() {
+    val previewConfig = parameter.previewConfig
     try {
       composeRule.setContent {
         val klass = Class.forName(previewConfig.fullyQualifiedClassName)
+        Log.d(TAG, "Found class for ${previewConfig.fullyQualifiedClassName}: ${klass.name}")
+        val methodName = previewConfig.originalFqn.substringAfterLast(".")
         val composableMethod = klass.methods.find {
-          it.name == previewConfig.originalFqn.substringAfterLast(".")
+          Log.d(TAG, "Checking method in class ${klass.name}: ${it.name}")
+          it.name == methodName
+        } ?: klass.getDeclaredMethod(methodName, Composer::class.java, Int::class.javaPrimitiveType)
+
+        if (composableMethod != null && !composableMethod.isAccessible) {
+          Log.e(TAG, "Marking composable method as accessible: ${previewConfig.originalFqn}")
+          composableMethod.isAccessible = true
         }
 
-        Log.d(TAG, "Invoking composable method: $composableMethod")
+        Log.d(TAG, "Invoking composable method: ${composableMethod?.name}")
 
         composableMethod?.let {
           it.isAccessible = true


### PR DESCRIPTION
Fixes private Preview method invocations, using `Class.getDeclaredMethod` as a fallback to find methods that are hidden in `class.methods`. We then mark the methods as accessible for invoking with reflection. Confirmed working locally on https://github.com/EmergeTools/nowinandroid/pull/1

Also implements a bit nicer naming for our reflective parameterized tests. It used to just show the index of the test, but now will show something like:
```
reflectiveComposableInvoker[66 com.google.samples.apps.nowinandroid.feature.settings.PreviewSettingsDialog]
```
with the unique keyName for the composable snapshot directly in the name, making debug/attribution easier.