### PR TITLE
Don't hard error on file already existing

### DIFF
--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
@@ -191,9 +191,12 @@ internal object SnapshotSaver {
     writer: FileOutputStream.() -> Unit,
   ) {
     val outputFile = File(dir, filenameWithExtension)
-    check(!outputFile.exists()) {
-      "File with name $filenameWithExtension already exists."
+
+    if (outputFile.exists()) {
+      Log.e(TAG, "File with name $filenameWithExtension already exists, skipping save.")
+      return
     }
+
     Log.d(TAG, "Saving file to ${outputFile.path}")
     outputFile.outputStream().use { writer(it) }
   }


### PR DESCRIPTION
We've historically hard crashed from this logic to ensure we don't overwrite a file with the same key. This hard crash seems to cause the underlying instrumentation to crash in some rare occasions.

Working to see if we can better run tests in-silo to prevent this, but in the meantime we should try to avoid taking the entire instrumentation down.