### PR TITLE
Add additional compose preview params to ensure unsupported preview params don't clobber other valid previews

### DIFF
--- a/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -21,6 +21,8 @@ data class ComposePreviewSnapshotConfig(
   val backgroundColor: Long? = null,
   val showSystemUi: Boolean? = null,
   val device: String? = null,
+  val apiLevel: Int? = null,
+  val wallpaper: Int? = null,
 ) {
 
   /**
@@ -35,7 +37,9 @@ data class ComposePreviewSnapshotConfig(
       showBackground == null &&
       backgroundColor == null &&
       showSystemUi == null &&
-      device == null
+      device == null &&
+      apiLevel == null &&
+      wallpaper == null
   }
 
   /**
@@ -57,6 +61,8 @@ data class ComposePreviewSnapshotConfig(
       backgroundColor?.let { append("_bgc_$it") }
       showSystemUi?.let { append("_sysui_$it") }
       device?.let { append("_dev_$it") }
+      apiLevel?.let { append("_api_$it") }
+      wallpaper?.let { append("_wp_$it") }
     }
   }
 }


### PR DESCRIPTION
Currently, if apiLevel or wallpaper are set, we won't properly respect that in the unique key for the preview. This results in two different previews writing to the same file, which can cause a clobber/error.

While we still don't support these params first-class, this will prevent a clobber and will render the snapshot without the apiLevel/wallpaper params respected, but without an error.