### PR TITLE
Temporarily remove showSystemUi

### DIFF
--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -68,20 +68,11 @@ fun snapshotComposable(
     composeView.post {
       // Measure the composable agnostic of the parent constraints to layout properly in activity
       val composableSize = measureComposableSize(composeView, previewConfig)
-      val bitmap = if (previewConfig.showSystemUi == true && previewConfig.device == null) {
-        val rootView = activity.window.decorView.rootView
-        captureBitmap(
-          view = rootView,
-          width = rootView.width,
-          height = rootView.height,
-        )
-      } else {
-        captureBitmap(
-          view = composeView,
-          width = composableSize.width,
-          height = composableSize.height,
-        )
-      }
+      val bitmap = captureBitmap(
+        view = composeView,
+        width = composableSize.width,
+        height = composableSize.height,
+      )
       bitmap?.let {
         snapshotRule.take(bitmap, previewConfig)
       } ?: run {
@@ -121,7 +112,8 @@ private fun measureComposableSize(
       // Override the width and height if set in preview annotation
       val deviceDpScale = deviceSpec.densityPpi / DEFAULT_DENSITY_PPI
       val widthPixels = previewConfig.widthDp?.let { it * deviceDpScale } ?: deviceSpec.widthPixels
-      val heightPixels = previewConfig.heightDp?.let { it * deviceDpScale } ?: deviceSpec.heightPixels
+      val heightPixels =
+        previewConfig.heightDp?.let { it * deviceDpScale } ?: deviceSpec.heightPixels
       Log.i(
         EmergeComposeSnapshotReflectiveParameterizedInvoker.TAG,
         "Measuring composable with device dimensions: $widthPixels x $heightPixels"


### PR DESCRIPTION
Now that devices are up to spec, our implementation of showSystemUI no longer works when used in tandem with `device`. 

Until we can come along with a full solution, we'll temporarily disable our custom handling. This should result in the snapshots still succeeding, albeit without the surrounding system UI. We'll plan a full fix for `showSystemUI` in a later release of snapshots.