### PR TITLE
Reaper split business logic from IO

### DIFF
--- a/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/instrumentation/reaper/ReaperClassLoadTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/instrumentation/reaper/ReaperClassLoadTest.kt
@@ -6,7 +6,7 @@ import java.util.Base64
 
 class ReaperClassLoadTest {
 
-  fun byteArrayOf(vararg elements: Int): ByteArray {
+  private fun byteArrayOf(vararg elements: Int): ByteArray {
     return elements.map { it.toByte() }.toByteArray()
   }
 

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Paths.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Paths.kt
@@ -4,19 +4,19 @@ import android.content.Context
 import android.util.Log
 import java.io.File
 
-private const val REAPER_DIR_SUFFIX = "reaper"
-private const val REAPER_CURRENT_DIR_SUFFIX = "$REAPER_DIR_SUFFIX/current"
-private const val REAPER_PENDING_DIR_SUFFIX = "$REAPER_DIR_SUFFIX/pending"
-private const val REAPER_DEBUG_DIR_SUFFIX = "$REAPER_DIR_SUFFIX/debug"
+private const val REAPER_DIR = "reaper"
+private const val REAPER_CURRENT_DIR = "$REAPER_DIR/current"
+private const val REAPER_PENDING_DIR = "$REAPER_DIR/pending"
+private const val REAPER_DEBUG_DIR = "$REAPER_DIR/debug"
 
 internal fun getPendingDir(context: Context) =
-  File(context.applicationContext.cacheDir, REAPER_PENDING_DIR_SUFFIX)
+  File(context.applicationContext.cacheDir, REAPER_PENDING_DIR)
 
 internal fun getCurrentDir(context: Context) =
-  File(context.applicationContext.cacheDir, REAPER_CURRENT_DIR_SUFFIX)
+  File(context.applicationContext.cacheDir, REAPER_CURRENT_DIR)
 
 internal fun getDebugDir(context: Context) =
-  File(context.applicationContext.cacheDir, REAPER_DEBUG_DIR_SUFFIX)
+  File(context.applicationContext.cacheDir, REAPER_DEBUG_DIR)
 
 internal fun ensureDirectories(context: Context): Boolean {
   var success = true

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperImpl.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperImpl.kt
@@ -1,0 +1,152 @@
+package com.emergetools.reaper
+
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+
+// The Reaper report currently in progress:
+private class Report(
+  val stream: FileOutputStream,
+  val dataStream: DataOutputStream,
+  val path: File
+) {
+  // All the hashes we have written so far.
+  val written = mutableSetOf<Long>()
+}
+
+private const val REPORT_SUFFIX_SIZE = 8
+
+internal class ReaperImpl(
+  val tracker: HashTracker,
+  val delegate: Delegate,
+  val apiKey: String,
+  val baseUrl: String = ReaperConfig.EMERGE_BASE_URL,
+  val isDebug: Boolean = false,
+) {
+  interface Delegate {
+    fun startReport(id: String): File?
+    fun deleteReport(id: String)
+    fun markReportPending(id: String)
+    fun listCurrentReports(): Collection<String>
+    fun listPendingReports(): Collection<String>
+    fun requestUpload(apiKey: String, baseUrl: String, isDebug: Boolean)
+    fun d(message: String)
+    fun e(message: String)
+    fun <T> trace(name: String, block: () -> T): T
+  }
+
+  companion object {
+    private const val PENDING_REPORTS_LIMIT = 10
+  }
+
+  // Set by startReport() and reset on finalizeReport().
+  private var report: Report? = null
+
+  init {
+    delegate.d("Reaper initialized. backend=${this.baseUrl} tracker=${tracker.name}")
+  }
+
+  // Our internal API. Each of the methods must be thread safe.
+  @Synchronized
+  fun flush() {
+    val report = this.report
+    delegate.trace("Reaper#flush") {
+      if (report == null) {
+        delegate.e("No report to flush")
+        return@trace
+      } else {
+        delegate.d("Flushing report ${report.path.absolutePath}")
+      }
+
+      // Hashes observed since the last flush() this will normally be a mixture of hashes we
+      // already saw and new hashes.
+      tracker.flush {
+        it.forEach { hash ->
+          if (!report.written.contains(hash)) {
+            report.dataStream.writeLong(hash)
+            report.written.add(hash)
+          }
+        }
+      }
+
+      // Flush the underlying file.
+      report.dataStream.flush()
+      report.stream.flush()
+    }
+  }
+
+  /**
+   * 1. If there more than PENDING_REPORTS_LIMIT reports pending delete all pending reports.
+   * 2. Move all current reports for this process to pending.
+   * 3. Schedule an upload job.
+   */
+  @Synchronized
+  fun sweepReports() {
+    delegate.trace("Reaper#sweepReports") {
+      // If we have too many reports pending upload delete them all:
+      val pending = delegate.listPendingReports()
+      if (pending.size > PENDING_REPORTS_LIMIT) {
+        for (id in pending) {
+          delegate.deleteReport(id)
+        }
+      }
+
+      // Make all current reports to pending.
+      val current = delegate.listCurrentReports()
+      for (id in current) {
+        delegate.markReportPending(id)
+      }
+
+      delegate.requestUpload(apiKey = apiKey, baseUrl = baseUrl, isDebug = isDebug)
+    }
+  }
+
+  @Synchronized
+  fun startReport(): String? {
+    return delegate.trace("Reaper#startReport") {
+      val shortUuid = UUID.randomUUID().toString().substring(0, REPORT_SUFFIX_SIZE)
+      val file = delegate.startReport(shortUuid)
+      if (file == null) {
+        delegate.e("Failed to open Reaper report for writing")
+        return@trace null
+      }
+      val stream = FileOutputStream(file)
+      val absolutePath = file.absolutePath
+
+      if (!stream.fd.valid()) {
+        delegate.e("Failed to open Reaper report stream for writing $absolutePath")
+        return@trace null
+      }
+      report = Report(stream, DataOutputStream(stream), file)
+
+      delegate.d(
+        "Reaper report started. report=$absolutePath backend=$baseUrl tracker=${tracker.name}"
+      )
+      return@trace absolutePath
+    }
+  }
+
+  @Synchronized
+  fun finalizeReport() {
+    delegate.trace("Reaper#finalizeReport") {
+      // Flush any remaining hashes:
+      flush()
+
+      val report = this.report
+      this.report = null
+      if (report == null) {
+        delegate.e("No report to finalize")
+        return@trace
+      } else {
+        delegate.d("Finalizing report ${report.path.absolutePath}")
+      }
+
+      // Move report to pending and schedule upload.
+      sweepReports()
+
+      // Start a file for the next report:
+      startReport()
+    }
+  }
+}

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Tracing.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Tracing.kt
@@ -3,7 +3,7 @@ package com.emergetools.reaper
 import android.os.Trace
 import java.lang.Thread.sleep
 
-internal fun <T> trace(name: String, block: () -> T): T {
+internal fun <T> androidTrace(name: String, block: () -> T): T {
   try {
     Trace.beginSection(name)
     return block()
@@ -13,7 +13,7 @@ internal fun <T> trace(name: String, block: () -> T): T {
 }
 
 internal fun block(ms: Long) {
-  trace("sleep") {
+  androidTrace("sleep") {
     sleep(ms)
   }
 }

--- a/reaper/reaper/src/test/kotlin/com/emergetools/reaper/ReaperImplTest.kt
+++ b/reaper/reaper/src/test/kotlin/com/emergetools/reaper/ReaperImplTest.kt
@@ -1,0 +1,133 @@
+package com.emergetools.reaper
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+private class FakeDelegate : ReaperImpl.Delegate {
+  private val pendingReports = mutableSetOf<String>()
+  private val currentReports = mutableSetOf<String>()
+  val idToFile = mutableMapOf<String, File>()
+
+  override fun startReport(id: String): File? {
+    currentReports.add(id)
+    val file = File.createTempFile("FakeDelegate", null)
+    idToFile[id] = file
+    return file
+  }
+
+  override fun deleteReport(id: String) {
+    currentReports.remove(id)
+    pendingReports.remove(id)
+  }
+
+  override fun markReportPending(id: String) {
+    currentReports.remove(id)
+    pendingReports.add(id)
+  }
+
+  override fun listCurrentReports(): Collection<String> {
+    return currentReports.toMutableList()
+  }
+
+  override fun listPendingReports(): Collection<String> {
+    return pendingReports.toMutableList()
+  }
+
+  override fun requestUpload(apiKey: String, baseUrl: String, isDebug: Boolean) {
+    // Empty
+  }
+
+  override fun d(message: String) {
+    // Empty
+  }
+
+  override fun e(message: String) {
+    // Empty
+  }
+
+  override fun <T> trace(name: String, block: () -> T): T {
+    return block()
+  }
+}
+
+class ReaperImplTest {
+  private lateinit var tracker: HashTracker
+  private lateinit var delegate: FakeDelegate
+  private lateinit var impl: ReaperImpl
+
+  @BeforeEach
+  fun init() {
+    tracker = SynchronizedSetHashTracker()
+    delegate = FakeDelegate()
+  }
+
+  @Test
+  fun `clears pending reports if there are too many`() {
+    for (i in 1..11) {
+      delegate.startReport("$i")
+      delegate.markReportPending("$i")
+    }
+    impl = ReaperImpl(tracker = tracker, delegate = delegate, apiKey = "<apikey>")
+    impl.sweepReports()
+    assertThat(delegate.listPendingReports()).isEmpty()
+  }
+
+  @Test
+  fun `uploads reports containing hashes`() {
+    impl = ReaperImpl(tracker = tracker, delegate = delegate, apiKey = "<apikey>")
+
+    impl.startReport()
+    tracker.logMethodEntry(-1L)
+    impl.finalizeReport()
+
+    assertThat(delegate.listPendingReports()).hasSize(1)
+    val file = delegate.idToFile[delegate.listPendingReports().single()]!!
+    assertThat(file.readBytes().toList()).containsExactlyElementsIn(
+      byteArrayOf(
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1
+      ).toList()
+    ).inOrder()
+  }
+
+  @Test
+  fun `reports hashes prior to construction in the first report`() {
+    tracker.logMethodEntry(0x0102030405060708)
+    impl = ReaperImpl(tracker = tracker, delegate = delegate, apiKey = "<apikey>")
+    impl.startReport()
+    impl.finalizeReport()
+
+    assertThat(delegate.listPendingReports()).hasSize(1)
+    val file = delegate.idToFile[delegate.listPendingReports().single()]!!
+    assertThat(file.readBytes().toList()).containsExactlyElementsIn(
+      byteArrayOf(
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ).toList()
+    ).inOrder()
+  }
+
+  @Test
+  fun `sweeping finalizes pre-existing reports`() {
+    delegate.startReport("previous1")
+    delegate.startReport("previous2")
+    impl = ReaperImpl(tracker = tracker, delegate = delegate, apiKey = "<apikey>")
+    impl.sweepReports()
+
+    assertThat(delegate.listPendingReports()).containsExactly("previous1", "previous2")
+  }
+}


### PR DESCRIPTION
Split the logic for Reaper into two parts:
1. ReaperImpl which handles all the logic 
2. ReaperImpl.Delegate which handles all the IO and anything Android specific

This allows for:
- easy unit testing of the business logic (a few examples added in this PR)
- auditing all the IO for correct handling of errors e.g. `ENOSPC (No space left on device)` (in a follow up)