### PR TITLE
Remove skipping logic and ignore a test entirely if not a snapshot  test

### DIFF
--- a/snapshots/sample/app/src/androidTest/kotlin/com/emergetools/snapshots/sample/ExampleSkippedTest.kt
+++ b/snapshots/sample/app/src/androidTest/kotlin/com/emergetools/snapshots/sample/ExampleSkippedTest.kt
@@ -1,0 +1,24 @@
+package com.emergetools.snapshots.sample
+
+import android.util.Log
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.emergetools.snapshots.EmergeSnapshots
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ExampleSkippedTest {
+
+  @get:Rule
+  val activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+  @Test
+  fun basicActivityView() {
+    val scenario = activityScenarioRule.scenario
+    scenario.onActivity {
+      Log.d("ExampleSkippedTest", "basicActivityView")
+    }
+  }
+}

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/runner/SnapshotsRunner.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/runner/SnapshotsRunner.kt
@@ -37,10 +37,10 @@ internal class SnapshotsRunner(
     } else {
       // If isInDiscovery and the test is intended to be ignored,
       // we won't even mark it as ignored to ensure it isn't addressed
-      if (!isInDiscovery) {
+//      if (!isInDiscovery) {
         Log.d(TAG, "Ignoring test class: ${testClass.simpleName}")
-        notifier.fireTestIgnored(description)
-      }
+//        notifier.fireTestIgnored(description)
+//      }
     }
   }
 

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/runner/SnapshotsRunner.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/runner/SnapshotsRunner.kt
@@ -2,10 +2,8 @@ package com.emergetools.snapshots.runner
 
 import android.util.Log
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import androidx.test.platform.app.InstrumentationRegistry
 import com.emergetools.snapshots.EmergeSnapshots
 import com.emergetools.snapshots.compose.EmergeComposeSnapshotReflectiveParameterizedInvoker
-import com.emergetools.snapshots.runner.SnapshotsRunnerBuilder.Companion
 import org.junit.Rule
 import org.junit.runner.notification.RunNotifier
 

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/runner/SnapshotsRunner.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/runner/SnapshotsRunner.kt
@@ -24,23 +24,13 @@ internal class SnapshotsRunner(
     val isReflectiveInvoker =
       testClass == EmergeComposeSnapshotReflectiveParameterizedInvoker::class.java
 
-    val args = InstrumentationRegistry.getArguments()
-    val isInDiscovery = args.getBoolean(
-      "log",
-      false
-    )
-    Log.d(SnapshotsRunnerBuilder.TAG, "isInDiscovery: $isInDiscovery")
-
     if (hasEmergeSnapshotRule || (useReflectiveInvoke && isReflectiveInvoker)) {
       Log.d(TAG, "Running test class: ${testClass.simpleName}")
       super.run(notifier)
     } else {
-      // If isInDiscovery and the test is intended to be ignored,
-      // we won't even mark it as ignored to ensure it isn't addressed
-//      if (!isInDiscovery) {
-        Log.d(TAG, "Ignoring test class: ${testClass.simpleName}")
-//        notifier.fireTestIgnored(description)
-//      }
+      // Note: We intentionally do not mark the test as ignored as we
+      // don't care to acknowledge the test to ensure it doesn't take test run time/get assigned to an emulator
+      Log.d(TAG, "Ignoring test class: ${testClass.simpleName}")
     }
   }
 

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/runner/SnapshotsRunner.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/runner/SnapshotsRunner.kt
@@ -2,8 +2,10 @@ package com.emergetools.snapshots.runner
 
 import android.util.Log
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import androidx.test.platform.app.InstrumentationRegistry
 import com.emergetools.snapshots.EmergeSnapshots
 import com.emergetools.snapshots.compose.EmergeComposeSnapshotReflectiveParameterizedInvoker
+import com.emergetools.snapshots.runner.SnapshotsRunnerBuilder.Companion
 import org.junit.Rule
 import org.junit.runner.notification.RunNotifier
 
@@ -22,12 +24,23 @@ internal class SnapshotsRunner(
     val isReflectiveInvoker =
       testClass == EmergeComposeSnapshotReflectiveParameterizedInvoker::class.java
 
+    val args = InstrumentationRegistry.getArguments()
+    val isInDiscovery = args.getBoolean(
+      "log",
+      false
+    )
+    Log.d(SnapshotsRunnerBuilder.TAG, "isInDiscovery: $isInDiscovery")
+
     if (hasEmergeSnapshotRule || (useReflectiveInvoke && isReflectiveInvoker)) {
       Log.d(TAG, "Running test class: ${testClass.simpleName}")
       super.run(notifier)
     } else {
-      Log.d(TAG, "Ignoring test class: ${testClass.simpleName}")
-      notifier.fireTestIgnored(description)
+      // If isInDiscovery and the test is intended to be ignored,
+      // we won't even mark it as ignored to ensure it isn't addressed
+      if (!isInDiscovery) {
+        Log.d(TAG, "Ignoring test class: ${testClass.simpleName}")
+        notifier.fireTestIgnored(description)
+      }
     }
   }
 


### PR DESCRIPTION
When we mark a test as ignored/skipped, this takes a non-negligible amount of time and can still result in shards being assigned to the skipped tests, despite not actually executing anything.

By removing any acknowledgement of the test, this should allow us to truly "skip" the test, saving resources and preventing edge cases where shards/emulators are assigned to skipped tests.