### PR TITLE
Use providers.gradleProperty for project isolation compatibility

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -114,7 +114,7 @@ class EmergePlugin : Plugin<Project> {
           registerSnapshotTasks(appProject, emergeExtension, variant, androidTest)
         }
 
-        if (appProject.hasProperty(EMERGE_DEBUG_TASK_PROPERTY)) {
+        if (appProject.providers.gradleProperty(EMERGE_DEBUG_TASK_PROPERTY).orNull != null) {
           registerDebugTasks(appProject, emergeExtension)
         }
       }


### PR DESCRIPTION
Internal version of https://github.com/EmergeTools/emerge-android/pull/306 for secrets with tests