### PR TITLE
Move almost all work off the main thread

### DIFF
--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Manifest.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Manifest.kt
@@ -1,0 +1,24 @@
+package com.emergetools.reaper
+
+import android.os.Bundle
+
+private const val MANIFEST_TAG_INSTRUMENTED = "com.emergetools.reaper.REAPER_INSTRUMENTED"
+private const val MANIFEST_TAG_PUBLISHABLE_API_KEY = "com.emergetools.reaper.PUBLISHABLE_API_KEY"
+private const val MANIFEST_TAG_OVERRIDE_BASE_URL = "com.emergetools.OVERRIDE_BASE_URL"
+private const val MANIFEST_TAG_DEBUG = "com.emergetools.reaper.DEBUG"
+
+internal fun isInstrumented(metadata: Bundle): Boolean {
+  return metadata.getBoolean(MANIFEST_TAG_INSTRUMENTED, false)
+}
+
+internal fun getApiKey(metadata: Bundle): String {
+  return metadata.getString(MANIFEST_TAG_PUBLISHABLE_API_KEY, "")
+}
+
+internal fun getBaseUrl(metadata: Bundle): String {
+  return metadata.getString(MANIFEST_TAG_OVERRIDE_BASE_URL, ReaperConfig.EMERGE_BASE_URL)
+}
+
+internal fun isDebug(metadata: Bundle): Boolean {
+  return metadata.getBoolean(MANIFEST_TAG_DEBUG, false)
+}

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/OnStopLifecycleObserver.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/OnStopLifecycleObserver.kt
@@ -1,15 +1,14 @@
 package com.emergetools.reaper
 
-import android.content.Context
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 
-internal class ReaperLifecycleObserver(
-  private val applicationContext: Context,
+internal class OnStopLifecycleObserver(
+  private val onStop: () -> Unit
 ) : DefaultLifecycleObserver {
 
   override fun onStop(owner: LifecycleOwner) {
     super.onStop(owner)
-    ReaperInternal.finalizeReport(applicationContext)
+    onStop()
   }
 }

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Reaper.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Reaper.kt
@@ -10,22 +10,25 @@ import android.content.Context
  * - A server side component which aggregates those reports and compares the used code to the
  *   code in the app. Code which is not used by any user but exists in the app is detected,
  *   displayed and can be deleted.
- * See https://docs.emergetools.com/docs/reaper-setup-android for more
- * information.
+ * See https://docs.emergetools.com/docs/reaper-setup-android for more information.
  */
 object Reaper {
   /**
-   * Initialize Reaper with the provided apiKey. This should be called once in each process. In
-   * addition to calling this method the codebase need be instrumented using the Emergetools
-   * gradle plugin. This method may be called from any thread.
+   * Initialize Reaper. This should be called once in each process. In
+   * addition to calling this method the codebase must be instrumented using the Emergetools
+   * gradle plugin. This method may be called from any thread with a Looper. It is safe to
+   * call this from the main thread.
+   * @param context Android context
    */
   fun init(context: Context) {
     ReaperInternal.init(context)
   }
 
   /**
-   * Flush observed hashes into the current report.
+   * Flush observed hashes into the current report if any.
    * This method may be called from any thread.
+   * Blocks until the flush is complete.
+   * @param context Android context
    */
   fun flush(context: Context) {
     ReaperInternal.flush(context)

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperReportErrorWorker.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperReportErrorWorker.kt
@@ -1,6 +1,7 @@
 package com.emergetools.reaper
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.util.Log
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
@@ -128,8 +129,16 @@ class ReaperReportErrorWorker(
   }
 }
 
-fun reportError(ctx: Context, baseUrl: String, apiKey: String, message: String) {
-  Log.e(TAG, "Error. backend=$baseUrl message=$message")
+fun reportError(ctx: Context, message: String) {
+  val metaData = ctx.packageManager.getApplicationInfo(
+    ctx.packageName,
+    PackageManager.GET_META_DATA
+  ).metaData
+
+  val baseUrl = getBaseUrl(metaData)
+  val apiKey = getApiKey(metaData)
+
+  Log.e(TAG, "ReaperError: backend`=$baseUrl message=$message")
   val data = workDataOf(
     ReaperReportErrorWorker.EXTRA_API_KEY to apiKey,
     ReaperReportErrorWorker.EXTRA_BASE_URL to baseUrl,

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperReportUploadWorker.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperReportUploadWorker.kt
@@ -191,7 +191,7 @@ internal class ReaperReportUploadWorker(
           "Upload failed, backend or apiKey unknown. backend=$baseUrl apiKey=$apiKey"
         )
       } else {
-        reportError(applicationContext, baseUrl, apiKey, response.toString())
+        reportError(applicationContext, response.toString())
       }
     }
   }

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Tracing.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Tracing.kt
@@ -1,0 +1,19 @@
+package com.emergetools.reaper
+
+import android.os.Trace
+import java.lang.Thread.sleep
+
+internal fun <T> trace(name: String, block: () -> T): T {
+  try {
+    Trace.beginSection(name)
+    return block()
+  } finally {
+    Trace.endSection()
+  }
+}
+
+internal fun block(ms: Long) {
+  trace("sleep") {
+    sleep(ms)
+  }
+}

--- a/reaper/sample/app/build.gradle.kts
+++ b/reaper/sample/app/build.gradle.kts
@@ -43,6 +43,7 @@ android {
     release {
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
       isMinifyEnabled = true
+      signingConfig = signingConfigs.getByName("debug")
     }
     debug {
       applicationIdSuffix = ".debug"

--- a/reaper/sample/app/src/main/kotlin/com/emergetools/reaper/sample/screen/StoryDetailScreen.kt
+++ b/reaper/sample/app/src/main/kotlin/com/emergetools/reaper/sample/screen/StoryDetailScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
 import kotlinx.serialization.Serializable
 
@@ -39,7 +40,11 @@ fun StoryDetailScreen(
       TopAppBar(
         navigationIcon = {
           IconButton(
-            onClick = { navController.popBackStack() }
+            onClick = {
+              if (navController.currentBackStackEntry?.lifecycle?.currentState == Lifecycle.State.RESUMED) {
+                navController.popBackStack()
+              }
+            }
           ) {
             Icon(
               imageVector = Icons.Default.ArrowBack,


### PR DESCRIPTION
Rework how Reaper is initialized to avoid main thread work where possible.

The new startup flow is as follows:

There are two methods for initializing Reaper:
1. Manually via `Reaper.init`
2. Automatically via `ReaperInitializer`
Either way `ReaperInternal.init` is invoked.

- `ReaperInternal.init` method creates `ReaperImpl`
  - then schedules the remaining startup to happen in `DEFERRED_START_MS` via `Handler.postDelayed`.
- The deferred startup (`mainThreadStart`) runs on the main thread and:
  - Creates a thread with a `Looper` named `ReaperWorker`
  - Sets up an `OnStopLifecycleObserver` to call `ReaperImpl.finalizeReport`
  - And finally posts a message to `ReaperWorker` (`workerThreadStart`)
- `workerThreadStart` calls
  - `ReaperImpl.sweepReports` to action reports left from previous sessions
  - `ReaperImpl.startReport` to start the current report
  - Sets up a recurring call to `ReaperImpl.flush` every `FLUSH_PERIOD_MS`

Also:
- Fixes an issue with `com.emergetools.reaper.sample` where clicking back twice causes the UI to get stuck
- Move some code for getting values from the manifest into a new file `Manifest.kt`
- Introduce `Tracing.kt` and associated functions
- Move most business logic for Reaper into a class `ReaperImpl` making it easier to unittest in future.