### PR TITLE
Put reaper preflight behind enabled check as well to ensure we don't hook tasks we shouldn't be

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/PreflightReaper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/PreflightReaper.kt
@@ -4,10 +4,15 @@ import com.emergetools.android.gradle.util.preflight.Preflight
 import com.emergetools.android.gradle.util.preflight.PreflightFailure
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.internal.artifacts.configurations.Configurations
+import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
@@ -18,30 +23,40 @@ abstract class PreflightReaper : DefaultTask() {
   abstract val reaperEnabled: Property<Boolean>
 
   @get:Input
+  abstract val variantName: Property<String>
+
+  @get:Input
+  abstract val hasReaperImplementationDependency: Property<Boolean>
+
+  @get:Input
   @get:Optional
   abstract val reaperPublishableApiKey: Property<String>
 
-  @get:InputFile
-  abstract val mergedManifestFile: RegularFileProperty
 
   @TaskAction
   fun execute() {
     val preflight = Preflight("Reaper")
 
-    preflight.add("reaper.publishableApiKey set") {
-      val key = reaperPublishableApiKey.orNull
-        ?: throw PreflightFailure("reaper.publishableApiKey not set. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
-
-      if (key == "") {
-        throw PreflightFailure("reaper.publishableApiKey must not be empty. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
+    val variantName = variantName.get()
+    preflight.add("enabled for variant: $variantName") {
+      if (!reaperEnabled.getOrElse(false)) {
+        throw PreflightFailure("Reaper not enabled for variant $variantName. Make sure \"${variantName}\" is included in `reaper.enabledVariants`")
       }
     }
 
-    preflight.add("Reaper runtime SDK added") {
-      val manifest = mergedManifestFile.get()
-      val text = manifest.asFile.readText()
-      if (!text.contains("com.emergetools.reaper.REAPER_INSTRUMENTED")) {
-        throw PreflightFailure("Reaper runtime SDK missing. See https://docs.emergetools.com/docs/reaper-setup-android#install-the-sdk")
+    preflight.add("publishableApiKey set") {
+      val key = reaperPublishableApiKey.orNull
+      if (key == null) {
+        throw PreflightFailure("publishableApiKey not set. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
+      }
+      if (key == "") {
+        throw PreflightFailure("publishableApiKey must not be empty. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
+      }
+    }
+
+    preflight.add("Runtime SDK added") {
+      if (!hasReaperImplementationDependency.getOrElse(false)) {
+        throw PreflightFailure("Reaper runtime SDK missing as an implementation dependency. See https://docs.emergetools.com/docs/reaper-setup-android#install-the-sdk")
       }
     }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/PreflightReaper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/PreflightReaper.kt
@@ -5,7 +5,6 @@ import com.emergetools.android.gradle.util.preflight.PreflightFailure
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -19,9 +18,6 @@ abstract class PreflightReaper : DefaultTask() {
   abstract val reaperEnabled: Property<Boolean>
 
   @get:Input
-  abstract val variantName: Property<String>
-
-  @get:Input
   @get:Optional
   abstract val reaperPublishableApiKey: Property<String>
 
@@ -32,18 +28,10 @@ abstract class PreflightReaper : DefaultTask() {
   fun execute() {
     val preflight = Preflight("Reaper")
 
-    val variantName = variantName.get()
-    preflight.add("Reaper enabled for variant: ${variantName}") {
-      if (!reaperEnabled.getOrElse(false)) {
-        throw PreflightFailure("Reaper not enabled for variant $variantName. Make sure \"${variantName}\" is included in `reaper.enabledVariants`")
-      }
-    }
-
     preflight.add("reaper.publishableApiKey set") {
       val key = reaperPublishableApiKey.orNull
-      if (key == null) {
-        throw PreflightFailure("reaper.publishableApiKey not set. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
-      }
+        ?: throw PreflightFailure("reaper.publishableApiKey not set. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
+
       if (key == "") {
         throw PreflightFailure("reaper.publishableApiKey must not be empty. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
       }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/Register.kt
@@ -20,12 +20,11 @@ fun registerReaperTasks(
     "Registering reaper tasks for variant ${variant.name} in project ${appProject.path}"
   )
 
-  registerReaperPreflightTask(appProject, extension, variant)
-
   val enabledVariants = extension.reaperOptions.enabledVariants.getOrElse(emptyList())
   // Only register upload task if Reaper is enabled for variant
   if (enabledVariants.contains(variant.name)) {
     appProject.logger.debug("Reaper enabled for variant ${variant.name}")
+    registerReaperPreflightTask(appProject, extension, variant)
     registerReaperUploadTask(appProject, extension, variant)
   }
 }
@@ -39,7 +38,6 @@ private fun registerReaperPreflightTask(
   appProject.tasks.register(preflightTaskName, PreflightReaper::class.java) {
     it.group = EMERGE_REAPER_TASK_GROUP
     it.description = "Validate Reaper is properly set up for variant ${variant.name}"
-    it.variantName.set(variant.name)
     it.reaperEnabled.set(extension.reaperOptions.enabledVariants.getOrElse(emptyList()).contains(variant.name))
     it.reaperPublishableApiKey.set(extension.reaperOptions.publishableApiKey)
     it.mergedManifestFile.set(variant.artifacts.get(SingleArtifact.MERGED_MANIFEST))


### PR DESCRIPTION
The reaper preflight task currently hooks the `minify<variant>WithR8` task. This results in failures if reaper isn't properly set up, and since it hooks the minify task, this could throw for cases where we don't want to throw.

This moves the verify task behind the enabled check, so while it won't register for all variants outright, it will at least prevent breaking cases where it shouldn't