### PR TITLE
Handle issue where empty bitmap could crash entire test run

### DIFF
--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -107,3 +107,8 @@ fun TextRowWithIconPreviewFromMainBg() {
     )
   }
 }
+
+@Preview
+@Composable
+fun EmptyPreview() {
+}

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -108,6 +108,8 @@ fun TextRowWithIconPreviewFromMainBg() {
   }
 }
 
+// To ensure we properly handle a 0x0 snapshot
+@Suppress("EmptyFunctionBlock")
 @Preview
 @Composable
 fun EmptyPreview() {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -81,7 +81,9 @@ fun snapshotComposable(
           height = composableSize.height,
         )
       }
-      snapshotRule.take(bitmap, previewConfig)
+      bitmap?.let {
+        snapshotRule.take(bitmap, previewConfig)
+      } ?: snapshotRule.saveError(COMPOSABLE, previewConfig)
     }
   } catch (e: Exception) {
     Log.e(
@@ -89,7 +91,10 @@ fun snapshotComposable(
       "Error invoking composable method",
       e,
     )
-    snapshotRule.saveError(COMPOSABLE, previewConfig)
+    snapshotRule.saveError(
+      COMPOSABLE,
+      previewConfig
+    )
     // Re-throw to fail the test
     throw e
   }
@@ -125,10 +130,19 @@ fun captureBitmap(
   view: View,
   width: Int,
   height: Int,
-): Bitmap {
-  val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-  val canvas = Canvas(bitmap)
-  view.layout(0, 0, width, height)
-  view.draw(canvas)
-  return bitmap
+): Bitmap? {
+  try {
+    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    view.layout(0, 0, width, height)
+    view.draw(canvas)
+    return bitmap
+  } catch (e: Exception) {
+    Log.e(
+      EmergeComposeSnapshotReflectiveParameterizedInvoker.TAG,
+      "Error capturing bitmap",
+      e,
+    )
+    return null
+  }
 }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -137,7 +137,7 @@ fun captureBitmap(
     view.layout(0, 0, width, height)
     view.draw(canvas)
     return bitmap
-  } catch (e: Exception) {
+  } catch (e: IllegalArgumentException) {
     Log.e(
       EmergeComposeSnapshotReflectiveParameterizedInvoker.TAG,
       "Error capturing bitmap",


### PR DESCRIPTION
A 0x0 bitmap could crash the entire test run if not properly caught. It seems this is due to the exception being thrown from the body of the `post` runnable, which is uncaught on a separate thread.

To better handle, we can just return a null bitmap and save an error. In a future PR I'll add more robust error handling.

Resolves ET-3433