### PR TITLE
Add includePrivatePreviews option to allow disabling private previews from being snapshotted

### DIFF
--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -144,10 +144,13 @@ emerge {
   // ..
 
   size {
-    tag.set("release") // Tag to use for grouping builds in the Emerge dashboard
+    // Tag to use for grouping builds in the Emerge dashboard
+    tag.set("release")
     // Alternatively, use `setFromVariant()` to set the tag from the Android build variant
     tag.setFromVariant()
-    enabled.set(true) // If size tasks/project configuration are enabled.
+
+    // If size tasks/project configuration are enabled.
+    enabled.set(true)
   }
 }
 ```
@@ -181,13 +184,16 @@ emerge {
   // ..
 
   performance {
-    projectPath.set(
-      ":perf"
-    ) // REQUIRED - Relative gradle path from root project to the Emerge performance module
-    tag.set("release") // Tag to use for grouping builds in the Emerge dashboard
+    // REQUIRED - Relative gradle path from root project to the Emerge performance module
+    projectPath.set(":perf")
+
+    // Tag to use for grouping builds in the Emerge dashboard
+    tag.set("release")
     // Alternatively, use `setFromVariant()` to set the tag from the Android build variant
     tag.setFromVariant()
-    enabled.set(true) // If performance tasks/project configuration are enabled.
+
+    // If performance tasks/project configuration are enabled.
+    enabled.set(true)
   }
 }
 ```
@@ -218,17 +224,22 @@ emerge {
   // ..
 
   snapshots {
-    snapshotsStorageDirectory.set(
-      "/src/main/snapshots"
-    ) // Path to local snapshot image storage, defaults to `/build/emerge/snapshots/outputs`
+    // Path to local snapshot image storage, defaults to `/build/emerge/snapshots/outputs`
+    snapshotsStorageDirectory.set("/src/main/snapshots")
 
-    apiVersion.set(33) // Android API version to run snapshots on, must be 29, 31, 33 or 34.
+    // Android API version to run snapshots on, must be 29, 31, 33 or 34.
+    apiVersion.set(33)
 
-    tag.set("snapshots") // Tag to use for grouping builds in the Emerge dashboard
+    // Include private previews in snapshot generation - defaults to true
+    includePrivatePreviews.set(false)
+
+    // Tag to use for grouping builds in the Emerge dashboard
+    tag.set("snapshots")
     // Alternatively, use `setFromVariant()` to set the tag from the Android build variant
     tag.setFromVariant()
 
-    enabled.set(true) // If performance tasks/project configuration are enabled.
+    // If performance tasks/project configuration are enabled.
+    enabled.set(true)
   }
 }
 ```
@@ -244,6 +255,7 @@ versions to releases & names, see [Android API levels](https://apilevels.com/).
 | `snapshotsStorageDirectory` | `String`  | `/build/emerge/snapshots/outputs` | The path to local snapshot storage. Only used for local snapshot generation.                      |
 | `apiVersion`                | `Int`     | `34`                              | The Android API version to use for snapshot generation. Must be an int value in 29, 31, 33 or 34. |
 | `enabled`                   | `boolean` | `true`                            | If snapshot tasks/project configuration are enabled.                                              |
+| `includePrivatePreviews`    | `boolean` | `true`                            | If Emerge should snapshot `private` annotated `@Preview` functions.                               |
 
 ## Full configuration
 
@@ -253,48 +265,65 @@ emerge {
   apiToken.set(System.getenv("EMERGE_API_TOKEN"))
 
   vcs {
-    sha.set("..") // Optional, will be set automatically using Git information.
-    baseSha.set("..") // Optional, will be set automatically using Git information.
-    branchName.set("my-feature") // Optional, will be set automatically using Git information.
+    // Optional, will be set automatically using Git information.
+    sha.set("..")
+    // Optional, will be set automatically using Git information.
+    baseSha.set("..")
+    // Optional, will be set automatically using Git information.
+    branchName.set("my-feature")
     prNumber.set("123")
 
     gitHub {
-      repoOwner.set("..") // Required for CI status checks (only if using GitHub)
-      repoName.set("..") // Required for CI status checks (only if using GitHub)
+      // Required for CI status checks (only if using GitHub)
+      repoOwner.set("..")
+      // Required for CI status checks (only if using GitHub)
+      repoName.set("..")
     }
 
     gitLab {
-      projectId.set("..") // Required for CI status checks (only if using GitLab)
+      // Required for CI status checks (only if using GitLab)
+      projectId.set("..")
     }
   }
 
   size {
-    tag.set("release") // Optional, defaults to 'release'
-    // Alternatively, use `setFromVariant()` to set the tag from the Android build variant
+    // Optional, defaults to 'release'
+    tag.set("release")
+    // Alternatively, use `setFromVariant()` to set the tag from the Android build variant name
     tag.setFromVariant()
 
-    enabled.set(true) // If size tasks/project configuration are enabled.
+    // If size tasks/project configuration are enabled.
+    enabled.set(true)
   }
 
   performance {
-    projectPath.set(":perf") // Required for performance testing
-    tag.set("release") // Optional, defaults to 'release'
+    // Required for performance testing
+    projectPath.set(":perf")
+
+    // Optional, defaults to 'release'
+    tag.set("release")
     // Alternatively, use `setFromVariant()` to set the tag from the Android build variant
     tag.setFromVariant()
 
-    enabled.set(true) // If performance tasks/project configuration are enabled.
+    // If performance tasks/project configuration are enabled.
+    enabled.set(true)
   }
 
   snapshots {
-    snapshotsStorageDirectory.set("/src/main/snapshots") // Storage of locally generated snapshots
-    apiVersion.set(33) // Android API version to run snapshots on, must be 29, 31, 33 or 34.
+    // Storage of locally generated snapshots
+    snapshotsStorageDirectory.set("/src/main/snapshots")
+    // Android API version to run snapshots on, must be 29, 31, 33 or 34.
+    apiVersion.set(33)
+    // Include private previews in snapshot generation - defaults to true
+    includePrivatePreviews.set(false)
 
     // Optional, snapshots use debug builds, we recommend using a separate tag.
     tag.set("snapshots")
-    // Alternatively, use `setFromVariant()` to set the tag from the Android build variant
+    // Alternatively, use `setFromVariant()` to set the tag from the Android build variant name
     tag.setFromVariant()
 
-    enabled.set(true) // If snapshot tasks/project configuration are enabled.
+    // If snapshot tasks/project configuration are enabled.
+    enabled.set(true)
   }
 }
 ```
@@ -371,13 +400,13 @@ Additionally, `ANDROID_SDK_ROOT` must be set and point to the Android SDK locati
 2. Update the plugin version in documentation.
 3. Update the `/gradle-plugin/CHANGELOG.md`
 3. `gt c -am "Prepare for Gradle plugin release X.Y.Z"` (where X.Y.Z is the version set in step 1)
-   1. Alt
-      1. `git add *`
-      2. `git commit -m "Prepare for Gradle plugin release X.Y.Z"`
+1. Alt
+1. `git add *`
+2. `git commit -m "Prepare for Gradle plugin release X.Y.Z"`
 4. `gt ss`
-   1. Alt:
-      1. `git push`
-      2. Open PR
+1. Alt:
+1. `git push`
+2. Open PR
 6. Get PR approved and merge
 7. Create a new release on GitHub
 8. Tag version `gradle-plugin-vX.Y.Z`

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -405,6 +405,7 @@ class EmergePlugin : Plugin<Project> {
       it.artifactMetadataPath.set(
         packageTask.flatMap { packageTask -> packageTask.artifactMetadataPath })
       it.apiVersion.set(extension.snapshotOptions.apiVersion)
+      it.includePrivatePreviews.set(extension.snapshotOptions.includePrivatePreviews)
       it.setUploadTaskInputs(extension, appProject)
       it.setTagFromProductOptions(extension.snapshotOptions, variant)
       it.dependsOn(packageTask)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -383,6 +383,7 @@ class EmergePlugin : Plugin<Project> {
       it.targetAppId.set(targetAppId)
       it.testAppId.set(testAppId)
       it.testInstrumentationRunner.set(testInstrumentationRunner)
+      it.includePrivatePreviews.set(extension.snapshotOptions.includePrivatePreviews)
       it.dependsOn(packageTask)
     }
   }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -152,6 +152,8 @@ abstract class SnapshotOptions : ProductOptions() {
   abstract val snapshotsStorageDirectory: DirectoryProperty
 
   abstract val apiVersion: Property<Int>
+
+  abstract val includePrivatePreviews: Property<Boolean>
 }
 
 abstract class DebugOptions : ProductOptions() {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
@@ -58,6 +58,9 @@ abstract class LocalSnapshots : DefaultTask() {
   @get:Input
   abstract val testInstrumentationRunner: Property<String>
 
+  @get:Input
+  abstract val includePrivatePreviews: Property<Boolean>
+
   @TaskAction
   fun execute() {
     val artifactMetadataFiles = packageDir.asFileTree.matching {
@@ -95,7 +98,11 @@ abstract class LocalSnapshots : DefaultTask() {
       outputDir = extractedApkDir
     )
 
-    val composeSnapshots = PreviewUtils.findPreviews(extractedApkDir, logger)
+    val composeSnapshots = PreviewUtils.findPreviews(
+      extractedApkDir,
+      includePrivatePreviews.getOrElse(true),
+      logger
+    )
     logger.info("Found ${composeSnapshots.snapshots.size} Compose Preview snapshots")
     val composeSnapshotsJson = File(previewExtractionDir, COMPOSE_SNAPSHOTS_FILENAME)
     composeSnapshotsJson.writeText(Json.encodeToString(composeSnapshots))

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
@@ -10,6 +10,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -59,6 +60,7 @@ abstract class LocalSnapshots : DefaultTask() {
   abstract val testInstrumentationRunner: Property<String>
 
   @get:Input
+  @get:Optional
   abstract val includePrivatePreviews: Property<Boolean>
 
   @TaskAction

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
@@ -4,16 +4,13 @@ import com.emergetools.android.gradle.tasks.upload.ArtifactMetadata
 import com.emergetools.android.gradle.tasks.upload.BaseUploadTask
 import com.emergetools.android.gradle.util.network.EmergeUploadRequestData
 import kotlinx.datetime.Clock
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -21,7 +18,6 @@ import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
-import javax.inject.Inject
 
 abstract class UploadSnapshotBundle : BaseUploadTask() {
 
@@ -33,8 +29,12 @@ abstract class UploadSnapshotBundle : BaseUploadTask() {
   @get:Optional
   abstract val apiVersion: Property<Int>
 
+  @get:Input
+  abstract val includePrivatePreviews: Property<Boolean>
+
   @get:InputFile
   abstract val artifactMetadataPath: RegularFileProperty
+
 
   override fun includeFilesInUpload(zos: ZipOutputStream) {
     val artifactMetadataFilePath = checkNotNull(artifactMetadataPath.asFile.orNull) {
@@ -68,6 +68,7 @@ abstract class UploadSnapshotBundle : BaseUploadTask() {
     return super.uploadRequestData(file).copy(
       androidSnapshotsEnabled = true,
       androidSnapshotsApiVersion = apiVersion.orNull,
+      androidSnapshotsPrivateEnabled = includePrivatePreviews.getOrElse(false),
     )
   }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
@@ -30,6 +30,7 @@ abstract class UploadSnapshotBundle : BaseUploadTask() {
   abstract val apiVersion: Property<Int>
 
   @get:Input
+  @get:Optional
   abstract val includePrivatePreviews: Property<Boolean>
 
   @get:InputFile

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
@@ -68,7 +68,7 @@ abstract class UploadSnapshotBundle : BaseUploadTask() {
     return super.uploadRequestData(file).copy(
       androidSnapshotsEnabled = true,
       androidSnapshotsApiVersion = apiVersion.orNull,
-      androidSnapshotsPrivateEnabled = includePrivatePreviews.getOrElse(false),
+      androidSnapshotsPrivateEnabled = includePrivatePreviews.getOrElse(true),
     )
   }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/PreviewUtils.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/PreviewUtils.kt
@@ -1,5 +1,6 @@
 package com.emergetools.android.gradle.tasks.snapshots.utils
 
+import org.jf.dexlib2.AccessFlags
 import org.jf.dexlib2.DexFileFactory
 import org.jf.dexlib2.dexbacked.DexBackedClassDef
 import org.jf.dexlib2.dexbacked.DexBackedMethod
@@ -29,6 +30,7 @@ object PreviewUtils {
 
   fun findPreviews(
     extractedApkDirectory: File,
+    includePrivatePreviews: Boolean,
     logger: Logger,
   ): ComposeSnapshots {
 
@@ -54,6 +56,13 @@ object PreviewUtils {
         }
 
         if (previewAnnotations.isEmpty()) {
+          return@forEach
+        }
+
+        if (!includePrivatePreviews && AccessFlags.PRIVATE.isSet(method.accessFlags)) {
+          logger.info(
+            "Ignoring snapshot for method: $methodKey as it is private and includePrivatePreviews is set to false"
+          )
           return@forEach
         }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/network/EmergeUploadRequest.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/network/EmergeUploadRequest.kt
@@ -30,6 +30,7 @@ data class EmergeUploadRequestData(
   val source: String,
   val androidSnapshotsEnabled: Boolean,
   val androidSnapshotsApiVersion: Int? = null,
+  val androidSnapshotsPrivateEnabled: Boolean = false,
 )
 
 @Serializable


### PR DESCRIPTION
From a bit of user feedback, some users wanted the ability to hide all previews that were private rather than adding `@IgnoreEmergeSnapshot`. This adds that functionality with a Gradle plugin property - `includePrivatePreviews`, which will default to `true`, but optionally users can set to false to exclude `@Preview` annotated functions that are `private`.

Backend component implemented separately.