### PR TITLE
[Snapshots] Fix device specs

### DIFF
--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
@@ -1,0 +1,108 @@
+package com.emergetools.snapshots.sample.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PortraitLandscapeView() {
+  BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+    val aspectRatio = maxWidth / maxHeight
+
+    if (maxWidth < 840.dp) {
+      // Portrait mode for phones, tablets, and unfolded foldables
+      Column(
+        modifier = Modifier.fillMaxSize()
+      ) {
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f)
+            .background(Color.Blue)
+        )
+
+        Card(
+          modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f)
+            .padding(16.dp)
+        ) {
+          // Card content can be added here
+          Box(modifier = Modifier.fillMaxSize()) // Placeholder for card content
+        }
+      }
+    } else {
+      // Landscape mode or desktop
+      if (aspectRatio >= 2) {
+        // Mobile landscape
+        Row(
+          modifier = Modifier.fillMaxSize()
+        ) {
+          Box(
+            modifier = Modifier
+              .weight(1f)
+              .fillMaxHeight()
+              .background(Color.Blue)
+          )
+
+          Card(
+            modifier = Modifier
+              .weight(1f)
+              .fillMaxHeight()
+              .padding(16.dp)
+          ) {
+            // Card content can be added here
+            Box(modifier = Modifier.fillMaxSize()) // Placeholder for card content
+          }
+        }
+      } else {
+        // Portrait mode for tablets and unfolded foldables, landscape for desktops
+        Column(
+          modifier = Modifier.fillMaxSize()
+        ) {
+          Box(
+            modifier = Modifier
+              .fillMaxWidth()
+              .weight(1f)
+              .background(Color.Blue)
+          )
+
+          Card(
+            modifier = Modifier
+              .fillMaxWidth()
+              .weight(1f)
+              .padding(16.dp)
+          ) {
+            // Card content can be added here
+            Box(modifier = Modifier.fillMaxSize()) // Placeholder for card content
+          }
+        }
+      }
+    }
+  }
+}
+
+
+@Preview(device = Devices.PIXEL_5)
+@Preview(name = "Phone (Landscape)", device = "spec:width=430dp,height=860dp,orientation=landscape")
+@Preview(name = "Phone (Portrait)", device = "spec:width=430dp,height=860dp")
+@Composable
+fun PortraitLandscapeViewPreview() {
+  Surface {
+    PortraitLandscapeView()
+  }
+}

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
@@ -23,8 +23,8 @@ fun PortraitLandscapeView() {
   BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
     val aspectRatio = maxWidth / maxHeight
 
+    // Repro of client case with different layouts for different screen sizes
     if (maxWidth < 840.dp) {
-      // Portrait mode for phones, tablets, and unfolded foldables
       Column(
         modifier = Modifier.fillMaxSize()
       ) {
@@ -41,14 +41,11 @@ fun PortraitLandscapeView() {
             .weight(1f)
             .padding(16.dp)
         ) {
-          // Card content can be added here
           Box(modifier = Modifier.fillMaxSize()) // Placeholder for card content
         }
       }
     } else {
-      // Landscape mode or desktop
       if (aspectRatio >= 2) {
-        // Mobile landscape
         Row(
           modifier = Modifier.fillMaxSize()
         ) {
@@ -65,12 +62,10 @@ fun PortraitLandscapeView() {
               .fillMaxHeight()
               .padding(16.dp)
           ) {
-            // Card content can be added here
             Box(modifier = Modifier.fillMaxSize()) // Placeholder for card content
           }
         }
       } else {
-        // Portrait mode for tablets and unfolded foldables, landscape for desktops
         Column(
           modifier = Modifier.fillMaxSize()
         ) {
@@ -87,7 +82,6 @@ fun PortraitLandscapeView() {
               .weight(1f)
               .padding(16.dp)
           ) {
-            // Card content can be added here
             Box(modifier = Modifier.fillMaxSize()) // Placeholder for card content
           }
         }
@@ -95,7 +89,6 @@ fun PortraitLandscapeView() {
     }
   }
 }
-
 
 @Preview(device = Devices.PIXEL_5)
 @Preview(name = "Phone (Landscape)", device = "spec:width=430dp,height=860dp,orientation=landscape")

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -179,7 +179,7 @@ private fun snapshot(
     }
 
     // Add the ComposeView to the activity
-    activity.setContentView(composeView)
+    activity.addContentView(composeView, LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT))
 
     composeView.post {
       val size = measureViewSize(composeView, previewConfig)
@@ -219,7 +219,7 @@ private fun measureViewSize(
     }
 
     else ->
-      View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+      View.MeasureSpec.makeMeasureSpec(view.width, View.MeasureSpec.AT_MOST)
   }
 
   val heightMeasureSpec = when {
@@ -234,7 +234,7 @@ private fun measureViewSize(
     }
 
     else ->
-      View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.AT_MOST)
+      View.MeasureSpec.makeMeasureSpec(view.height, View.MeasureSpec.AT_MOST)
   }
 
   view.measure(widthMeasureSpec, heightMeasureSpec)

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -208,9 +208,6 @@ private fun measureViewSize(
 
   // Use exact measurements when we have them
   val widthMeasureSpec = when {
-    deviceSpec?.widthPixels != null && deviceSpec.widthPixels != -1 ->
-      View.MeasureSpec.makeMeasureSpec(deviceSpec.widthPixels, View.MeasureSpec.EXACTLY)
-
     previewConfig.widthDp != null -> {
       View.MeasureSpec.makeMeasureSpec(
         dpToPx(previewConfig.widthDp!!, view),
@@ -218,20 +215,23 @@ private fun measureViewSize(
       )
     }
 
+    deviceSpec?.widthPixels != null && deviceSpec.widthPixels != -1 ->
+      View.MeasureSpec.makeMeasureSpec(deviceSpec.widthPixels, View.MeasureSpec.EXACTLY)
+
     else ->
       View.MeasureSpec.makeMeasureSpec(view.width, View.MeasureSpec.AT_MOST)
   }
 
   val heightMeasureSpec = when {
-    deviceSpec?.heightPixels != null && deviceSpec.heightPixels != -1 ->
-      View.MeasureSpec.makeMeasureSpec(deviceSpec.heightPixels, View.MeasureSpec.EXACTLY)
-
     previewConfig.heightDp != null -> {
       View.MeasureSpec.makeMeasureSpec(
         dpToPx(previewConfig.heightDp!!, view),
         View.MeasureSpec.UNSPECIFIED
       )
     }
+
+    deviceSpec?.heightPixels != null && deviceSpec.heightPixels != -1 ->
+      View.MeasureSpec.makeMeasureSpec(deviceSpec.heightPixels, View.MeasureSpec.EXACTLY)
 
     else ->
       View.MeasureSpec.makeMeasureSpec(view.height, View.MeasureSpec.AT_MOST)

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -220,7 +220,7 @@ private fun measureViewSize(
       )
     }
 
-    deviceSpec?.widthPixels != null && deviceSpec.widthPixels != -1 ->
+    deviceSpec?.widthPixels != null && deviceSpec.widthPixels > 0 ->
       View.MeasureSpec.makeMeasureSpec(deviceSpec.widthPixels, View.MeasureSpec.EXACTLY)
 
     else ->
@@ -235,7 +235,7 @@ private fun measureViewSize(
       )
     }
 
-    deviceSpec?.heightPixels != null && deviceSpec.heightPixels != -1 ->
+    deviceSpec?.heightPixels != null && deviceSpec.heightPixels > 0 ->
       View.MeasureSpec.makeMeasureSpec(deviceSpec.heightPixels, View.MeasureSpec.EXACTLY)
 
     else ->

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -179,7 +179,10 @@ private fun snapshot(
     }
 
     // Add the ComposeView to the activity
-    activity.addContentView(composeView, LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT))
+    activity.addContentView(
+      composeView,
+      LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+    )
 
     composeView.post {
       val size = measureViewSize(composeView, previewConfig)
@@ -207,11 +210,13 @@ private fun measureViewSize(
   val deviceSpec = configToDeviceSpec(previewConfig)
 
   // Use exact measurements when we have them
+  val scalingFactor = deviceSpec?.scalingFactor ?: view.resources.displayMetrics.density
+
   val widthMeasureSpec = when {
     previewConfig.widthDp != null -> {
       View.MeasureSpec.makeMeasureSpec(
-        dpToPx(previewConfig.widthDp!!, view),
-        View.MeasureSpec.UNSPECIFIED
+        dpToPx(previewConfig.widthDp!!, scalingFactor),
+        View.MeasureSpec.EXACTLY
       )
     }
 
@@ -225,8 +230,8 @@ private fun measureViewSize(
   val heightMeasureSpec = when {
     previewConfig.heightDp != null -> {
       View.MeasureSpec.makeMeasureSpec(
-        dpToPx(previewConfig.heightDp!!, view),
-        View.MeasureSpec.UNSPECIFIED
+        dpToPx(previewConfig.heightDp!!, scalingFactor),
+        View.MeasureSpec.EXACTLY
       )
     }
 
@@ -251,8 +256,8 @@ private fun updateActivityBounds(activity: Activity, deviceSpec: DeviceSpec) {
   }
 }
 
-private fun dpToPx(dp: Int, view: View): Int {
-  return (dp * view.resources.displayMetrics.density).toInt()
+private fun dpToPx(dp: Int, scalingFactor: Float): Int {
+  return (dp * scalingFactor).toInt()
 }
 
 fun captureBitmap(

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -210,6 +210,14 @@ private fun measureViewSize(
   val widthMeasureSpec = when {
     deviceSpec?.widthPixels != null && deviceSpec.widthPixels != -1 ->
       View.MeasureSpec.makeMeasureSpec(deviceSpec.widthPixels, View.MeasureSpec.EXACTLY)
+
+    previewConfig.widthDp != null -> {
+      View.MeasureSpec.makeMeasureSpec(
+        dpToPx(previewConfig.widthDp!!, view),
+        View.MeasureSpec.UNSPECIFIED
+      )
+    }
+
     else ->
       View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
   }
@@ -217,8 +225,16 @@ private fun measureViewSize(
   val heightMeasureSpec = when {
     deviceSpec?.heightPixels != null && deviceSpec.heightPixels != -1 ->
       View.MeasureSpec.makeMeasureSpec(deviceSpec.heightPixels, View.MeasureSpec.EXACTLY)
+
+    previewConfig.heightDp != null -> {
+      View.MeasureSpec.makeMeasureSpec(
+        dpToPx(previewConfig.heightDp!!, view),
+        View.MeasureSpec.UNSPECIFIED
+      )
+    }
+
     else ->
-      View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+      View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.AT_MOST)
   }
 
   view.measure(widthMeasureSpec, heightMeasureSpec)
@@ -235,8 +251,8 @@ private fun updateActivityBounds(activity: Activity, deviceSpec: DeviceSpec) {
   }
 }
 
-private fun dpToPx(view: View, dp: Int, scalingFactor: Float): Int {
-  return (dp * scalingFactor).toInt()
+private fun dpToPx(dp: Int, view: View): Int {
+  return (dp * view.resources.displayMetrics.density).toInt()
 }
 
 fun captureBitmap(

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -3,7 +3,6 @@
 package com.emergetools.snapshots.compose
 
 import android.util.DisplayMetrics
-import android.util.Log
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import kotlin.math.roundToInt
 
@@ -216,11 +215,9 @@ fun configToDeviceSpec(config: ComposePreviewSnapshotConfig): DeviceSpec? {
       var heightDp = config.heightDp ?: devicePreviewString?.heightDp
 
       if (devicePreviewString?.orientation == "landscape") {
-        Log.d("SnapshotVariantProvider", "Flipping width $widthDp and height $heightDp")
         val height = heightDp
         heightDp = widthDp
         widthDp = height
-        Log.d("SnapshotVariantProvider", "Flipped new width $widthDp and height $heightDp")
       }
 
       DeviceSpec(
@@ -276,11 +273,6 @@ private fun parseSpecContent(specContent: String): DevicePreviewString {
   val paramPattern = Regex("""([^,:\s]\w+)=([^,]+)""")
   val params = paramPattern.findAll(specContent)
     .associate { it.groupValues[1].trim() to it.groupValues[2].trim() }
-
-  Log.d(
-    "SnapshotVariantProvider",
-    "params: ${params.entries.joinToString(separator = ",") { "${it.key}=${it.value}" }}"
-  )
 
   return DevicePreviewString(
     type = "spec",

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -16,10 +16,10 @@ data class DeviceSpec(
 
   // For pixel calculations, we need to use the actual density
   val widthPixels: Int
-    get() = if (widthDp < 0) -1 else (widthDp * density).roundToInt()
+    get() = if (widthDp < 0) -1 else (widthDp * density).toInt()
 
   val heightPixels: Int
-    get() = if (heightDp < 0) -1 else (heightDp * density).roundToInt()
+    get() = if (heightDp < 0) -1 else (heightDp * density).toInt()
 
   // This is used for the preview scaling factor
   val scalingFactor: Float

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -6,8 +6,8 @@ import android.util.DisplayMetrics
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 
 data class DeviceSpec(
-  val widthDp: Int,
-  val heightDp: Int,
+  val widthDp: Int?,
+  val heightDp: Int?,
   val dpi: Int,
 ) {
   // Calculate the density factor the same way Android does
@@ -15,10 +15,10 @@ data class DeviceSpec(
 
   // For pixel calculations, we need to use the actual density
   val widthPixels: Int
-    get() = if (widthDp < 0) -1 else (widthDp * density).toInt()
+    get() = if (widthDp == null) 0 else (widthDp * density).toInt()
 
   val heightPixels: Int
-    get() = if (heightDp < 0) -1 else (heightDp * density).toInt()
+    get() = if (heightDp == null) 0 else (heightDp * density).toInt()
 
   // This is used for the preview scaling factor
   val scalingFactor: Float
@@ -220,8 +220,8 @@ fun configToDeviceSpec(config: ComposePreviewSnapshotConfig): DeviceSpec? {
       }
 
       DeviceSpec(
-        heightDp = heightDp ?: -1,
-        widthDp = widthDp ?: -1,
+        heightDp = heightDp,
+        widthDp = widthDp,
         // https://cs.android.com/android-studio/platform/tools/adt/idea/+/mirror-goog-studio-main:preview-elements/src/com/android/tools/preview/config/Constants.kt;l=80
         dpi = devicePreviewString?.dpi ?: DisplayMetrics.DENSITY_420,
       )

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -26,6 +26,7 @@ data class DeviceSpec(
     get() = density
 
   // Restrict width/height to be multiples of 10
+  @Suppress("MagicNumber")
   private fun Float.roundToTen(): Int {
     return (this / 10).roundToInt() * 10
   }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -4,7 +4,6 @@ package com.emergetools.snapshots.compose
 
 import android.util.DisplayMetrics
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
-import kotlin.math.roundToInt
 
 data class DeviceSpec(
   val widthDp: Int,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -2,252 +2,207 @@
 
 package com.emergetools.snapshots.compose
 
-import com.emergetools.snapshots.compose.DeviceSpec.Companion.MDPI_THRESHOLD
+import android.util.DisplayMetrics
+import android.util.Log
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
-import kotlin.math.abs
-
-data class DimensionSpec(
-  val widthDp: Int? = null,
-  val heightDp: Int? = null,
-  val densityPpi: Int? = null,
-  val scalingFactor: Float? = null,
-  val fontScale: Float? = null,
-)
+import kotlin.math.roundToInt
 
 data class DeviceSpec(
-  val widthPixels: Int,
-  val heightPixels: Int,
-  val densityPpi: Int,
+  val widthDp: Int,
+  val heightDp: Int,
+  val dpi: Int,
 ) {
-  // https://m3.material.io/blog/device-metrics
-  val dimensionSpec: DimensionSpec
-    get() {
-      val proportion = densityPpi / MDPI_THRESHOLD
-      val widthDp = widthPixels / proportion
-      val heightDp = heightPixels / proportion
-      return DimensionSpec(
-        widthDp = widthDp,
-        heightDp = heightDp,
-        densityPpi = densityPpi,
-        scalingFactor = getClosestDensityScalingFactor(densityPpi),
-      )
-    }
+  // Calculate the density factor the same way Android does
+  private val density: Float = dpi.toFloat() / DisplayMetrics.DENSITY_DEFAULT
 
-  companion object {
-    private const val LDPI_THRESHOLD = 120
-    const val MDPI_THRESHOLD = 160
-    private const val HDPI_THRESHOLD = 240
-    private const val XHDPI_THRESHOLD = 320
-    private const val XXHDPI_THRESHOLD = 480
-    private const val XXXHDPI_THRESHOLD = 640
-    private const val LDPI_SCALE = 0.75f
-    private const val MDPI_SCALE = 1f
-    private const val HDPI_SCALE = 1.5f
-    private const val XHDPI_SCALE = 2f
-    private const val XXHDPI_SCALE = 3f
-    private const val XXXHDPI_SCALE = 4f
+  // For pixel calculations, we need to use the actual density
+  val widthPixels: Int
+    get() = if (widthDp < 0) -1 else (widthDp * density).roundToInt()
 
-    // https://m3.material.io/blog/device-metrics#finding-the-density-bucket
-    fun getClosestDensityScalingFactor(dpi: Int): Float {
-      val densityMap = mapOf(
-        LDPI_THRESHOLD to LDPI_SCALE,
-        MDPI_THRESHOLD to MDPI_SCALE,
-        HDPI_THRESHOLD to HDPI_SCALE,
-        XHDPI_THRESHOLD to XHDPI_SCALE,
-        XXHDPI_THRESHOLD to XXHDPI_SCALE,
-        XXXHDPI_THRESHOLD to XXXHDPI_SCALE,
-      )
+  val heightPixels: Int
+    get() = if (heightDp < 0) -1 else (heightDp * density).roundToInt()
 
-      var closestDensityScaling = MDPI_SCALE
-      var smallestDifference = Int.MAX_VALUE
-
-      for ((key, value) in densityMap.entries) {
-        val difference = abs(dpi - key)
-        if (difference < smallestDifference) {
-          smallestDifference = difference
-          closestDensityScaling = value
-        }
-      }
-
-      return closestDensityScaling
-    }
-  }
+  // This is used for the preview scaling factor
+  val scalingFactor: Float
+    get() = density
 }
 
+// https://m3.material.io/blog/device-metrics#putting-it-all-together
+// Calculated by dimension / (ppi / 160)
 val KNOWN_DEVICE_SPECS = mapOf<String, DeviceSpec>(
   // https://www.gsmarena.com/asus_google_nexus_7-4850.php
   "Nexus 7" to DeviceSpec(
-    widthPixels = 800,
-    heightPixels = 1280,
-    densityPpi = 216,
+    widthDp = 593,
+    heightDp = 948,
+    dpi = 216,
   ),
   // https://www.gsmarena.com/asus_google_nexus_7_(2013)-5600.php
   "Nexus 7 2013" to DeviceSpec(
-    widthPixels = 1200,
-    heightPixels = 1920,
-    densityPpi = 323,
+    widthDp = 594,
+    heightDp = 951,
+    dpi = 323,
   ),
   // https://www.gsmarena.com/lg_nexus_5-5705.php
   "Nexus 5" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 1920,
-    densityPpi = 445,
+    widthDp = 388,
+    heightDp = 690,
+    dpi = 445,
   ),
   // https://www.gsmarena.com/motorola_nexus_6-6604.php,
   "Nexus 6" to DeviceSpec(
-    widthPixels = 1440,
-    heightPixels = 2560,
-    densityPpi = 493,
+    widthDp = 467,
+    heightDp = 831,
+    dpi = 493,
   ),
-  // https://www.gsmarena.com/lg_nexus_5-5705.php
+  // https://www.gsmarena.com/htc_nexus_9-5823.php
   "Nexus 9" to DeviceSpec(
-    widthPixels = 1440,
-    heightPixels = 2560,
-    densityPpi = 518,
+    widthDp = 875,
+    heightDp = 1166,
+    dpi = 281,
   ),
   // https://www.gsmarena.com/samsung_google_nexus_10_p8110-5084.php
   "Nexus 10" to DeviceSpec(
-    widthPixels = 2560,
-    heightPixels = 1600,
-    densityPpi = 299,
+    widthDp = 1370,
+    heightDp = 856,
+    dpi = 299,
   ),
   // https://www.gsmarena.com/lg_nexus_5x-7556.php
   "Nexus 5X" to DeviceSpec(
-    widthPixels = 2560,
-    heightPixels = 1600,
-    densityPpi = 299,
+    widthDp = 409,
+    heightDp = 726,
+    dpi = 423,
   ),
   // https://www.gsmarena.com/huawei_nexus_6p-7588.php
   "Nexus 6P" to DeviceSpec(
-    widthPixels = 1440,
-    heightPixels = 2560,
-    densityPpi = 518,
+    widthDp = 445,
+    heightDp = 791,
+    dpi = 518,
   ),
   // https://www.gsmarena.com/google_pixel_c-7826.php
   "pixel_c" to DeviceSpec(
-    widthPixels = 2560,
-    heightPixels = 1800,
-    densityPpi = 308,
+    widthDp = 1330,
+    heightDp = 935,
+    dpi = 308,
   ),
   // https://www.gsmarena.com/google_pixel-8346.php
   "pixel" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 1920,
-    densityPpi = 441,
+    widthDp = 392,
+    heightDp = 697,
+    dpi = 441,
   ),
   // https://www.gsmarena.com/google_pixel_xl-8345.php
   "pixel_xl" to DeviceSpec(
-    widthPixels = 1440,
-    heightPixels = 2560,
-    densityPpi = 534,
+    widthDp = 431,
+    heightDp = 766,
+    dpi = 534,
   ),
   // https://www.gsmarena.com/google_pixel_2-8733.php
   "pixel_2" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 1920,
-    densityPpi = 441,
+    widthDp = 392,
+    heightDp = 697,
+    dpi = 441,
   ),
   // https://www.gsmarena.com/google_pixel_2_xl-8720.php
   "pixel_2_xl" to DeviceSpec(
-    widthPixels = 1440,
-    heightPixels = 2880,
-    densityPpi = 538,
+    widthDp = 428,
+    heightDp = 857,
+    dpi = 538,
   ),
   // https://www.gsmarena.com/google_pixel_3-9256.php
   "pixel_3" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 2160,
-    densityPpi = 443,
+    widthDp = 390,
+    heightDp = 780,
+    dpi = 443,
   ),
   // https://www.gsmarena.com/google_pixel_3_xl-9257.php
   "pixel_3_xl" to DeviceSpec(
-    widthPixels = 1440,
-    heightPixels = 2960,
-    densityPpi = 523,
+    widthDp = 441,
+    heightDp = 906,
+    dpi = 523,
   ),
   // https://www.gsmarena.com/google_pixel_3a-9408.php
   "pixel_3a" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 2220,
-    densityPpi = 441,
+    widthDp = 392,
+    heightDp = 805,
+    dpi = 441,
   ),
   // https://www.gsmarena.com/google_pixel_3a_xl-9690.php
   "pixel_3a_xl" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 2160,
-    densityPpi = 402,
+    widthDp = 430,
+    heightDp = 860,
+    dpi = 402,
   ),
   // https://www.gsmarena.com/google_pixel_4-9896.php
   "pixel_4" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 2280,
-    densityPpi = 444,
+    widthDp = 392,
+    heightDp = 822,
+    dpi = 444,
   ),
   // https://www.gsmarena.com/google_pixel_4_xl-9895.php
   "pixel_4_xl" to DeviceSpec(
-    widthPixels = 1440,
-    heightPixels = 3040,
-    densityPpi = 537,
+    widthDp = 429,
+    heightDp = 906,
+    dpi = 537,
   ),
   // https://www.gsmarena.com/google_pixel_4a-10123.php
   "pixel_4a" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 2340,
-    densityPpi = 443,
+    widthDp = 390,
+    heightDp = 845,
+    dpi = 443,
   ),
   // https://www.gsmarena.com/google_pixel_5-10386.php
   "pixel_5" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 2340,
-    densityPpi = 432,
+    widthDp = 400,
+    heightDp = 867,
+    dpi = 432,
   ),
   // https://www.gsmarena.com/google_pixel_6-11037.php
   "pixel_6" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 2400,
-    densityPpi = 411,
+    widthDp = 420,
+    heightDp = 934,
+    dpi = 411,
   ),
   // https://www.gsmarena.com/google_pixel_6_pro-10918.php
   "pixel_6_pro" to DeviceSpec(
-    widthPixels = 1440,
-    heightPixels = 3120,
-    densityPpi = 512,
+    widthDp = 450,
+    heightDp = 975,
+    dpi = 512,
   ),
   // https://www.gsmarena.com/google_pixel_6a-11229.php
   "pixel_6a" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 2400,
-    densityPpi = 429,
+    widthDp = 403,
+    heightDp = 895,
+    dpi = 429,
   ),
   // https://www.gsmarena.com/google_pixel_7-11903.php
   "pixel_7" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 2400,
-    densityPpi = 416,
+    widthDp = 415,
+    heightDp = 923,
+    dpi = 416,
   ),
   // https://www.gsmarena.com/google_pixel_7_pro-11908.php
   "pixel_7_pro" to DeviceSpec(
-    widthPixels = 1440,
-    heightPixels = 3120,
-    densityPpi = 512,
+    widthDp = 450,
+    heightDp = 975,
+    dpi = 512,
   ),
   // https://www.gsmarena.com/google_pixel_7a-12170.php
   "pixel_7a" to DeviceSpec(
-    widthPixels = 1080,
-    heightPixels = 2400,
-    densityPpi = 429,
+    widthDp = 403,
+    heightDp = 895,
+    dpi = 429,
   ),
   // https://www.gsmarena.com/google_pixel_fold-12265.php
   "pixel_fold" to DeviceSpec(
-    widthPixels = 1840,
-    heightPixels = 2208,
-    densityPpi = 378,
+    widthDp = 779,
+    heightDp = 935,
+    dpi = 378,
   ),
   // https://www.gsmarena.com/google_pixel_tablet-11905.php
   "pixel_tablet" to DeviceSpec(
-    widthPixels = 2560,
-    heightPixels = 1600,
-    densityPpi = 276,
+    widthDp = 1484,
+    heightDp = 928,
+    dpi = 276,
   ),
 )
 
@@ -256,43 +211,26 @@ fun configToDeviceSpec(config: ComposePreviewSnapshotConfig): DeviceSpec? {
   return when {
     devicePreviewString?.name != null -> KNOWN_DEVICE_SPECS[devicePreviewString.name]
     devicePreviewString?.id != null -> KNOWN_DEVICE_SPECS[devicePreviewString.id]
-    else -> null
-  }
-}
-
-fun configToDimensionSpec(
-  config: ComposePreviewSnapshotConfig,
-): DimensionSpec {
-  val devicePreviewString = parseDevicePreviewString(config.device)
-  val densityPpi = devicePreviewString?.dpi?.let { it / MDPI_THRESHOLD }
-  val dimensionSpec: DimensionSpec? = when {
-    devicePreviewString?.name != null -> KNOWN_DEVICE_SPECS[devicePreviewString.name]?.dimensionSpec
-    devicePreviewString?.id != null -> KNOWN_DEVICE_SPECS[devicePreviewString.id]?.dimensionSpec
     else -> {
-      var widthDp = devicePreviewString?.widthDp
-      var heightDp = devicePreviewString?.heightDp
-      // Flip to match orientation
+      var widthDp = config.widthDp ?: devicePreviewString?.widthDp
+      var heightDp = config.heightDp ?: devicePreviewString?.heightDp
+
       if (devicePreviewString?.orientation == "landscape") {
-        heightDp = devicePreviewString.widthDp
-        widthDp = devicePreviewString.heightDp
+        Log.d("SnapshotVariantProvider", "Flipping width $widthDp and height $heightDp")
+        val height = heightDp
+        heightDp = widthDp
+        widthDp = height
+        Log.d("SnapshotVariantProvider", "Flipped new width $widthDp and height $heightDp")
       }
-      DimensionSpec(
-        widthDp = widthDp,
-        heightDp = heightDp,
-        densityPpi = densityPpi,
-        scalingFactor = densityPpi?.let(DeviceSpec::getClosestDensityScalingFactor)
+
+      DeviceSpec(
+        heightDp = heightDp ?: -1,
+        widthDp = widthDp ?: -1,
+        // https://cs.android.com/android-studio/platform/tools/adt/idea/+/mirror-goog-studio-main:preview-elements/src/com/android/tools/preview/config/Constants.kt;l=80
+        dpi = devicePreviewString?.dpi ?: DisplayMetrics.DENSITY_420,
       )
     }
   }
-
-  // Override final values with those specified by user (width/height), and use the default values if not specified
-  return DimensionSpec(
-    widthDp = config.widthDp ?: dimensionSpec?.widthDp,
-    heightDp = config.heightDp ?: dimensionSpec?.heightDp,
-    fontScale = config.fontScale,
-    densityPpi = dimensionSpec?.densityPpi,
-    scalingFactor = dimensionSpec?.scalingFactor,
-  )
 }
 
 data class DevicePreviewString(
@@ -335,9 +273,14 @@ fun parseDevicePreviewString(deviceString: String?): DevicePreviewString? {
 }
 
 private fun parseSpecContent(specContent: String): DevicePreviewString {
-  val paramPattern = Regex("""(\w+)=([^,]+)""")
+  val paramPattern = Regex("""([^,:\s]\w+)=([^,]+)""")
   val params = paramPattern.findAll(specContent)
-    .associate { it.groupValues[1] to it.groupValues[2].trim() }
+    .associate { it.groupValues[1].trim() to it.groupValues[2].trim() }
+
+  Log.d(
+    "SnapshotVariantProvider",
+    "params: ${params.entries.joinToString(separator = ",") { "${it.key}=${it.value}" }}"
+  )
 
   return DevicePreviewString(
     type = "spec",

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -4,6 +4,7 @@ package com.emergetools.snapshots.compose
 
 import android.util.DisplayMetrics
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import kotlin.math.roundToInt
 
 data class DeviceSpec(
   val widthDp: Int?,
@@ -15,19 +16,24 @@ data class DeviceSpec(
 
   // For pixel calculations, we need to use the actual density
   val widthPixels: Int
-    get() = if (widthDp == null) 0 else (widthDp * density).toInt()
+    get() = if (widthDp == null) 0 else (widthDp * density).roundToTen()
 
   val heightPixels: Int
-    get() = if (heightDp == null) 0 else (heightDp * density).toInt()
+    get() = if (heightDp == null) 0 else (heightDp * density).roundToTen()
 
   // This is used for the preview scaling factor
   val scalingFactor: Float
     get() = density
+
+  // Restrict width/height to be multiples of 10
+  private fun Float.roundToTen(): Int {
+    return (this / 10).roundToInt() * 10
+  }
 }
 
 // https://m3.material.io/blog/device-metrics#putting-it-all-together
 // Calculated by dimension / (ppi / 160)
-val KNOWN_DEVICE_SPECS = mapOf<String, DeviceSpec>(
+val KNOWN_DEVICE_SPECS = mapOf(
   // https://www.gsmarena.com/asus_google_nexus_7-4850.php
   "Nexus 7" to DeviceSpec(
     widthDp = 593,
@@ -132,7 +138,7 @@ val KNOWN_DEVICE_SPECS = mapOf<String, DeviceSpec>(
   ),
   // https://www.gsmarena.com/google_pixel_4-9896.php
   "pixel_4" to DeviceSpec(
-    widthDp = 392,
+    widthDp = 390,
     heightDp = 822,
     dpi = 444,
   ),

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -5,11 +5,8 @@ import android.content.ContextWrapper
 import android.content.res.Configuration
 import android.content.res.Configuration.UI_MODE_NIGHT_MASK
 import android.content.res.Resources
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -19,7 +16,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.dp
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import java.util.Locale
 

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -43,17 +43,9 @@ fun SnapshotVariantProvider(
     setLocale(locale)
     parseDevicePreviewString(config.device)?.orientation?.let {
       orientation = when (it) {
-        "landscape" -> {
-          Configuration.ORIENTATION_LANDSCAPE
-        }
-
-        "portrait" -> {
-          Configuration.ORIENTATION_PORTRAIT
-        }
-
-        else -> {
-          Configuration.ORIENTATION_UNDEFINED
-        }
+        "landscape" -> Configuration.ORIENTATION_LANDSCAPE
+        "portrait" -> Configuration.ORIENTATION_PORTRAIT
+        else -> Configuration.ORIENTATION_UNDEFINED
       }
     }
   }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -41,6 +41,21 @@ fun SnapshotVariantProvider(
   val localConfiguration = Configuration(LocalConfiguration.current).apply {
     config.uiMode?.let { uiMode = it }
     setLocale(locale)
+    parseDevicePreviewString(config.device)?.orientation?.let {
+      orientation = when (it) {
+        "landscape" -> {
+          Configuration.ORIENTATION_LANDSCAPE
+        }
+
+        "portrait" -> {
+          Configuration.ORIENTATION_PORTRAIT
+        }
+
+        else -> {
+          Configuration.ORIENTATION_UNDEFINED
+        }
+      }
+    }
   }
 
   val providedValues = arrayOf(

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -5,6 +5,7 @@ import android.content.ContextWrapper
 import android.content.res.Configuration
 import android.content.res.Configuration.UI_MODE_NIGHT_MASK
 import android.content.res.Resources
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
@@ -25,13 +26,12 @@ import java.util.Locale
 @Composable
 fun SnapshotVariantProvider(
   config: ComposePreviewSnapshotConfig,
+  scalingFactor: Float?,
   content: @Composable () -> Unit,
 ) {
-  val dimensionSpec = configToDimensionSpec(config)
-
   val localDensity = Density(
-    fontScale = dimensionSpec.fontScale ?: LocalDensity.current.fontScale,
-    density = dimensionSpec.scalingFactor ?: LocalDensity.current.density,
+    fontScale = config.fontScale ?: LocalDensity.current.fontScale,
+    density = scalingFactor ?: LocalDensity.current.density,
   )
 
   val locale = config.locale?.let(::localeForLanguageCode) ?: Locale.getDefault()
@@ -58,8 +58,6 @@ fun SnapshotVariantProvider(
     values = providedValues.toList().toTypedArray(),
   ) {
     val modifier = Modifier
-      .then(dimensionSpec.widthDp?.let { Modifier.width(it.dp) } ?: Modifier)
-      .then(dimensionSpec.heightDp?.let { Modifier.height(it.dp) } ?: Modifier)
       .then(
         config.showBackground?.let {
           // By default, previews use White as the background color, so preserve behavior.

--- a/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/compose/DeviceUtilsTest.kt
+++ b/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/compose/DeviceUtilsTest.kt
@@ -6,29 +6,6 @@ import org.junit.Test
 class DeviceUtilsTest {
 
   @Test
-  fun `test properly gets closest density scaling factors`() {
-    val testCases = listOf(
-      120 to 0.75f,
-      160 to 1f,
-      240 to 1.5f,
-      320 to 2f,
-      480 to 3f,
-      640 to 4f,
-      100 to 0.75f,
-      150 to 1f,
-      220 to 1.5f,
-      290 to 2f,
-      500 to 3f,
-      700 to 4f
-    )
-
-    for ((input, expected) in testCases) {
-      val result = DeviceSpec.getClosestDensityScalingFactor(input)
-      assertEquals(expected, result)
-    }
-  }
-
-  @Test
   fun `test properly parses device preview strings`() {
     val testCases = listOf(
       "id:Nexus 7" to DevicePreviewString(type = "id", id = "Nexus 7"),


### PR DESCRIPTION
Fixes device specs to be true-to-size to reference devices. Also adjusts to properly scale custom specs. Added a repro case of a troublesome client snapshot that wasn't rendering in landscaped.

Verified with a sxs run against Google's compose preview snapshotting library, Emerge matches 1:1 on all device specs now. Android Studio images (copied directly from the previews) appear smaller, and dimensions do not match the reference device specs, so I believe matching the expected device dimensions like we do now is preferred over 1:1 matching of AS.

Also checked all reference devices against the outputted dimensions from Emerge snapshots after this change and all match 1:1.

<img width="787" alt="Screenshot 2024-10-22 at 9 15 45 AM" src="https://github.com/user-attachments/assets/44d3b0e4-a58f-4232-9491-1b4ae41c8d83">