### PR TITLE
Use providers.gradleProperty for project isolation compatibility

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -114,7 +114,7 @@ class EmergePlugin : Plugin<Project> {
           registerSnapshotTasks(appProject, emergeExtension, variant, androidTest)
         }
 
-        if (appProject.hasProperty(EMERGE_DEBUG_TASK_PROPERTY)) {
+        if (appProject.providers.gradleProperty(EMERGE_DEBUG_TASK_PROPERTY).orNull != null) {
           registerDebugTasks(appProject, emergeExtension)
         }
       }


### PR DESCRIPTION
The EmergePlugin has a couple violations when enabling project isolation on a consuming project. This addresses one of the violations by using `providers.gradleProperty` which is PI compatible.

The remaining violation is related to setting up the performance project, but fixing that requires a lot more changes and is easy to workaround by disabling performance on local builds.