### PR TITLE
[Gradle plugin] Cleanup and move task registration logic into separate files in relevant packages

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/Register.kt
@@ -1,0 +1,128 @@
+package com.emergetools.android.gradle.tasks.perf
+
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.ApplicationVariant
+import com.android.build.api.variant.TestVariant
+import com.android.build.api.variant.Variant
+import com.android.build.gradle.internal.tasks.factory.dependsOn
+import com.emergetools.android.gradle.EmergePlugin.Companion.EMERGE_TASK_PREFIX
+import com.emergetools.android.gradle.EmergePluginExtension
+import com.emergetools.android.gradle.tasks.upload.BaseUploadTask.Companion.setTagFromProductOptions
+import com.emergetools.android.gradle.tasks.upload.BaseUploadTask.Companion.setUploadTaskInputs
+import com.emergetools.android.gradle.util.capitalize
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+
+const val EMERGE_PERFORMANCE_TASK_GROUP = "Emerge performance"
+
+fun registerPerformanceTasks(
+  appProject: Project,
+  performanceProject: Project,
+  extension: EmergePluginExtension,
+  perfVariant: TestVariant,
+  appVariants: List<ApplicationVariant>,
+) {
+  appProject.logger.debug(
+    "Registering performance tasks for variant ${perfVariant.name} in project ${appProject.path}"
+  )
+
+  // We're not concerned with the variants of the performance project, rather the app variants,
+  // generate a perf task for each app variant for the single debug variant of the perf project.
+  appVariants.forEach { appVariant ->
+    registerEmergeLocalTestTask(appProject, performanceProject, appVariant, perfVariant)
+    registerUploadPerfBundleTask(
+      appProject, performanceProject, appVariant, perfVariant, extension
+    )
+  }
+}
+
+private fun registerUploadPerfBundleTask(
+  appProject: Project,
+  performanceProject: Project,
+  appVariant: Variant,
+  performanceVariant: TestVariant,
+  extension: EmergePluginExtension,
+) {
+  val taskName = "${EMERGE_TASK_PREFIX}Upload${appVariant.name.capitalize()}PerfBundle"
+  appProject.tasks.register(taskName, UploadPerfBundle::class.java) {
+    it.group = EMERGE_PERFORMANCE_TASK_GROUP
+    it.description = "Builds & uploads an AAB for variant ${appVariant.name} to " +
+      "Emerge with ${performanceProject.name} test APK."
+    it.artifact.set(appVariant.artifacts.get(SingleArtifact.BUNDLE))
+    it.perfArtifactDir.set(performanceVariant.artifacts.get(SingleArtifact.APK))
+    it.setUploadTaskInputs(extension, appProject, appVariant)
+    it.setTagFromProductOptions(extension.perfOptions, appVariant)
+  }
+}
+
+private fun registerEmergeLocalTestTask(
+  appProject: Project,
+  performanceProject: Project,
+  appVariant: ApplicationVariant,
+  performanceVariant: TestVariant,
+) {
+  val appVariantName = appVariant.name.capitalize()
+  val perfVariantName = performanceVariant.name.capitalize()
+
+  val taskName = "emergeLocal${appVariantName}Test"
+  val task = appProject.tasks.register(taskName, LocalPerfTest::class.java) {
+    it.group = EMERGE_PERFORMANCE_TASK_GROUP
+    it.description = "Installs and runs tests for ${performanceVariant.name} on" +
+      " connected devices. For testing and debugging."
+    it.appPackageName.set(appVariant.applicationId)
+    it.testPackageName.set(performanceVariant.namespace)
+  }
+
+  val uninstallAppTaskPath = "${appProject.path}:uninstall$appVariantName"
+  val installAppTaskPath = "${appProject.path}:install$appVariantName"
+
+  // We need the uninstall task to run first but don't want to enforce that
+  // order unless the local test task is actually being run
+  if (appProject.project.gradle.startParameter.taskNames.any { it.contains(taskName) }) {
+    appProject.tasks.all {
+      if (it.path == installAppTaskPath) {
+        it.shouldRunAfter(uninstallAppTaskPath)
+      }
+    }
+  }
+
+  task.dependsOn(uninstallAppTaskPath)
+  task.dependsOn(installAppTaskPath)
+  task.dependsOn("${performanceProject.path}:install$perfVariantName")
+}
+
+fun registerGeneratePerfProjectTask(
+  appProject: Project,
+  performanceProjectPath: Property<String>,
+  appVariants: List<ApplicationVariant>,
+) {
+  appProject.logger.debug(
+    "Registering generate perf project tasks in project ${appProject.path}"
+  )
+
+  val rootDir = appProject.rootDir
+  appProject.tasks.register("emergeGeneratePerformanceProject", GeneratePerfProject::class.java) {
+    it.group = EMERGE_PERFORMANCE_TASK_GROUP
+    it.description = "Generates a new performance testing project."
+    it.appPackageName.set(
+      appProject.provider {
+        if (appVariants.isEmpty()) return@provider null
+        val appVariant =
+          appVariants.find { appVariant -> appVariant.name == "release" } ?: appVariants.first()
+        appVariant.applicationId.get()
+      }
+    )
+    it.performanceProjectPath.set(performanceProjectPath)
+    it.rootDir.set(rootDir)
+    rootDir.resolve("settings.gradle.kts").let { settingsKtsFile ->
+      if (settingsKtsFile.exists()) {
+        it.gradleSettingsFile.set(settingsKtsFile)
+      }
+    }
+    rootDir.resolve("settings.gradle").let { settingsFile ->
+      if (settingsFile.exists()) {
+        it.gradleSettingsFile.set(settingsFile)
+      }
+    }
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/Register.kt
@@ -1,0 +1,72 @@
+package com.emergetools.android.gradle.tasks.reaper
+
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.Variant
+import com.emergetools.android.gradle.EmergePlugin.Companion.EMERGE_TASK_PREFIX
+import com.emergetools.android.gradle.EmergePluginExtension
+import com.emergetools.android.gradle.tasks.upload.BaseUploadTask.Companion.setTagFromProductOptions
+import com.emergetools.android.gradle.tasks.upload.BaseUploadTask.Companion.setUploadTaskInputs
+import com.emergetools.android.gradle.util.capitalize
+import org.gradle.api.Project
+
+const val EMERGE_REAPER_TASK_GROUP = "Emerge reaper"
+
+fun registerReaperTasks(
+  appProject: Project,
+  extension: EmergePluginExtension,
+  variant: Variant,
+) {
+  appProject.logger.debug(
+    "Registering reaper tasks for variant ${variant.name} in project ${appProject.path}"
+  )
+
+  registerReaperPreflightTask(appProject, extension, variant)
+  // Only register upload task if Reaper is enabled
+  if (extension.reaperOptions.enabled.getOrElse(false)) {
+    registerReaperUploadTask(appProject, extension, variant)
+  }
+}
+
+private fun registerReaperPreflightTask(
+  appProject: Project,
+  extension: EmergePluginExtension,
+  variant: Variant,
+) {
+  val preflightTaskName = "${EMERGE_TASK_PREFIX}ValidateReaper${variant.name.capitalize()}"
+  appProject.tasks.register(preflightTaskName, PreflightReaper::class.java) {
+    it.group = EMERGE_REAPER_TASK_GROUP
+    it.description = "Validate Reaper is properly set up for variant ${variant.name}"
+    it.reaperEnabled.set(extension.reaperOptions.enabled)
+    it.reaperPublishableApiKey.set(extension.reaperOptions.publishableApiKey)
+    it.mergedManifestFile.set(variant.artifacts.get(SingleArtifact.MERGED_MANIFEST))
+
+    // We want preflight to happen pretty early so we can detect error conditions and give them
+    // nice messages. Specifically we need it to occur prior to 'linking' steps which we detect
+    // that the Reaper added instrumentation calls methods in the SDK to avoid confusing error
+    // messages.
+    val minifyTaskName = "minify${variant.name.capitalize()}WithR8"
+    val minifyTasks = appProject.getTasksByName(minifyTaskName, false)
+    if (minifyTasks.size != 0) {
+      minifyTasks.forEach { minifyTask -> minifyTask.dependsOn(it) }
+    }
+  }
+}
+
+private fun registerReaperUploadTask(
+  appProject: Project,
+  extension: EmergePluginExtension,
+  variant: Variant,
+) {
+  val uploadReaperAabTaskName = "${EMERGE_TASK_PREFIX}UploadReaperAab${variant.name.capitalize()}"
+  val uploadReaperAabTask =
+    appProject.tasks.register(uploadReaperAabTaskName, InitializeReaper::class.java) {
+      it.artifact.set(variant.artifacts.get(SingleArtifact.BUNDLE))
+      it.setUploadTaskInputs(extension, appProject, variant)
+      it.setTagFromProductOptions(extension.reaperOptions, variant)
+    }
+  // Hook the bundle tasks to run the reaper upload task after they complete.
+  appProject.afterEvaluate { project ->
+    val bundleTask = project.tasks.named("bundle${variant.name.capitalize()}")
+    bundleTask.configure { it.finalizedBy(uploadReaperAabTask) }
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/Register.kt
@@ -1,0 +1,58 @@
+package com.emergetools.android.gradle.tasks.size
+
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.Variant
+import com.emergetools.android.gradle.EmergePlugin.Companion.EMERGE_TASK_PREFIX
+import com.emergetools.android.gradle.EmergePluginExtension
+import com.emergetools.android.gradle.tasks.upload.BaseUploadTask.Companion.setTagFromProductOptions
+import com.emergetools.android.gradle.tasks.upload.BaseUploadTask.Companion.setUploadTaskInputs
+import com.emergetools.android.gradle.util.capitalize
+import org.gradle.api.Project
+
+const val EMERGE_SIZE_TASK_GROUP = "Emerge size analysis"
+
+fun registerSizeTasks(
+  appProject: Project,
+  extension: EmergePluginExtension,
+  variant: Variant,
+) {
+  appProject.logger.debug(
+    "Registering size tasks for variant ${variant.name} in project ${appProject.path}"
+  )
+
+  registerUploadAPKTask(appProject, extension, variant)
+  registerUploadAABTask(appProject, extension, variant)
+}
+
+private fun registerUploadAPKTask(
+  appProject: Project,
+  extension: EmergePluginExtension,
+  variant: Variant,
+) {
+  val taskName = "${EMERGE_TASK_PREFIX}Upload${variant.name.capitalize()}Apk"
+
+  appProject.tasks.register(taskName, UploadAPK::class.java) {
+    it.group = EMERGE_SIZE_TASK_GROUP
+    it.description = "Builds and uploads an APK for variant ${variant.name} to Emerge."
+    it.artifactDir.set(variant.artifacts.get(SingleArtifact.APK))
+    it.proguardMapping.set(variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE))
+    it.setUploadTaskInputs(extension, appProject, variant)
+    it.setTagFromProductOptions(extension.sizeOptions, variant)
+  }
+}
+
+private fun registerUploadAABTask(
+  appProject: Project,
+  extension: EmergePluginExtension,
+  variant: Variant,
+) {
+  val taskName = "${EMERGE_TASK_PREFIX}Upload${variant.name.capitalize()}Aab"
+
+  appProject.tasks.register(taskName, UploadAAB::class.java) {
+    it.group = EMERGE_SIZE_TASK_GROUP
+    it.description = "Builds and uploads an AAB for variant ${variant.name} to Emerge."
+    it.artifact.set(variant.artifacts.get(SingleArtifact.BUNDLE))
+    it.setUploadTaskInputs(extension, appProject, variant)
+    it.setTagFromProductOptions(extension.sizeOptions, variant)
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
@@ -1,0 +1,128 @@
+package com.emergetools.android.gradle.tasks.snapshots
+
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.instrumentation.InstrumentationScope
+import com.android.build.api.variant.AndroidTest
+import com.android.build.api.variant.ApplicationVariant
+import com.emergetools.android.gradle.EmergePlugin.Companion.BUILD_OUTPUT_DIR_NAME
+import com.emergetools.android.gradle.EmergePlugin.Companion.EMERGE_TASK_PREFIX
+import com.emergetools.android.gradle.EmergePluginExtension
+import com.emergetools.android.gradle.instrumentation.snapshots.SnapshotsPreviewRuntimeRetentionTransformFactory
+import com.emergetools.android.gradle.tasks.upload.ArtifactMetadata
+import com.emergetools.android.gradle.tasks.upload.BaseUploadTask.Companion.setTagFromProductOptions
+import com.emergetools.android.gradle.tasks.upload.BaseUploadTask.Companion.setUploadTaskInputs
+import com.emergetools.android.gradle.util.AgpVersions
+import com.emergetools.android.gradle.util.capitalize
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+
+const val EMERGE_SNAPSHOTS_TASK_GROUP = "Emerge snapshots"
+
+fun registerSnapshotTasks(
+  appProject: Project,
+  extension: EmergePluginExtension,
+  variant: ApplicationVariant,
+  androidTest: AndroidTest,
+) {
+  appProject.logger.debug(
+    "Registering snapshot tasks for variant ${variant.name} in project ${appProject.path}"
+  )
+
+  variant.instrumentation.let { instrumentation ->
+    instrumentation.transformClassesWith(
+      SnapshotsPreviewRuntimeRetentionTransformFactory::class.java,
+      InstrumentationScope.ALL,
+    ) { params ->
+      // Force invalidate/reinstrument classes if debug option is set
+      if (extension.debugOptions.forceInstrumentation.getOrElse(false)) {
+        params.invalidate.set(System.currentTimeMillis())
+      }
+    }
+  }
+
+  val snapshotPackageTask = registerSnapshotPackageTask(appProject, variant, androidTest)
+  registerSnapshotLocalTask(appProject, extension, variant, androidTest, snapshotPackageTask)
+  registerSnapshotUploadTask(appProject, extension, variant, snapshotPackageTask)
+}
+
+private fun registerSnapshotPackageTask(
+  appProject: Project,
+  variant: ApplicationVariant,
+  androidTest: AndroidTest,
+): TaskProvider<PackageSnapshotArtifacts> {
+  val variantName = variant.name.capitalize()
+
+  val taskName = "${EMERGE_TASK_PREFIX}Package${variantName}SnapshotArtifacts"
+  return appProject.tasks.register(taskName, PackageSnapshotArtifacts::class.java) {
+    it.artifactDir.set(variant.artifacts.get(SingleArtifact.APK))
+    it.testArtifactDir.set(androidTest.artifacts.get(SingleArtifact.APK))
+    it.outputDirectory.set(
+      appProject.layout.buildDirectory.dir("$BUILD_OUTPUT_DIR_NAME/snapshots/artifacts")
+    )
+    it.artifactMetadataPath.set(
+      appProject.layout.buildDirectory.file(
+        "$BUILD_OUTPUT_DIR_NAME/snapshots/artifacts/${ArtifactMetadata.JSON_FILE_NAME}"
+      )
+    )
+    it.agpVersion.set(AgpVersions.CURRENT.toString())
+  }
+}
+
+private fun registerSnapshotLocalTask(
+  appProject: Project,
+  extension: EmergePluginExtension,
+  variant: ApplicationVariant,
+  androidTest: AndroidTest,
+  packageTask: TaskProvider<PackageSnapshotArtifacts>,
+) {
+  val variantName = variant.name.capitalize()
+
+  val buildDirectory = appProject.layout.buildDirectory
+  val snapshotStorageDirectory = extension.snapshotOptions.snapshotsStorageDirectory.orElse(
+    buildDirectory.dir("$BUILD_OUTPUT_DIR_NAME/snapshots/outputs")
+  )
+
+  val targetAppId = variant.applicationId
+  val testAppId = androidTest.applicationId
+  val testInstrumentationRunner = androidTest.instrumentationRunner
+
+  val taskName = "${EMERGE_TASK_PREFIX}LocalSnapshots$variantName"
+  appProject.tasks.register(taskName, LocalSnapshots::class.java) {
+    it.group = EMERGE_SNAPSHOTS_TASK_GROUP
+    it.description = "Generate snapshots locally for variant $variantName." +
+      " Requires a device or emulator connected."
+    it.packageDir.set(packageTask.flatMap { packageTask -> packageTask.outputDirectory })
+    it.snapshotStorageDirectory.set(snapshotStorageDirectory)
+    it.previewExtractDir.set(buildDirectory.dir("$BUILD_OUTPUT_DIR_NAME/previews"))
+    it.targetAppId.set(targetAppId)
+    it.testAppId.set(testAppId)
+    it.testInstrumentationRunner.set(testInstrumentationRunner)
+    it.includePrivatePreviews.set(extension.snapshotOptions.includePrivatePreviews)
+    it.dependsOn(packageTask)
+  }
+}
+
+private fun registerSnapshotUploadTask(
+  appProject: Project,
+  extension: EmergePluginExtension,
+  variant: ApplicationVariant,
+  packageTask: TaskProvider<PackageSnapshotArtifacts>,
+) {
+  val variantName = variant.name.capitalize()
+
+  val taskName = "${EMERGE_TASK_PREFIX}UploadSnapshotBundle${variantName}"
+  appProject.tasks.register(taskName, UploadSnapshotBundle::class.java) {
+    it.group = EMERGE_SNAPSHOTS_TASK_GROUP
+    it.description = "Builds and uploads a snapshot bundle to Emerge. Snapshots will be" +
+      " generated on Emerge's cloud infrastructure and diffed based on the vcs params set" +
+      " in the Emerge plugin extension."
+    it.packageDir.set(packageTask.flatMap { packageTask -> packageTask.outputDirectory })
+    it.artifactMetadataPath.set(
+      packageTask.flatMap { packageTask -> packageTask.artifactMetadataPath })
+    it.apiVersion.set(extension.snapshotOptions.apiVersion)
+    it.includePrivatePreviews.set(extension.snapshotOptions.includePrivatePreviews)
+    it.setUploadTaskInputs(extension, appProject, variant)
+    it.setTagFromProductOptions(extension.snapshotOptions, variant)
+    it.dependsOn(packageTask)
+  }
+}


### PR DESCRIPTION
`EmergePlugin` was getting a bit large/hard to navigate, so I figured moving the task registration logic to the respective packages seems to make sense to me.

Additionally, this groups the tasks by their respective product when running the `:project:tasks` task to make it easier to find the relevant task a user needs to invoke.
<img width="1055" alt="Screenshot 2024-08-06 at 9 14 50 PM" src="https://github.com/user-attachments/assets/a585d685-8597-4142-8adc-613643f769eb">
