### PR TITLE
Fix issue with nested typed/primitive preview params

### DIFF
--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/IconGroup.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/IconGroup.kt
@@ -1,0 +1,74 @@
+package com.emergetools.snapshots.sample.ui
+
+import androidx.annotation.IntRange
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.times
+import com.emergetools.snapshots.sample.ui.theme.SnapshotsSampleTheme
+
+private class CompletedWorkoutsDataForPreview : PreviewParameterProvider<Int> {
+  override val values: Sequence<Int>
+    get() = sequenceOf(1, 2, 3, 4, 5)
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun CompletedIconPilePreview(
+  @PreviewParameter(CompletedWorkoutsDataForPreview::class) completedWorkouts: Int,
+) {
+  SnapshotsSampleTheme {
+    IconGroup(
+      completedCount = completedWorkouts,
+    )
+  }
+}
+
+@Composable
+fun IconGroup(
+  @IntRange(from = 1) completedCount: Int,
+) {
+  // Display up to 9 icons
+  val resultCompletedCount = completedCount.coerceAtMost(9)
+  val iconSize = 48.dp
+  val borderSize = 2.dp
+  val boxSize = iconSize + borderSize
+  val overlapSize = -1 * 20.dp
+
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(overlapSize),
+  ) {
+    repeat(resultCompletedCount) {
+      Box(
+        modifier = Modifier
+            .clip(CircleShape)
+            .background(Color.Blue)
+            .border(borderSize, Color.White, CircleShape)
+            .size(boxSize),
+        contentAlignment = Alignment.Center,
+      ) {
+        Icon(
+          painter = painterResource(com.emergetools.snapshots.sample.R.drawable.ic_launcher_foreground),
+          contentDescription = null,
+          modifier = Modifier.size(iconSize),
+        )
+      }
+    }
+  }
+}

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/IconGroup.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/IconGroup.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
 import com.emergetools.snapshots.sample.ui.theme.SnapshotsSampleTheme
 
-private class CompletedWorkoutsDataForPreview : PreviewParameterProvider<Int> {
+private class CompletedIconPreviewProvider : PreviewParameterProvider<Int> {
   override val values: Sequence<Int>
     get() = sequenceOf(1, 2, 3, 4, 5)
 }
@@ -32,7 +32,7 @@ private class CompletedWorkoutsDataForPreview : PreviewParameterProvider<Int> {
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
 fun CompletedIconPilePreview(
-  @PreviewParameter(CompletedWorkoutsDataForPreview::class) completedWorkouts: Int,
+  @PreviewParameter(CompletedIconPreviewProvider::class) completedWorkouts: Int,
 ) {
   SnapshotsSampleTheme {
     IconGroup(

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/IconGroup.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/IconGroup.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MagicNumber")
+
 package com.emergetools.snapshots.sample.ui
 
 import androidx.annotation.IntRange
@@ -29,7 +31,7 @@ private class CompletedWorkoutsDataForPreview : PreviewParameterProvider<Int> {
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
-private fun CompletedIconPilePreview(
+fun CompletedIconPilePreview(
   @PreviewParameter(CompletedWorkoutsDataForPreview::class) completedWorkouts: Int,
 ) {
   SnapshotsSampleTheme {
@@ -57,10 +59,10 @@ fun IconGroup(
     repeat(resultCompletedCount) {
       Box(
         modifier = Modifier
-            .clip(CircleShape)
-            .background(Color.Blue)
-            .border(borderSize, Color.White, CircleShape)
-            .size(boxSize),
+          .clip(CircleShape)
+          .background(Color.Blue)
+          .border(borderSize, Color.White, CircleShape)
+          .size(boxSize),
         contentAlignment = Alignment.Center,
       ) {
         Icon(

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/MultiUserRow.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/MultiUserRow.kt
@@ -33,16 +33,16 @@ fun MultiUserRow(users: List<User>) {
     users.forEach { user ->
       Row(
         modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
+          .fillMaxWidth()
+          .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically
       ) {
         // Profile picture
         Surface(
           modifier = Modifier
-              .size(40.dp)
-              .clip(CircleShape)
-              .background(Color.Cyan),
+            .size(40.dp)
+            .clip(CircleShape)
+            .background(Color.Cyan),
           color = Color.Transparent
         ) {
           // Center content vertically and horizontally
@@ -70,7 +70,6 @@ fun MultiUserRow(users: List<User>) {
     }
   }
 }
-
 
 @Preview(showBackground = true)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/MultiUserRow.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/MultiUserRow.kt
@@ -1,0 +1,110 @@
+package com.emergetools.snapshots.sample.ui
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.emergetools.snapshots.sample.ui.theme.SnapshotsSampleTheme
+
+@Composable
+fun MultiUserRow(users: List<User>) {
+  Column {
+    users.forEach { user ->
+      Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        // Profile picture
+        Surface(
+          modifier = Modifier
+              .size(40.dp)
+              .clip(CircleShape)
+              .background(Color.Cyan),
+          color = Color.Transparent
+        ) {
+          // Center content vertically and horizontally
+          Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+          ) {
+            Text(
+              text = user.name.firstOrNull()?.uppercase() ?: "",
+              style = MaterialTheme.typography.bodyLarge,
+              textAlign = TextAlign.Center
+            )
+          }
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        // User details
+        Column {
+          Text(text = user.name, style = MaterialTheme.typography.bodyMedium)
+          Text(text = user.email, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+        }
+      }
+    }
+  }
+}
+
+
+@Preview(showBackground = true)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun MultiUserRowPreview(
+  @PreviewParameter(MultiUserRowPreviewProvider::class) users: List<User>,
+) {
+  SnapshotsSampleTheme {
+    MultiUserRow(users = users)
+  }
+}
+
+@Preview(showBackground = true)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun MultiUserRowPreviewWithLimit(
+  @PreviewParameter(MultiUserRowPreviewProvider::class, limit = 2) users: List<User>,
+) {
+  SnapshotsSampleTheme {
+    MultiUserRow(users = users)
+  }
+}
+
+class MultiUserRowPreviewProvider : PreviewParameterProvider<List<User>> {
+  override val values: Sequence<List<User>> = sequenceOf(
+    listOf(User(name = "Ryan", email = "ryan@emergetools.com")),
+    listOf(
+      User(name = "Ryan", email = "ryan@emergetools.com"),
+      User(name = "Trevor", email = "trevor@emergetools.com"),
+    ),
+    listOf(
+      User(name = "Ryan", email = "ryan@emergetools.com"),
+      User(name = "Trevor", email = "trevor@emergetools.com"),
+      User(name = "Josh", email = "josh@emergetools.com"),
+    ),
+  )
+}

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposableInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposableInvoker.kt
@@ -1,0 +1,155 @@
+package com.emergetools.snapshots.compose
+
+import android.util.Log
+import androidx.compose.runtime.reflect.ComposableMethod
+import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import java.lang.reflect.Modifier
+import java.lang.reflect.ParameterizedType
+
+/**
+ * Handles reflection-based invocation of Composable methods,
+ * including support for preview parameters.
+ */
+object ComposableInvoker {
+  private const val TAG = "ComposableInvoker"
+
+  /**
+   * Finds and returns the appropriate ComposableMethod for the given parameters.
+   */
+  fun findComposableMethod(
+    klass: Class<*>,
+    methodName: String,
+    previewProviderClass: Class<out PreviewParameterProvider<*>>? = null
+  ): ComposableMethod {
+    return previewProviderClass?.let { previewProvider ->
+      Log.d(TAG, "Looking for parameterized composable method: $methodName in class: ${klass.name}")
+
+      // Find the type argument for PreviewParameterProvider
+      val providerType = findPreviewParameterType(previewProvider)
+        ?: throw IllegalArgumentException("Unable to determine type argument for PreviewParameterProvider")
+
+      // Try to find the method with either the primitive or wrapper type
+      tryGetComposableMethod(klass, methodName, providerType)
+        ?: throw NoSuchMethodException("Could not find composable method: $methodName")
+    } ?: run {
+      Log.d(TAG, "Looking for composable method: $methodName in class: ${klass.name}")
+      klass.getDeclaredComposableMethod(methodName)
+    }
+  }
+
+  /**
+   * Prepares the composable method for invocation by ensuring accessibility.
+   */
+  fun prepareComposableMethod(
+    composableMethod: ComposableMethod,
+    originalFqn: String
+  ): ComposableMethod {
+    val backingMethod = composableMethod.asMethod()
+    if (!backingMethod.isAccessible) {
+      Log.i(TAG, "Marking composable method as accessible: $originalFqn")
+      backingMethod.isAccessible = true
+    }
+    return composableMethod
+  }
+
+  /**
+   * Gets parameters from a PreviewParameterProvider, respecting the limit if specified.
+   */
+  fun getPreviewParameters(
+    parameterProviderClass: Class<out PreviewParameterProvider<*>>?,
+    limit: Int? = null
+  ): List<Any?> {
+    return parameterProviderClass?.let {
+      val params = getPreviewProviderParameters(it)
+      limit?.let { maxLimit -> params.take(maxLimit) } ?: params
+    } ?: listOf(null)
+  }
+
+  fun isStatic(composableMethod: ComposableMethod): Boolean {
+    return Modifier.isStatic(composableMethod.asMethod().modifiers)
+  }
+
+  private fun findPreviewParameterType(previewProviderClass: Class<*>): Class<*>? {
+    // Look through all interfaces implemented by the class
+    for (genericInterface in previewProviderClass.genericInterfaces) {
+      if (genericInterface is ParameterizedType &&
+        genericInterface.rawType == PreviewParameterProvider::class.java
+      ) {
+        val typeArg = genericInterface.actualTypeArguments.firstOrNull()
+
+        // Handle different types of type arguments
+        return when (typeArg) {
+          // Direct class reference
+          is Class<*> -> typeArg
+          // Nested generic type (e.g., List<User>)
+          is ParameterizedType -> typeArg.rawType as? Class<*>
+          // Other cases (wildcards, type variables, etc.)
+          else -> null
+        }
+      }
+    }
+
+    // Check superclass if the interface isn't found in the current class
+    val superclass = previewProviderClass.genericSuperclass
+    if (superclass is ParameterizedType) {
+      return findPreviewParameterType(superclass.rawType as Class<*>)
+    }
+
+    return null
+  }
+
+  private fun tryGetComposableMethod(
+    klass: Class<*>,
+    methodName: String,
+    parameterType: Class<*>
+  ): ComposableMethod? {
+    // Map of primitive types to their wrapper classes
+    val primitiveToWrapper: Map<Class<*>?, Class<*>?> = mapOf(
+      Int::class.javaPrimitiveType to Integer::class.java,
+      Long::class.javaPrimitiveType to Long::class.java,
+      Double::class.javaPrimitiveType to Double::class.java,
+      Float::class.javaPrimitiveType to Float::class.java,
+      Boolean::class.javaPrimitiveType to Boolean::class.java,
+      Byte::class.javaPrimitiveType to Byte::class.java,
+      Short::class.javaPrimitiveType to Short::class.java,
+      Char::class.javaPrimitiveType to Character::class.java
+    )
+
+    // Map of wrapper classes to their primitive types
+    val wrapperToPrimitive = primitiveToWrapper.entries.associate { (k, v) -> v to k }
+
+    return try {
+      // First try with the original type
+      klass.getDeclaredComposableMethod(methodName, parameterType)
+    } catch (e: NoSuchMethodException) {
+      // If that fails, try with the corresponding primitive/wrapper type
+      val alternateType: Class<*>? = when {
+        parameterType.isPrimitive -> primitiveToWrapper[parameterType]
+        wrapperToPrimitive.containsKey(parameterType) -> wrapperToPrimitive[parameterType]
+        else -> null
+      }
+
+      alternateType?.let {
+        try {
+          klass.getDeclaredComposableMethod(methodName, it)
+        } catch (e: NoSuchMethodException) {
+          null
+        }
+      }
+    }
+  }
+
+  private fun getPreviewProviderParameters(
+    parameterProviderClass: Class<out PreviewParameterProvider<*>>
+  ): List<Any?> {
+    val constructor = parameterProviderClass.constructors
+      .singleOrNull { it.parameterTypes.isEmpty() }
+      ?.apply { isAccessible = true }
+      ?: throw IllegalArgumentException(
+        "PreviewParameterProvider constructor can not have parameters"
+      )
+    val params = constructor.newInstance() as PreviewParameterProvider<*>
+    return params.values.toList()
+  }
+}

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.IntSize
 import com.emergetools.snapshots.EmergeSnapshots
 import com.emergetools.snapshots.SnapshotErrorType
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import java.lang.reflect.Modifier
 
 @Suppress("TooGenericExceptionCaught", "ThrowsCount")
 fun snapshotComposable(
@@ -45,9 +46,7 @@ fun snapshotComposable(
       klass = klass,
       methodName = methodName,
       previewProviderClass = previewProviderClass
-    ).also { method ->
-      ComposableInvoker.prepareComposableMethod(method, previewConfig.originalFqn)
-    }
+    )
 
     // Get preview parameters
     val previewParams = ComposableInvoker.getPreviewParameters(
@@ -119,7 +118,7 @@ private fun snapshot(
     composeView.setContent {
       SnapshotVariantProvider(previewConfig, deviceSpec?.scalingFactor) {
         @Suppress("SpreadOperator")
-        if (ComposableInvoker.isStatic(composableMethod)) {
+        if (Modifier.isStatic(composableMethod.asMethod().modifiers)) {
           // This is a top level or static method
           composableMethod.invoke(currentComposer, null, *args)
         } else {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -54,6 +54,11 @@ fun snapshotComposable(
         ?.actualTypeArguments?.firstOrNull() as? Class<*> ?: throw IllegalArgumentException(
         "Unable to determine type argument for PreviewParameterProvider"
       )
+      // Find the type argument for PreviewParameterProvider
+      // TODO: Handle value types
+//      val providerType = findPreviewParameterType(previewProvider)
+//        ?: throw IllegalArgumentException("Unable to determine type argument for PreviewParameterProvider")
+
 
       klass.getDeclaredComposableMethod(methodName, providerType)
     } ?: run {
@@ -116,6 +121,39 @@ fun snapshotComposable(
     throw e
   }
 }
+
+///**
+// * Finds the actual type argument for a PreviewParameterProvider, handling nested generic types.
+// */
+//private fun findPreviewParameterType(previewProviderClass: Class<*>): Class<*>? {
+//  // Look through all interfaces implemented by the class
+//  for (genericInterface in previewProviderClass.genericInterfaces) {
+//    if (genericInterface is ParameterizedType &&
+//      genericInterface.rawType == PreviewParameterProvider::class.java) {
+//      val typeArg = genericInterface.actualTypeArguments.firstOrNull()
+//
+//      // Handle different types of type arguments
+//      return when (typeArg) {
+//        // Direct class reference
+//        is Class<*> -> typeArg
+//
+//        // Nested generic type (e.g., List<User>)
+//        is ParameterizedType -> typeArg.rawType as? Class<*>
+//
+//        // Other cases (wildcards, type variables, etc.)
+//        else -> null
+//      }
+//    }
+//  }
+//
+//  // Check superclass if the interface isn't found in the current class
+//  val superclass = previewProviderClass.genericSuperclass
+//  if (superclass is ParameterizedType) {
+//    return findPreviewParameterType(superclass.rawType as Class<*>)
+//  }
+//
+//  return null
+//}
 
 private fun getPreviewProviderParameters(
   parameterProviderClass: Class<out PreviewParameterProvider<*>>,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.unit.IntSize
 import com.emergetools.snapshots.EmergeSnapshots
 import com.emergetools.snapshots.SnapshotErrorType
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
-import java.lang.reflect.Modifier
 
 @Suppress("TooGenericExceptionCaught", "ThrowsCount")
 fun snapshotComposable(


### PR DESCRIPTION
A client tested out our latest 1.3.0 rc01 today and caught two edge cases in our PreviewParameter handling:

1. If the previewParameter provided a primitive, we weren't properly coercing it to the non-Kotlin wrapper type. We need to coerce it to the java primitive/java wrapper type for proper unboxing.
2. if the previewParameter was a nested generic, like `List<User>`, we weren't properly getting the providerType, which led to an error being thrown. We'll now handle nested parameterized types.

Also realized `ComposeSnapshotter` was getting a bit unwieldy, so abstracted it out to `ComposeInvoker`, inspiration taken from [here](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui-tooling/src/jvmMain/kotlin/androidx/compose/ui/tooling/ComposableInvoker.jvm.kt;l=26?q=androidx.compose.runtime.reflect.ComposableMethodInvoker&sq=&ss=androidx/platform/frameworks/support).