### PR TITLE
[Gradle plugin][Reaper] Hook default bundle task rather than having explicit initialize task

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/InitializeReaper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/InitializeReaper.kt
@@ -41,9 +41,9 @@ abstract class InitializeReaper : BaseUploadTask() {
     checkNotNull(response) {
       "Upload failed, please check your network connection and try again. ${response.toString()}"
     }
-    logger.lifecycle("Reaper initialized. View Reaper status at the url:")
+    logger.lifecycle("Reaper initialized! View Reaper reports at the url:")
     logger.lifecycle("https://emergetools.com/reaper/${response.uploadId}")
-    logger.lifecycle("Reaper processing can take up to 10 minutes.")
+    logger.lifecycle("Initial processing can take up to 10 minutes.")
   }
 
   companion object {


### PR DESCRIPTION
Rather than having an explicit initialize task, I figured we could have the initialize (upload) task "hook" the default `bundle` AGP task. That way users can build their AAB as-is but we'll handle the uploading side of things.