### PR TITLE
Better handle dryRun

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/UploadPerfBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/UploadPerfBundle.kt
@@ -65,16 +65,13 @@ abstract class UploadPerfBundle : BaseUploadTask() {
       proguardMappingsZipPath = "$artifactName/${UploadAAB.AAB_PROGUARD_PATH}",
     )
 
-    val response = upload(artifactMetadata)
-    checkNotNull(response) {
-      "Upload failed, please check your network connection and try again."
+    upload(artifactMetadata) { response ->
+      logger.lifecycle(
+        "Performance bundle upload successful! " +
+          "View Emerge's performance analysis at the following url:"
+      )
+      logger.lifecycle("https://emergetools.com/performance/compare/${response.uploadId}")
+      logger.lifecycle("Performance testing usually takes around 30 minutes or less.")
     }
-
-    logger.lifecycle(
-      "Performance bundle upload successful! " +
-        "View Emerge's performance analysis at the following url:"
-    )
-    logger.lifecycle("https://emergetools.com/build/${response.uploadId}?buildContent=comparison")
-    logger.lifecycle("Performance testing usually takes around 30 minutes or less.")
   }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/InitializeReaper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/InitializeReaper.kt
@@ -37,13 +37,11 @@ abstract class InitializeReaper : BaseUploadTask() {
       proguardMappingsZipPath = "$artifactName/$AAB_PROGUARD_PATH",
     )
 
-    val response = upload(artifactMetadata)
-    checkNotNull(response) {
-      "Upload failed, please check your network connection and try again. ${response.toString()}"
+    upload(artifactMetadata) { response ->
+      logger.lifecycle("Reaper initialized! View Reaper reports for this version at the following url:")
+      logger.lifecycle("https://emergetools.com/reaper/${response.uploadId}")
+      logger.lifecycle("Note: Initial Reaper processing can take up to 10 minutes.")
     }
-    logger.lifecycle("Reaper initialized! View Reaper reports at the url:")
-    logger.lifecycle("https://emergetools.com/reaper/${response.uploadId}")
-    logger.lifecycle("Initial processing can take up to 10 minutes.")
   }
 
   companion object {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAAB.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAAB.kt
@@ -37,14 +37,11 @@ abstract class UploadAAB : BaseUploadTask() {
       proguardMappingsZipPath = "$artifactName/$AAB_PROGUARD_PATH",
     )
 
-    val response = upload(artifactMetadata)
-    checkNotNull(response) {
-      "Upload failed, please check your network connection and try again. ${response.toString()}"
+    upload(artifactMetadata) { response ->
+      logger.lifecycle("AAB Upload successful! View Emerge's size analysis at the following url:")
+      logger.lifecycle("https://emergetools.com/build/${response.uploadId}")
+      logger.lifecycle("Size processing can take up to 10 minutes.")
     }
-
-    logger.lifecycle("AAB Upload successful! View Emerge's size analysis at the following url:")
-    logger.lifecycle("https://emergetools.com/build/${response.uploadId}")
-    logger.lifecycle("Size processing can take up to 10 minutes.")
   }
 
   companion object {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAPK.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAPK.kt
@@ -65,14 +65,11 @@ abstract class UploadAPK : BaseUploadTask() {
       proguardMappingsZipPath = proguardMappingName,
     )
 
-    val response = upload(artifactMetadata)
-    checkNotNull(response) {
-      "Upload failed, please check your network connection and try again."
+    upload(artifactMetadata) { response ->
+      logger.lifecycle("APK Upload successful! View Emerge's size analysis at the following url:")
+      logger.lifecycle("https://emergetools.com/build/${response.uploadId}")
+      logger.lifecycle("Size processing can take up to 10 minutes.")
     }
-
-    logger.lifecycle("APK Upload successful! View Emerge's size analysis at the following url:")
-    logger.lifecycle("https://emergetools.com/build/${response.uploadId}")
-    logger.lifecycle("Size processing can take up to 10 minutes.")
   }
 
   companion object {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
@@ -83,20 +83,17 @@ abstract class UploadSnapshotBundle : BaseUploadTask() {
     }
     val artifactMetadata: ArtifactMetadata = Json.decodeFromString(artifactMetadataFilePath.readText())
 
-    val response = upload(
+    upload(
       artifactMetadata = artifactMetadata.copy(
         created = Clock.System.now()
       )
-    )
-    checkNotNull(response) {
-      "Upload failed, please check your network connection and try again."
+    ) { response ->
+      logger.lifecycle(
+        "Snapshot bundle upload successful! View snapshots at the following url:"
+      )
+      logger.lifecycle("https://emergetools.com/snapshot/${response.uploadId}")
+      logger.lifecycle("Snapshot generations usually take ~10 minutes or less.")
     }
-
-    logger.lifecycle(
-      "Snapshot bundle upload successful! View snapshots at the following url:"
-    )
-    logger.lifecycle("https://emergetools.com/snapshot/${response.uploadId}")
-    logger.lifecycle("Snapshot generations usually take ~10 minutes or less.")
   }
 
   companion object {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
@@ -109,7 +109,10 @@ abstract class BaseUploadTask : DefaultTask() {
   @get:Optional
   abstract val baseUrl: Property<String>
 
-  protected fun upload(artifactMetadata: ArtifactMetadata, onUpload: (EmergeUploadResponse) -> Unit) {
+  protected fun upload(
+    artifactMetadata: ArtifactMetadata,
+    onSuccessfulUpload: (EmergeUploadResponse) -> Unit,
+  ) {
     check(!apiToken.getOrElse(System.getenv(DEFAULT_API_TOKEN_ENV_KEY)).isNullOrBlank()) {
       "Missing API token. Please set the 'apiToken' property in the emerge {} extension block or" +
         " ensure an 'EMERGE_API_TOKEN' environment variable is set with a valid API token." +
@@ -185,7 +188,7 @@ abstract class BaseUploadTask : DefaultTask() {
       it.createNewFile()
       it.writeText(Json.encodeToString(response))
     }
-    onUpload(response)
+    onSuccessfulUpload(response)
   }
 
   /**
@@ -256,7 +259,8 @@ abstract class BaseUploadTask : DefaultTask() {
       project: Project,
       variant: Variant,
     ) {
-      val emergeOutputDir = File(project.layout.buildDirectory.asFile.get(), ARTIFACT_OUTPUT_DIR).also(File::mkdirs)
+      val emergeOutputDir =
+        File(project.layout.buildDirectory.asFile.get(), ARTIFACT_OUTPUT_DIR).also(File::mkdirs)
       dryRun.set(extension.dryRun)
       apiToken.set(extension.apiToken)
       agpVersion.set(AgpVersions.CURRENT.toString())

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/upload/BaseUploadTask.kt
@@ -171,9 +171,10 @@ abstract class BaseUploadTask : DefaultTask() {
       }
     }
 
-    if (dryRun.get()) {
-      zipFile.copyTo(File(outputDir, "/${zipFile.name}"), overwrite = true)
-      logger.lifecycle("Dry run complete. Zip file created at: ${zipFile.path}")
+    if (dryRun.getOrElse(false)) {
+      val outputFilePath = File(outputDir, zipFile.name)
+      zipFile.copyTo(outputFilePath, overwrite = true)
+      logger.lifecycle("Dry run complete. Zip file created at: ${outputFilePath.path}")
       return
     }
 
@@ -182,7 +183,7 @@ abstract class BaseUploadTask : DefaultTask() {
     // the uploadId or url
     File(outputDir, UPLOAD_RESPONSE_FILE_NAME).also {
       it.createNewFile()
-      it.writeText(Json.encodeToString(it))
+      it.writeText(Json.encodeToString(response))
     }
     onUpload(response)
   }
@@ -255,7 +256,7 @@ abstract class BaseUploadTask : DefaultTask() {
       project: Project,
       variant: Variant,
     ) {
-      val emergeOutputDir = File(project.buildDir, ARTIFACT_OUTPUT_DIR).also(File::mkdirs)
+      val emergeOutputDir = File(project.layout.buildDirectory.asFile.get(), ARTIFACT_OUTPUT_DIR).also(File::mkdirs)
       dryRun.set(extension.dryRun)
       apiToken.set(extension.apiToken)
       agpVersion.set(AgpVersions.CURRENT.toString())


### PR DESCRIPTION
When running any task with the `dryRun` property set to true, there would be a pretty aggressive crash, despite this being expected:
<img width="926" alt="Screenshot 2024-08-08 at 12 10 44 PM" src="https://github.com/user-attachments/assets/38f8657c-b3e8-4c38-ab73-322c49017d86">

This better handles a successful dryRun.
<img width="1000" alt="Screenshot 2024-08-08 at 12 17 37 PM" src="https://github.com/user-attachments/assets/4ac8454e-b132-4924-a5ee-525f482eeb3a">

