### PR TITLE
Support device Preview annotation parameter

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/ComposeSnapshots.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/ComposeSnapshots.kt
@@ -23,4 +23,5 @@ data class ComposePreviewSnapshotConfig(
   val showBackground: Boolean?,
   val backgroundColor: Long?,
   val showSystemUi: Boolean?,
+  val device: String? = null,
 )

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/PreviewUtils.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/utils/PreviewUtils.kt
@@ -168,6 +168,7 @@ object PreviewUtils {
           showBackground = (annotation.elements.firstOrNull { it.name == "showBackground" }?.value as? BooleanEncodedValue)?.value,
           backgroundColor = (annotation.elements.firstOrNull { it.name == "backgroundColor" }?.value as? LongEncodedValue)?.value,
           showSystemUi = (annotation.elements.firstOrNull { it.name == "showSystemUi" }?.value as? BooleanEncodedValue)?.value,
+          device = (annotation.elements.firstOrNull { it.name == "device" }?.value as? StringEncodedValue)?.value,
         )
       )
 
@@ -188,6 +189,7 @@ object PreviewUtils {
             showBackground = (preview.elements.firstOrNull { it.name == "showBackground" }?.value as? BooleanEncodedValue)?.value,
             backgroundColor = (preview.elements.firstOrNull { it.name == "backgroundColor" }?.value as? LongEncodedValue)?.value,
             showSystemUi = (preview.elements.firstOrNull { it.name == "showSystemUi" }?.value as? BooleanEncodedValue)?.value,
+            device = (preview.elements.firstOrNull { it.name == "device" }?.value as? StringEncodedValue)?.value,
           )
         }.orEmpty()
       }

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -118,15 +118,15 @@ fun TextRowWithIconPreviewFromMainBg() {
 )
 @Preview(
   device = Devices.PIXEL_3,
-  heightDp = 1000,
-)
-@Preview(
-  device = Devices.PIXEL_3,
   widthDp = 1000,
 )
 @Preview(
   device = Devices.PIXEL_3,
   fontScale = 2f,
+  showSystemUi = true,
+)
+@Preview(
+  device = Devices.PIXEL_TABLET,
   showSystemUi = true,
 )
 @Composable

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.emergetools.snapshots.annotations.IgnoreEmergeSnapshot
 import com.emergetools.snapshots.sample.ui.theme.SnapshotsSampleTheme
@@ -100,6 +101,36 @@ fun TextRowWithIconPreviewFromMainIgnored() {
 )
 @Composable
 fun TextRowWithIconPreviewFromMainBg() {
+  SnapshotsSampleTheme {
+    TextRowWithIcon(
+      titleText = "Title",
+      subtitleText = "Subtitle"
+    )
+  }
+}
+
+@Preview(
+  device = Devices.PIXEL,
+)
+@Preview(
+  device = Devices.NEXUS_7_2013,
+  showSystemUi = true,
+)
+@Preview(
+  device = Devices.PIXEL_3,
+  heightDp = 1000,
+)
+@Preview(
+  device = Devices.PIXEL_3,
+  widthDp = 1000,
+)
+@Preview(
+  device = Devices.PIXEL_3,
+  fontScale = 2f,
+  showSystemUi = true,
+)
+@Composable
+fun TextRowWithIconPreviewFromMainDevices() {
   SnapshotsSampleTheme {
     TextRowWithIcon(
       titleText = "Title",

--- a/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -19,6 +19,7 @@ data class ComposePreviewSnapshotConfig(
   val showBackground: Boolean? = null,
   val backgroundColor: Long? = null,
   val showSystemUi: Boolean? = null,
+  val device: String? = null,
 ) {
 
   /**
@@ -32,7 +33,8 @@ data class ComposePreviewSnapshotConfig(
       heightDp == null &&
       showBackground == null &&
       backgroundColor == null &&
-      showSystemUi == null
+      showSystemUi == null &&
+      device == null
   }
 
   /**
@@ -53,6 +55,7 @@ data class ComposePreviewSnapshotConfig(
       showBackground?.let { append("_bg_$it") }
       backgroundColor?.let { append("_bgc_$it") }
       showSystemUi?.let { append("_sysui_$it") }
+      device?.let { append("_dev_$it") }
     }
   }
 }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -1,0 +1,294 @@
+package com.emergetools.snapshots.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import kotlin.math.abs
+
+data class DimensionSpec(
+  val widthDp: Int? = null,
+  val heightDp: Int? = null,
+  val density: Float? = null,
+  val fontScale: Float? = null,
+)
+
+data class DeviceSpec(
+  val widthPixels: Int,
+  val heightPixels: Int,
+  val densityPpi: Int,
+) {
+  // https://m3.material.io/blog/device-metrics
+  val dimensionSpec: DimensionSpec
+    get() {
+      val proportion = densityPpi / 160
+      val widthDp = widthPixels * proportion
+      val heightDp = heightPixels * proportion
+      return DimensionSpec(
+        widthDp = widthDp,
+        heightDp = heightDp,
+        density = getClosestDensityScalingFactor(densityPpi),
+      )
+    }
+
+  companion object {
+    fun getClosestDensityScalingFactor(dpi: Int): Float {
+      val densityMap = mapOf(
+        120 to 0.75f,
+        160 to 1f,
+        240 to 1.5f,
+        320 to 2f,
+        480 to 3f,
+        640 to 4f,
+      )
+
+      var closestDensityScaling = 1f
+      var smallestDifference = Int.MAX_VALUE
+
+      for ((key, value) in densityMap.entries) {
+        val difference = abs(dpi - key)
+        if (difference < smallestDifference) {
+          smallestDifference = difference
+          closestDensityScaling = value
+        }
+      }
+
+      return closestDensityScaling
+    }
+  }
+}
+
+val KNOWN_DEVICE_SPECS = mapOf<String, DeviceSpec>(
+  // https://www.gsmarena.com/asus_google_nexus_7-4850.php
+  "Nexus 7" to DeviceSpec(
+    widthPixels = 800,
+    heightPixels = 1280,
+    densityPpi = 216,
+  ),
+  // https://www.gsmarena.com/asus_google_nexus_7_(2013)-5600.php
+  "Nexus 7 2013" to DeviceSpec(
+    widthPixels = 1200,
+    heightPixels = 1920,
+    densityPpi = 323,
+  ),
+  // https://www.gsmarena.com/lg_nexus_5-5705.php
+  "Nexus 5" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 1920,
+    densityPpi = 445,
+  ),
+  // https://www.gsmarena.com/motorola_nexus_6-6604.php,
+  "Nexus 6" to DeviceSpec(
+    widthPixels = 1440,
+    heightPixels = 2560,
+    densityPpi = 493,
+  ),
+  // https://www.gsmarena.com/lg_nexus_5-5705.php
+  "Nexus 9" to DeviceSpec(
+    widthPixels = 1440,
+    heightPixels = 2560,
+    densityPpi = 518,
+  ),
+  // https://www.gsmarena.com/samsung_google_nexus_10_p8110-5084.php
+  "Nexus 10" to DeviceSpec(
+    widthPixels = 2560,
+    heightPixels = 1600,
+    densityPpi = 299,
+  ),
+  // https://www.gsmarena.com/lg_nexus_5x-7556.php
+  "Nexus 5X" to DeviceSpec(
+    widthPixels = 2560,
+    heightPixels = 1600,
+    densityPpi = 299,
+  ),
+  // https://www.gsmarena.com/huawei_nexus_6p-7588.php
+  "Nexus 6P" to DeviceSpec(
+    widthPixels = 1440,
+    heightPixels = 2560,
+    densityPpi = 518,
+  ),
+  // https://www.gsmarena.com/google_pixel_c-7826.php
+  "pixel_c" to DeviceSpec(
+    widthPixels = 2560,
+    heightPixels = 1800,
+    densityPpi = 308,
+  ),
+  // https://www.gsmarena.com/google_pixel-8346.php
+  "pixel" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 1920,
+    densityPpi = 441,
+  ),
+  // https://www.gsmarena.com/google_pixel_xl-8345.php
+  "pixel_xl" to DeviceSpec(
+    widthPixels = 1440,
+    heightPixels = 2560,
+    densityPpi = 534,
+  ),
+  // https://www.gsmarena.com/google_pixel_2-8733.php
+  "pixel_2" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 1920,
+    densityPpi = 441,
+  ),
+  // https://www.gsmarena.com/google_pixel_2_xl-8720.php
+  "pixel_2_xl" to DeviceSpec(
+    widthPixels = 1440,
+    heightPixels = 2880,
+    densityPpi = 538,
+  ),
+  // https://www.gsmarena.com/google_pixel_3-9256.php
+  "pixel_3" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 2160,
+    densityPpi = 443,
+  ),
+  // https://www.gsmarena.com/google_pixel_3_xl-9257.php
+  "pixel_3_xl" to DeviceSpec(
+    widthPixels = 1440,
+    heightPixels = 2960,
+    densityPpi = 523,
+  ),
+  // https://www.gsmarena.com/google_pixel_3a-9408.php
+  "pixel_3a" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 2220,
+    densityPpi = 441,
+  ),
+  // https://www.gsmarena.com/google_pixel_3a_xl-9690.php
+  "pixel_3a_xl" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 2160,
+    densityPpi = 402,
+  ),
+  // https://www.gsmarena.com/google_pixel_4-9896.php
+  "pixel_4" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 2280,
+    densityPpi = 444,
+  ),
+  // https://www.gsmarena.com/google_pixel_4_xl-9895.php
+  "pixel_4_xl" to DeviceSpec(
+    widthPixels = 1440,
+    heightPixels = 3040,
+    densityPpi = 537,
+  ),
+  // https://www.gsmarena.com/google_pixel_4a-10123.php
+  "pixel_4a" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 2340,
+    densityPpi = 443,
+  ),
+  // https://www.gsmarena.com/google_pixel_5-10386.php
+  "pixel_5" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 2340,
+    densityPpi = 432,
+  ),
+  // https://www.gsmarena.com/google_pixel_6-11037.php
+  "pixel_6" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 2400,
+    densityPpi = 411,
+  ),
+  // https://www.gsmarena.com/google_pixel_6_pro-10918.php
+  "pixel_6_pro" to DeviceSpec(
+    widthPixels = 1440,
+    heightPixels = 3120,
+    densityPpi = 512,
+  ),
+  // https://www.gsmarena.com/google_pixel_6a-11229.php
+  "pixel_6a" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 2400,
+    densityPpi = 429,
+  ),
+  // https://www.gsmarena.com/google_pixel_7-11903.php
+  "pixel_7" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 2400,
+    densityPpi = 416,
+  ),
+  // https://www.gsmarena.com/google_pixel_7_pro-11908.php
+  "pixel_7_pro" to DeviceSpec(
+    widthPixels = 1440,
+    heightPixels = 3120,
+    densityPpi = 512,
+  ),
+  // https://www.gsmarena.com/google_pixel_7a-12170.php
+  "pixel_7a" to DeviceSpec(
+    widthPixels = 1080,
+    heightPixels = 2400,
+    densityPpi = 429,
+  ),
+  // https://www.gsmarena.com/google_pixel_fold-12265.php
+  "pixel_fold" to DeviceSpec(
+    widthPixels = 1840,
+    heightPixels = 2208,
+    densityPpi = 378,
+  ),
+  // https://www.gsmarena.com/google_pixel_tablet-11905.php
+  "pixel_tablet" to DeviceSpec(
+    widthPixels = 2560,
+    heightPixels = 1600,
+    densityPpi = 276,
+  ),
+)
+
+@Composable
+fun configToDimensionSpec(
+  device: String?,
+  config: ComposePreviewSnapshotConfig,
+): DimensionSpec {
+  val devicePreviewString = parseDevicePreviewString(device)
+  val dimensionSpec: DimensionSpec? = when {
+    devicePreviewString?.name != null -> KNOWN_DEVICE_SPECS[devicePreviewString.name]?.dimensionSpec
+    devicePreviewString?.id != null -> KNOWN_DEVICE_SPECS[devicePreviewString.id]?.dimensionSpec
+    else -> DimensionSpec(
+      widthDp = devicePreviewString?.widthDp,
+      heightDp = devicePreviewString?.heightDp,
+      density = devicePreviewString?.dpi?.let(DeviceSpec::getClosestDensityScalingFactor)
+    )
+  }
+
+  // Override final values with those specified by user (width/height), and use the default values if not specified
+  return DimensionSpec(
+    widthDp = config.widthDp ?: dimensionSpec?.widthDp,
+    heightDp = config.heightDp ?: dimensionSpec?.heightDp,
+    fontScale = config.fontScale,
+    density = dimensionSpec?.density,
+  )
+}
+
+data class DevicePreviewString(
+  val type: String,
+  val id: String? = null,
+  val name: String? = null,
+  val widthDp: Int? = null,
+  val heightDp: Int? = null,
+  val dpi: Int? = null
+)
+
+fun parseDevicePreviewString(deviceString: String?): DevicePreviewString? {
+  if (deviceString.isNullOrEmpty()) return null
+
+  val devicePattern = Regex(
+    """(id:(?<id>[a-zA-Z0-9_ ]+))|(name:(?<name>[a-zA-Z0-9_ ]+))|(spec:id=(?<specId>[a-zA-Z0-9_]+),shape=(?<shape>[a-zA-Z0-9_]+),width=(?<width>\d+),height=(?<height>\d+),unit=(?<unit>[a-zA-Z]+),dpi=(?<dpi>\d+))"""
+  )
+
+  val matchResult = devicePattern.matchEntire(deviceString)
+  return matchResult?.let { result ->
+    val groups = result.groups
+    when {
+      groups["id"]?.value != null -> DevicePreviewString(type = "id", id = groups["id"]?.value)
+      groups["name"]?.value != null -> DevicePreviewString(type = "name", name = groups["name"]?.value)
+      groups["specId"]?.value != null -> DevicePreviewString(
+        type = "spec",
+        id = groups["specId"]?.value,
+        widthDp = groups["width"]?.value?.toInt(),
+        heightDp = groups["height"]?.value?.toInt(),
+        dpi = groups["dpi"]?.value?.toInt(),
+      )
+      else -> null
+    }
+  }
+}

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -62,15 +62,15 @@ fun SnapshotVariantProvider(
     values = providedValues.toList().toTypedArray(),
   ) {
     val modifier = Modifier
-        .then(dimensionSpec.widthDp?.let { Modifier.width(it.dp) } ?: Modifier)
-        .then(dimensionSpec.heightDp?.let { Modifier.height(it.dp) } ?: Modifier)
-        .then(
-            config.showBackground?.let {
-                // By default, previews use White as the background color, so preserve behavior.
-                val color = config.backgroundColor?.let { Color(it) } ?: Color.White
-                Modifier.background(color)
-            } ?: Modifier
-        )
+      .then(dimensionSpec.widthDp?.let { Modifier.width(it.dp) } ?: Modifier)
+      .then(dimensionSpec.heightDp?.let { Modifier.height(it.dp) } ?: Modifier)
+      .then(
+        config.showBackground?.let {
+          // By default, previews use White as the background color, so preserve behavior.
+          val color = config.backgroundColor?.let { Color(it) } ?: Color.White
+          Modifier.background(color)
+        } ?: Modifier
+      )
 
     Box(modifier = modifier) {
       content()

--- a/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/compose/DeviceUtilsTest.kt
+++ b/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/compose/DeviceUtilsTest.kt
@@ -1,8 +1,5 @@
 package com.emergetools.snapshots.compose
 
-import com.emergetools.snapshots.compose.DevicePreviewString
-import com.emergetools.snapshots.compose.DeviceSpec
-import com.emergetools.snapshots.compose.parseDevicePreviewString
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/compose/DeviceUtilsTest.kt
+++ b/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/compose/DeviceUtilsTest.kt
@@ -1,0 +1,57 @@
+package com.emergetools.snapshots.compose
+
+import com.emergetools.snapshots.compose.DevicePreviewString
+import com.emergetools.snapshots.compose.DeviceSpec
+import com.emergetools.snapshots.compose.parseDevicePreviewString
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeviceUtilsTest {
+
+  @Test
+  fun `test properly gets closest density scaling factors`() {
+    val testCases = listOf(
+      120 to 0.75f,
+      160 to 1f,
+      240 to 1.5f,
+      320 to 2f,
+      480 to 3f,
+      640 to 4f,
+      100 to 0.75f,
+      150 to 1f,
+      220 to 1.5f,
+      290 to 2f,
+      500 to 3f,
+      700 to 4f
+    )
+
+    for ((input, expected) in testCases) {
+      val result = DeviceSpec.getClosestDensityScalingFactor(input)
+      assertEquals(expected, result)
+    }
+  }
+
+  @Test
+  fun `test properly parses device preview strings`() {
+    val testCases = listOf(
+      "id:Nexus 7" to DevicePreviewString(type = "id", id = "Nexus 7"),
+      "id:Nexus 7 2013" to DevicePreviewString(type = "id", id = "Nexus 7 2013"),
+      "name:Nexus 10" to DevicePreviewString(type = "name", name = "Nexus 10"),
+      "spec:id=reference_phone,shape=Normal,width=411,height=891,unit=dp,dpi=420" to DevicePreviewString(
+        type = "spec",
+        id = "reference_phone",
+        widthDp = 411,
+        heightDp = 891,
+        dpi = 420
+      ),
+      null to null,
+      "" to null,
+      "invalid string" to null
+    )
+
+    for ((input, expected) in testCases) {
+      val result = parseDevicePreviewString(input)
+      assertEquals(expected, result)
+    }
+  }
+}


### PR DESCRIPTION
Adds support for the `device` Preview annotation parameter.

Leverages a regex to parse custom values, or cross-references a known ID->device spec map that uses https://m3.material.io/blog/device-metrics to calculate the proper width/height dp and scaling factor.