### PR TITLE
Fix snapshot workflow to always run on main pushes

### DIFF
--- a/.github/workflows/snapshots-sample-app.yml
+++ b/.github/workflows/snapshots-sample-app.yml
@@ -1,12 +1,9 @@
 name: snapshots sample app
 
 on:
+  # Intentionally run on all pushes to main branch to ensure we always have a base build with snapshots
   push:
     branches: [ main ]
-    paths:
-      - gradle/**
-      - gradle-plugin/**
-      - snapshots/**
   pull_request:
     branches: [ main ]
     paths:


### PR DESCRIPTION
Noticed in #216 we're missing a base snapshots build, as the commit it's based off of didn't touch snapshots code and therefore didn't run snapshots. 

This fixes the sample snapshots workflow to always run on main pushes to ensure we always have a valid build.