### PR TITLE
Lower compose version to avoid breaking change added in 1.7.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,13 @@ androidx-test = "1.5.0"
 androidx-test-ext = "1.1.5"
 agp = "8.5.2"
 androidxactivity = "1.7.1"
-compose-bom = "2024.10.01"
+# 2024.08.00 is 1.6.8
+# 1.7.0+ updates ComposableLambda to leverage a new rememberComposableLambda function that
+# is implicitly added by the compose compiler. This is a breaking change for consumers before 1.7.0,
+# so we'll need to lock ourselves to an older version and later add restrictions for what compose
+# versions are supported when we decided to update.
+# https://android-review.googlesource.com/c/platform/frameworks/support/+/2692852/37/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/internal/ComposableLambda.kt#625
+compose-bom = "2024.08.00"
 detekt = "1.22.0"
 kotlin = "2.0.21"
 kotlin-coroutines = "1.8.0"
@@ -26,7 +32,7 @@ foundation-layout-android = "1.7.3"
 emerge-gradle-plugin = "4.0.2"
 emerge-performance = "2.1.2"
 emerge-reaper = "1.0.0-rc03"
-emerge-snapshots = "1.3.0-rc03"
+emerge-snapshots = "1.3.0-rc02"
 emerge-distribution = "0.0.1"
 
 [plugins]


### PR DESCRIPTION
1.7.0 of `compose-runtime` (any compose-bom after `2024.08.00`) has a breaking change in our snapshots SDK when targeting an app with 1.6.8 or lower (bom `2024.08.00`). 

When building our SDK with a 1.7.0+, a `rememberComposableLambda` function is called that was [added in 1.7.0](https://android-review.googlesource.com/c/platform/frameworks/support/+/2692852/37/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/internal/ComposableLambda.kt#625). When our snapshots SDK is used as an `androidTestImplementation` dependency against an app with a lower compose version, this function is not present, which leads to a `NoSuchMethodError` upon trying to invoke the snapshot.

For now, this should be able to be fixed with a simple version drop, and longer term we can work through a more elegant solution that can allow us to ship with whatever version of compose we'd like, while supporting any client version.