### PR TITLE
Fix bugs that are blocking use of Android test orchestrator

### DIFF
--- a/snapshots/snapshots-shared/build.gradle.kts
+++ b/snapshots/snapshots-shared/build.gradle.kts
@@ -34,6 +34,8 @@ tasks.withType<KotlinCompile> {
 
 dependencies {
   implementation(libs.kotlinx.serialization)
+
+  testImplementation(libs.junit)
 }
 
 tasks.register("generateMetaInfVersion") {

--- a/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -45,19 +45,13 @@ data class ComposePreviewSnapshotConfig(
   /**
    * Stable key name generation that takes into account all diff-relevant variants.
    */
-  fun keyName(shortFqn: Boolean = false): String {
-    val fqn = if (shortFqn) {
-      originalFqn.substringAfterLast('.')
-    } else {
-      originalFqn
-    }
-
+  fun keyName(): String {
     if (isDefault()) {
-      return fqn
+      return originalFqn
     }
 
     return buildString {
-      append(fqn)
+      append(originalFqn)
       uiMode?.let { append("_uim_$it") }
       locale?.let { append("_loc_$it") }
       fontScale?.let { append("_fsc_$it") }
@@ -71,5 +65,4 @@ data class ComposePreviewSnapshotConfig(
       wallpaper?.let { append("_wp_$it") }
     }
   }
-
 }

--- a/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -47,7 +47,7 @@ data class ComposePreviewSnapshotConfig(
    */
   fun keyName(shortFqn: Boolean = false): String {
     val fqn = if (shortFqn) {
-      originalFqn.substringBeforeLast('.')
+      originalFqn.substringAfterLast('.')
     } else {
       originalFqn
     }

--- a/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -47,15 +47,13 @@ data class ComposePreviewSnapshotConfig(
   /**
    * Stable key name generation that takes into account all diff-relevant variants.
    */
-  fun keyName(shortFqn: Boolean = false): String {
-    val fqn = if (shortFqn) functionName else originalFqn
-
+  fun keyName(baseKey: String = originalFqn): String {
     if (isDefault()) {
-      return fqn
+      return baseKey
     }
 
     return buildString {
-      append(fqn)
+      append(baseKey)
       uiMode?.let { append("_uim_$it") }
       locale?.let { append("_loc_$it") }
       fontScale?.let { append("_fsc_$it") }
@@ -69,5 +67,4 @@ data class ComposePreviewSnapshotConfig(
       wallpaper?.let { append("_wp_$it") }
     }
   }
-
 }

--- a/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -45,13 +45,19 @@ data class ComposePreviewSnapshotConfig(
   /**
    * Stable key name generation that takes into account all diff-relevant variants.
    */
-  fun keyName(): String {
+  fun keyName(shortFqn: Boolean = false): String {
+    val fqn = if (shortFqn) {
+      originalFqn.substringBeforeLast('.')
+    } else {
+      originalFqn
+    }
+
     if (isDefault()) {
-      return originalFqn
+      return fqn
     }
 
     return buildString {
-      append(originalFqn)
+      append(fqn)
       uiMode?.let { append("_uim_$it") }
       locale?.let { append("_loc_$it") }
       fontScale?.let { append("_fsc_$it") }
@@ -65,4 +71,5 @@ data class ComposePreviewSnapshotConfig(
       wallpaper?.let { append("_wp_$it") }
     }
   }
+
 }

--- a/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots-shared/src/main/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfig.kt
@@ -24,6 +24,8 @@ data class ComposePreviewSnapshotConfig(
   val apiLevel: Int? = null,
   val wallpaper: Int? = null,
 ) {
+  val functionName: String
+    get() = originalFqn.substringAfterLast(".")
 
   /**
    * We consider the "default" config to be one where no variants are set.
@@ -45,13 +47,15 @@ data class ComposePreviewSnapshotConfig(
   /**
    * Stable key name generation that takes into account all diff-relevant variants.
    */
-  fun keyName(): String {
+  fun keyName(shortFqn: Boolean = false): String {
+    val fqn = if (shortFqn) functionName else originalFqn
+
     if (isDefault()) {
-      return originalFqn
+      return fqn
     }
 
     return buildString {
-      append(originalFqn)
+      append(fqn)
       uiMode?.let { append("_uim_$it") }
       locale?.let { append("_loc_$it") }
       fontScale?.let { append("_fsc_$it") }
@@ -65,4 +69,5 @@ data class ComposePreviewSnapshotConfig(
       wallpaper?.let { append("_wp_$it") }
     }
   }
+
 }

--- a/snapshots/snapshots-shared/src/test/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfigTest.kt
+++ b/snapshots/snapshots-shared/src/test/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfigTest.kt
@@ -1,0 +1,75 @@
+package com.emergetools.snapshots.shared
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ComposePreviewSnapshotConfigTest {
+
+  @Test
+  fun `test keyName with default configuration`() {
+      val config = ComposePreviewSnapshotConfig(
+          fullyQualifiedClassName = "com.example.MyClass",
+          originalFqn = "com.example.MyClass.original"
+      )
+      val expectedKeyName = "com.example.MyClass.original"
+      assertEquals(expectedKeyName, config.keyName())
+  }
+
+  @Test
+  fun `test keyName with non-default uiMode`() {
+      val config = ComposePreviewSnapshotConfig(
+          fullyQualifiedClassName = "com.example.MyClass",
+          originalFqn = "com.example.MyClass.original",
+          uiMode = 2
+      )
+      val expectedKeyName = "com.example.MyClass.original_uim_2"
+      assertEquals(expectedKeyName, config.keyName())
+  }
+
+  @Test
+  fun `test keyName with multiple non-default configurations`() {
+      val config = ComposePreviewSnapshotConfig(
+          fullyQualifiedClassName = "com.example.MyClass",
+          originalFqn = "com.example.MyClass.original",
+          uiMode = 2,
+          locale = "en-US",
+          widthDp = 320
+      )
+      val expectedKeyName = "com.example.MyClass.original_uim_2_loc_en-US_wdp_320"
+      assertEquals(expectedKeyName, config.keyName())
+  }
+
+  @Test
+  fun `test keyName with baseKey override`() {
+      val config = ComposePreviewSnapshotConfig(
+          fullyQualifiedClassName = "com.example.MyClass",
+          originalFqn = "com.example.MyClass.original",
+          uiMode = 2
+      )
+      val baseKey = "baseKeyOverride"
+      val expectedKeyName = "baseKeyOverride_uim_2"
+      assertEquals(expectedKeyName, config.keyName(baseKey))
+  }
+
+  @Test
+  fun `test keyName with all non-default configurations`() {
+      val config = ComposePreviewSnapshotConfig(
+          fullyQualifiedClassName = "com.example.MyClass",
+          originalFqn = "com.example.MyClass.original",
+          uiMode = 2,
+          locale = "en-US",
+          fontScale = 1.5f,
+          widthDp = 320,
+          heightDp = 480,
+          showBackground = true,
+          backgroundColor = 0xFFFFFF,
+          showSystemUi = true,
+          device = "deviceModel",
+          apiLevel = 29,
+          wallpaper = 101
+      )
+      val expectedKeyName = "com.example.MyClass.original_uim_2_loc_en-US_fsc_1.5_wdp_320_hdp_480_bg_true_bgc_16777215_sysui_true_dev_deviceModel_api_29_wp_101"
+      assertEquals(expectedKeyName, config.keyName())
+  }
+
+}

--- a/snapshots/snapshots-shared/src/test/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfigTest.kt
+++ b/snapshots/snapshots-shared/src/test/kotlin/com/emergetools/snapshots/shared/ComposePreviewSnapshotConfigTest.kt
@@ -7,69 +7,69 @@ class ComposePreviewSnapshotConfigTest {
 
   @Test
   fun `test keyName with default configuration`() {
-      val config = ComposePreviewSnapshotConfig(
-          fullyQualifiedClassName = "com.example.MyClass",
-          originalFqn = "com.example.MyClass.original"
-      )
-      val expectedKeyName = "com.example.MyClass.original"
-      assertEquals(expectedKeyName, config.keyName())
+    val config = ComposePreviewSnapshotConfig(
+      fullyQualifiedClassName = "com.example.MyClass",
+      originalFqn = "com.example.MyClass.original"
+    )
+    val expectedKeyName = "com.example.MyClass.original"
+    assertEquals(expectedKeyName, config.keyName())
   }
 
   @Test
   fun `test keyName with non-default uiMode`() {
-      val config = ComposePreviewSnapshotConfig(
-          fullyQualifiedClassName = "com.example.MyClass",
-          originalFqn = "com.example.MyClass.original",
-          uiMode = 2
-      )
-      val expectedKeyName = "com.example.MyClass.original_uim_2"
-      assertEquals(expectedKeyName, config.keyName())
+    val config = ComposePreviewSnapshotConfig(
+      fullyQualifiedClassName = "com.example.MyClass",
+      originalFqn = "com.example.MyClass.original",
+      uiMode = 2
+    )
+    val expectedKeyName = "com.example.MyClass.original_uim_2"
+    assertEquals(expectedKeyName, config.keyName())
   }
 
   @Test
   fun `test keyName with multiple non-default configurations`() {
-      val config = ComposePreviewSnapshotConfig(
-          fullyQualifiedClassName = "com.example.MyClass",
-          originalFqn = "com.example.MyClass.original",
-          uiMode = 2,
-          locale = "en-US",
-          widthDp = 320
-      )
-      val expectedKeyName = "com.example.MyClass.original_uim_2_loc_en-US_wdp_320"
-      assertEquals(expectedKeyName, config.keyName())
+    val config = ComposePreviewSnapshotConfig(
+      fullyQualifiedClassName = "com.example.MyClass",
+      originalFqn = "com.example.MyClass.original",
+      uiMode = 2,
+      locale = "en-US",
+      widthDp = 320
+    )
+    val expectedKeyName = "com.example.MyClass.original_uim_2_loc_en-US_wdp_320"
+    assertEquals(expectedKeyName, config.keyName())
   }
 
   @Test
   fun `test keyName with baseKey override`() {
-      val config = ComposePreviewSnapshotConfig(
-          fullyQualifiedClassName = "com.example.MyClass",
-          originalFqn = "com.example.MyClass.original",
-          uiMode = 2
-      )
-      val baseKey = "baseKeyOverride"
-      val expectedKeyName = "baseKeyOverride_uim_2"
-      assertEquals(expectedKeyName, config.keyName(baseKey))
+    val config = ComposePreviewSnapshotConfig(
+      fullyQualifiedClassName = "com.example.MyClass",
+      originalFqn = "com.example.MyClass.original",
+      uiMode = 2
+    )
+    val baseKey = "baseKeyOverride"
+    val expectedKeyName = "baseKeyOverride_uim_2"
+    assertEquals(expectedKeyName, config.keyName(baseKey))
   }
 
   @Test
   fun `test keyName with all non-default configurations`() {
-      val config = ComposePreviewSnapshotConfig(
-          fullyQualifiedClassName = "com.example.MyClass",
-          originalFqn = "com.example.MyClass.original",
-          uiMode = 2,
-          locale = "en-US",
-          fontScale = 1.5f,
-          widthDp = 320,
-          heightDp = 480,
-          showBackground = true,
-          backgroundColor = 0xFFFFFF,
-          showSystemUi = true,
-          device = "deviceModel",
-          apiLevel = 29,
-          wallpaper = 101
-      )
-      val expectedKeyName = "com.example.MyClass.original_uim_2_loc_en-US_fsc_1.5_wdp_320_hdp_480_bg_true_bgc_16777215_sysui_true_dev_deviceModel_api_29_wp_101"
-      assertEquals(expectedKeyName, config.keyName())
+    val config = ComposePreviewSnapshotConfig(
+      fullyQualifiedClassName = "com.example.MyClass",
+      originalFqn = "com.example.MyClass.original",
+      uiMode = 2,
+      locale = "en-US",
+      fontScale = 1.5f,
+      widthDp = 320,
+      heightDp = 480,
+      showBackground = true,
+      backgroundColor = 0xFFFFFF,
+      showSystemUi = true,
+      device = "deviceModel",
+      apiLevel = 29,
+      wallpaper = 101
+    )
+    val expectedKeyName = "com.example.MyClass.original_uim_2_loc_en-US_fsc_1.5" +
+      "_wdp_320_hdp_480_bg_true_bgc_16777215_sysui_true_dev_deviceModel_api_29_wp_101"
+    assertEquals(expectedKeyName, config.keyName())
   }
-
 }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -25,7 +25,7 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
     val previewConfig: ComposePreviewSnapshotConfig,
   ) {
     // AndroidTestOrchestrator requires tests be
-    override fun toString(): String = previewConfig.keyName(shortFqn = true)
+    override fun toString(): String = previewConfig.hashCode().toString()
   }
 
   companion object {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -24,7 +24,7 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
   data class EmergeComposeSnapshotReflectiveParameters(
     val previewConfig: ComposePreviewSnapshotConfig,
   ) {
-    override fun toString(): String = previewConfig.keyName()
+    override fun toString(): String = previewConfig.keyName().hashCode().toString()
   }
 
   companion object {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -31,7 +31,7 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
     // Different issues online have presented different limits, so we'll be conservative here.
     // https://github.com/android/android-test/issues/1935 is one reference issue
     override fun toString(): String {
-      val key = previewConfig.keyName(shortFqn = true)
+      val key = previewConfig.keyName(baseKey = previewConfig.functionName)
       if (key.length > MAX_PARAM_NAME_LENGTH) {
         return key.substring(
           0,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -24,6 +24,7 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
   data class EmergeComposeSnapshotReflectiveParameters(
     val previewConfig: ComposePreviewSnapshotConfig,
   ) {
+    // AndroidTestOrchestrator requires tests be
     override fun toString(): String = previewConfig.keyName(shortFqn = true)
   }
 
@@ -35,7 +36,6 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
     @Parameterized.Parameters(name = "{index}_{0}")
     fun data(): Iterable<EmergeComposeSnapshotReflectiveParameters> {
       val args = InstrumentationRegistry.getArguments()
-      Log.d(TAG, "Instrumentation arguments: $args")
 
       val invokeDataPath = args.getString(ARG_REFLECTIVE_INVOKE_DATA_PATH) ?: run {
         Log.w(TAG, "Missing invoke_data_path arg")
@@ -52,7 +52,6 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
       }
 
       return json.decodeFromString<ComposeSnapshots>(invokeDataFile.readText()).snapshots.mapIndexed { index, param ->
-        Log.d(TAG, "Parameterized ${index}: ${param.keyName()}")
         EmergeComposeSnapshotReflectiveParameters(param)
       }
     }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -50,8 +50,9 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
         ignoreUnknownKeys = true
       }
 
-      return json.decodeFromString<ComposeSnapshots>(invokeDataFile.readText()).snapshots.map {
-        EmergeComposeSnapshotReflectiveParameters(it)
+      return json.decodeFromString<ComposeSnapshots>(invokeDataFile.readText()).snapshots.mapIndexed { index, param ->
+        Log.d(TAG, "Parameterized ${index}: ${param.keyName()}")
+        EmergeComposeSnapshotReflectiveParameters(param)
       }
     }
   }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -67,8 +67,8 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
         ignoreUnknownKeys = true
       }
 
-      return json.decodeFromString<ComposeSnapshots>(invokeDataFile.readText()).snapshots.mapIndexed { index, param ->
-        EmergeComposeSnapshotReflectiveParameters(param)
+      return json.decodeFromString<ComposeSnapshots>(invokeDataFile.readText()).snapshots.map {
+        EmergeComposeSnapshotReflectiveParameters(it)
       }
     }
   }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -32,18 +32,20 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
     // https://github.com/android/android-test/issues/1935 is one reference issue
     override fun toString(): String {
       val key = previewConfig.keyName(shortFqn = true)
-      return if (key.length > MAX_PARAM_NAME_LENGTH) {
-        key.substring(
+      if (key.length > MAX_PARAM_NAME_LENGTH) {
+        return key.substring(
           0,
-          MAX_PARAM_NAME_LENGTH - 3
-        ) + "..."
-      } else key
+          MAX_PARAM_NAME_LENGTH - ELLIPSIS_SIZE
+        ) + ".".repeat(ELLIPSIS_SIZE)
+      }
+      return key
     }
   }
 
   companion object {
     const val TAG = "EmergeComposeSnapshotReflectiveParameterizedInvoker"
     const val ARG_REFLECTIVE_INVOKE_DATA_PATH = "invoke_data_path"
+    const val ELLIPSIS_SIZE = 3
     const val MAX_PARAM_NAME_LENGTH = 40
 
     @JvmStatic

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -24,14 +24,27 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
   data class EmergeComposeSnapshotReflectiveParameters(
     val previewConfig: ComposePreviewSnapshotConfig,
   ) {
-    // AndroidTestOrchestrator requires a max name of 127 (inclusive of EmergeComposeSnapshotReflectiveParameterizedInvoker.reflectiveComposableInvoker[index_])
-    // This gives us a max limit of 40 characters for the parameter name, which we'll
-    override fun toString(): String = previewConfig.keyName(shortFqn = true).take(40)
+    // AndroidTestOrchestrator requires a max name of ~127 from trial/error inclusive of
+    // EmergeComposeSnapshotReflectiveParameterizedInvoker.reflectiveComposableInvoker[12345_].
+    // This gives us a max limit of ~40 characters for the parameter name, which we'll trim to
+    // be safe and for best debuggability so we can at least see a bit of the keyName.
+    // Different issues online have presented different limits, so we'll be conservative here.
+    // https://github.com/android/android-test/issues/1935 is one reference issue
+    override fun toString(): String {
+      val key = previewConfig.keyName(shortFqn = true)
+      return if (key.length > MAX_PARAM_NAME_LENGTH) {
+        key.substring(
+          0,
+          MAX_PARAM_NAME_LENGTH - 3
+        ) + "..."
+      } else key
+    }
   }
 
   companion object {
     const val TAG = "EmergeComposeSnapshotReflectiveParameterizedInvoker"
     const val ARG_REFLECTIVE_INVOKE_DATA_PATH = "invoke_data_path"
+    const val MAX_PARAM_NAME_LENGTH = 40
 
     @JvmStatic
     @Parameterized.Parameters(name = "{index}_{0}")

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -24,8 +24,9 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
   data class EmergeComposeSnapshotReflectiveParameters(
     val previewConfig: ComposePreviewSnapshotConfig,
   ) {
-    // AndroidTestOrchestrator requires tests be
-    override fun toString(): String = previewConfig.hashCode().toString()
+    // AndroidTestOrchestrator requires a max name of 127 (inclusive of EmergeComposeSnapshotReflectiveParameterizedInvoker.reflectiveComposableInvoker[index_])
+    // This gives us a max limit of 40 characters for the parameter name, which we'll
+    override fun toString(): String = previewConfig.keyName(shortFqn = true).take(40)
   }
 
   companion object {
@@ -65,6 +66,7 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
 
   @Test
   fun reflectiveComposableInvoker() {
+    Log.i(TAG, "Running snapshot test ${parameter.previewConfig.keyName()}")
     // Force application to be debuggable to ensure PreviewActivity doesn't early exit
     val applicationInfo = InstrumentationRegistry.getInstrumentation().targetContext.applicationInfo
     applicationInfo.flags = applicationInfo.flags or ApplicationInfo.FLAG_DEBUGGABLE

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -24,7 +24,7 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
   data class EmergeComposeSnapshotReflectiveParameters(
     val previewConfig: ComposePreviewSnapshotConfig,
   ) {
-    override fun toString(): String = previewConfig.keyName().hashCode().toString()
+    override fun toString(): String = previewConfig.keyName(shortFqn = true)
   }
 
   companion object {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -35,6 +35,7 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
     @Parameterized.Parameters(name = "{index}_{0}")
     fun data(): Iterable<EmergeComposeSnapshotReflectiveParameters> {
       val args = InstrumentationRegistry.getArguments()
+      Log.d(TAG, "Instrumentation arguments: $args")
 
       val invokeDataPath = args.getString(ARG_REFLECTIVE_INVOKE_DATA_PATH) ?: run {
         Log.w(TAG, "Missing invoke_data_path arg")


### PR DESCRIPTION
Fixes bugs that were blocking us from leveraging Android test orchestrator. Particularly there is a bug in older versions where the length of the test name would cause orchestrator to fail. This is not well documented but is present in a few ASG discussions and this issue https://github.com/android/android-test/issues/1935