### PR TITLE
[Reaper] Use instrumented manifest placeholder as indication reaper is enabled and end early if not rather than fatal erroring

### DIFF
--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperInternal.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperInternal.kt
@@ -24,7 +24,11 @@ import java.io.FileOutputStream
 import java.util.UUID
 
 // The Reaper report currently in progress:
-private class Report(val stream: FileOutputStream, val dataStream: DataOutputStream, val path: File) {
+private class Report(
+  val stream: FileOutputStream,
+  val dataStream: DataOutputStream,
+  val path: File
+) {
   // All the hashes we have written so far.
   val written = mutableSetOf<Long>()
 
@@ -129,8 +133,10 @@ internal object ReaperInternal {
 
     if (!isEnabled) {
       // Explicitly don't use fatalError to ensure we don't crash other variants
-      Log.w(TAG,
-        "Reaper is not enabled, ensure this variant is specified in the reaper.enabledVariants list in the Emerge gradle plugin configuration block."
+      Log.w(
+        TAG,
+        "Reaper is not enabled, ensure this variant is specified in the reaper.enabledVariants" +
+          " list in the Emerge gradle plugin configuration block."
       )
       return
     }

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperInternal.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperInternal.kt
@@ -136,7 +136,8 @@ internal object ReaperInternal {
       Log.w(
         TAG,
         "Reaper is not enabled, ensure this variant is specified in the reaper.enabledVariants" +
-          " list in the Emerge gradle plugin configuration block. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk."
+          " list in the Emerge gradle plugin configuration block." +
+          " See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk."
       )
       return
     }

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperInternal.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperInternal.kt
@@ -136,7 +136,7 @@ internal object ReaperInternal {
       Log.w(
         TAG,
         "Reaper is not enabled, ensure this variant is specified in the reaper.enabledVariants" +
-          " list in the Emerge gradle plugin configuration block."
+          " list in the Emerge gradle plugin configuration block. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk."
       )
       return
     }


### PR DESCRIPTION
I found in https://github.com/EmergeTools/hackernews/pull/107 that when adding reaper as an `implementation` dependency, it would also be added to non-intended variants (debug in that case). Upon the manifest placeholder for publishableApiKey being empty, we'd hit a `Manifest com.emergetools.PUBLISHABLE_API_KEY must be set and non-empty.` error.

The thing is, this is intentional, as we don't want to init reaper for non-intended variants. 

So rather than fatally erroring here, we're exit the init early and log a warning to make it clear this is an intended situation. I use the `INSTRUMENTED` placeholder to indicate this.