### PR TITLE
Snapshots performance profiling

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePlugin.kt
@@ -282,6 +282,7 @@ class EmergePlugin : Plugin<Project> {
       )
       addItem("tag (optional): ${extension.snapshotOptions.tag.orEmpty()}", snapshotsHeading)
       addItem("enabled: ${extension.snapshotOptions.enabled.getOrElse(true)}", snapshotsHeading)
+      addItem("profile: ${extension.snapshotOptions.profile.getOrElse(false)}", snapshotsHeading)
 
       val reaperHeading = addHeading("reaper")
       addItem(

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -201,6 +201,11 @@ abstract class SnapshotOptions : ProductOptions() {
    * defaults to true
    */
   abstract val includePreviewParamPreviews: Property<Boolean>
+
+  /**
+   * Record profiling information for snapshot tests, defaults to false.
+   */
+  abstract val profile: Property<Boolean>
 }
 
 abstract class ReaperOptions : ProductOptions() {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
@@ -68,6 +68,10 @@ abstract class LocalSnapshots : DefaultTask() {
   @get:Optional
   abstract val includePreviewParamPreviews: Property<Boolean>
 
+  @get:Input
+  @get:Optional
+  abstract val profile: Property<Boolean>
+
   @TaskAction
   fun execute() {
     val artifactMetadataFiles = packageDir.asFileTree.matching {
@@ -148,6 +152,8 @@ abstract class LocalSnapshots : DefaultTask() {
             it.add("-e")
             it.add("invoke_data_path")
             it.add("/data/local/tmp/$COMPOSE_SNAPSHOTS_FILENAME")
+          }
+          if (profile.getOrElse(false)) {
             it.add("-e")
             it.add("save_profile")
             it.add("true")

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
@@ -148,6 +148,9 @@ abstract class LocalSnapshots : DefaultTask() {
             it.add("-e")
             it.add("invoke_data_path")
             it.add("/data/local/tmp/$COMPOSE_SNAPSHOTS_FILENAME")
+            it.add("-e")
+            it.add("save_profile")
+            it.add("true")
           }
           it.add("${testAppId}/${testInstrumentationRunner.get()}")
         }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
@@ -127,6 +127,7 @@ private fun registerSnapshotLocalTask(
     it.testInstrumentationRunner.set(testInstrumentationRunner)
     it.includePrivatePreviews.set(extension.snapshotOptions.includePrivatePreviews)
     it.includePreviewParamPreviews.set(extension.snapshotOptions.includePreviewParamPreviews)
+    it.profile.set(extension.snapshotOptions.profile)
     it.dependsOn(packageTask)
   }
 }

--- a/snapshots/sample/app/build.gradle.kts
+++ b/snapshots/sample/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.util.profile
+
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
@@ -17,6 +19,8 @@ emerge {
 
   snapshots {
     tag.setFromVariant()
+
+    profile.set(true)
   }
 }
 

--- a/snapshots/sample/app/build.gradle.kts
+++ b/snapshots/sample/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.util.profile
-
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
@@ -39,6 +39,7 @@ internal object SnapshotSaver {
     fqn: String,
     composePreviewSnapshotConfig: ComposePreviewSnapshotConfig,
   ) {
+    Profiler.startSpan("save")
     val snapshotsDir = File(filesDir, SNAPSHOTS_DIR_NAME)
     if (!snapshotsDir.exists() && !snapshotsDir.mkdirs()) {
       error("Unable to create snapshots storage directory.")
@@ -63,6 +64,7 @@ internal object SnapshotSaver {
         composePreviewSnapshotConfig = composePreviewSnapshotConfig,
       )
     }
+    Profiler.endSpan()
   }
 
   fun saveError(
@@ -71,6 +73,7 @@ internal object SnapshotSaver {
     errorType: SnapshotErrorType,
     composePreviewSnapshotConfig: ComposePreviewSnapshotConfig,
   ) {
+    Profiler.startSpan("saveError")
     val snapshotsDir = File(filesDir, SNAPSHOTS_DIR_NAME)
     if (!snapshotsDir.exists() && !snapshotsDir.mkdirs()) {
       error("Unable to create snapshots storage directory.")
@@ -85,6 +88,7 @@ internal object SnapshotSaver {
         composePreviewSnapshotConfig = composePreviewSnapshotConfig,
       )
     }
+    Profiler.endSpan()
   }
 
   private fun saveImage(

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
@@ -18,7 +18,6 @@ internal object SnapshotSaver {
   private const val DEFAULT_PNG_QUALITY = 100
   private const val SNAPSHOTS_DIR_NAME = "snapshots"
   private const val ARG_KEY_SAVE_METADATA = "save_metadata"
-  private const val ARG_KEY_SAVE_PROFILE = "save_profile"
   private const val TAG = "SnapshotSaver"
 
   private val targetContext: Context
@@ -33,10 +32,6 @@ internal object SnapshotSaver {
   private val saveMetadata: Boolean
     get() = args.getBoolean(ARG_KEY_SAVE_METADATA, false) ||
       args.getString(ARG_KEY_SAVE_METADATA, "false").toBoolean()
-
-  private val saveProfile: Boolean
-    get() = args.getBoolean(ARG_KEY_SAVE_PROFILE, false) ||
-      args.getString(ARG_KEY_SAVE_PROFILE, "false").toBoolean()
 
   fun save(
     displayName: String?,
@@ -68,13 +63,6 @@ internal object SnapshotSaver {
         composePreviewSnapshotConfig = composePreviewSnapshotConfig,
       )
     }
-
-    if (saveProfile) {
-      saveProfile(
-        snapshotsDir = snapshotsDir,
-        keyName = keyName,
-      )
-    }
   }
 
   fun saveError(
@@ -95,13 +83,6 @@ internal object SnapshotSaver {
         fqn = fqn,
         errorType = errorType,
         composePreviewSnapshotConfig = composePreviewSnapshotConfig,
-      )
-    }
-
-    if (saveProfile) {
-      saveProfile(
-        snapshotsDir = snapshotsDir,
-        keyName = composePreviewSnapshotConfig.keyName(),
       )
     }
   }
@@ -163,18 +144,6 @@ internal object SnapshotSaver {
     }
   }
 
-  private fun saveProfile(
-    snapshotsDir: File,
-    keyName: String,
-  ) {
-    val profileData = Profiler.export() ?: return
-
-    Log.d(TAG, "Saving profile for $keyName")
-    saveFile(snapshotsDir, "$keyName$FOLDED_EXTENSION") {
-      write(profileData.toByteArray(Charset.defaultCharset()))
-    }
-  }
-
   private fun saveFile(
     dir: File,
     filenameWithExtension: String,
@@ -193,5 +162,4 @@ internal object SnapshotSaver {
 
   private const val PNG_EXTENSION = ".png"
   private const val JSON_EXTENSION = ".json"
-  private const val FOLDED_EXTENSION = ".folded"
 }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotSaver.kt
@@ -91,10 +91,12 @@ internal object SnapshotSaver {
     snapshotsDir: File,
     keyName: String,
     bitmap: Bitmap,
-  ) = Profiler.trace("saveImage") {
+  ) {
+    Profiler.startSpan("saveImage")
     saveFile(snapshotsDir, "$keyName$PNG_EXTENSION") {
       bitmap.compress(Bitmap.CompressFormat.PNG, DEFAULT_PNG_QUALITY, this)
     }
+    Profiler.endSpan()
   }
 
   private fun saveMetadata(
@@ -103,7 +105,8 @@ internal object SnapshotSaver {
     displayName: String?,
     fqn: String,
     composePreviewSnapshotConfig: ComposePreviewSnapshotConfig,
-  ) = Profiler.trace("saveMetadata") {
+  ) {
+    Profiler.startSpan("saveMetadata")
     val metadata: SnapshotMetadata = SnapshotMetadata.SuccessMetadata(
       name = keyName,
       displayName = displayName,
@@ -118,6 +121,7 @@ internal object SnapshotSaver {
     saveFile(snapshotsDir, "$keyName$JSON_EXTENSION") {
       write(jsonString.toByteArray(Charset.defaultCharset()))
     }
+    Profiler.endSpan()
   }
 
   private fun saveErrorMetadata(
@@ -126,7 +130,8 @@ internal object SnapshotSaver {
     fqn: String,
     errorType: SnapshotErrorType,
     composePreviewSnapshotConfig: ComposePreviewSnapshotConfig,
-  ) = Profiler.trace("saveErrorMetadata") {
+  ) {
+    Profiler.startSpan("saveErrorMetadata")
     val keyName = composePreviewSnapshotConfig.keyName()
     val metadata: SnapshotMetadata = SnapshotMetadata.ErrorMetadata(
       name = composePreviewSnapshotConfig.keyName(),
@@ -142,22 +147,25 @@ internal object SnapshotSaver {
     saveFile(snapshotsDir, "$keyName$JSON_EXTENSION") {
       write(jsonString.toByteArray(Charset.defaultCharset()))
     }
+    Profiler.endSpan()
   }
 
   private fun saveFile(
     dir: File,
     filenameWithExtension: String,
     writer: FileOutputStream.() -> Unit,
-  ) = Profiler.trace("saveFile") {
+  ) {
+    Profiler.startSpan("saveFile")
     val outputFile = File(dir, filenameWithExtension)
 
     if (outputFile.exists()) {
       Log.e(TAG, "File with name $filenameWithExtension already exists, skipping save.")
-      return@trace
+      return
     }
 
     Log.d(TAG, "Saving file to ${outputFile.path}")
     outputFile.outputStream().use { writer(it) }
+    Profiler.endSpan()
   }
 
   private const val PNG_EXTENSION = ".png"

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposableInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposableInvoker.kt
@@ -98,10 +98,10 @@ object ComposableInvoker {
   private fun Class<*>.findComposableMethod(
     methodName: String,
     vararg previewParamArgs: Any?
-  ): Method? {
+  ): Method? = Profiler.trace("findComposableMethod") {
     val argsArray: Array<Class<out Any>> =
       previewParamArgs.mapNotNull { it?.javaClass }.toTypedArray()
-    return try {
+    return@trace try {
       val changedParamsCount = changedParamCount(argsArray.size, 0)
       val changedParams = Int::class.java.dup(changedParamsCount)
       declaredMethods.findCompatibleComposeMethod(
@@ -134,7 +134,7 @@ object ComposableInvoker {
     instance: Any?,
     composer: Composer,
     vararg args: Any?
-  ): Any? {
+  ): Any? = Profiler.trace("Method.invokeComposableMethod") {
     val composerIndex = parameterTypes.indexOfLast { it == Composer::class.java }
     val realParams = composerIndex
     val thisParams = if (instance != null) 1 else 0
@@ -176,7 +176,7 @@ object ComposableInvoker {
           else -> error("Unexpected index")
         }
       }
-    return invoke(instance, *arguments)
+    return@trace invoke(instance, *arguments)
   }
 
   /**

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposableInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposableInvoker.kt
@@ -2,6 +2,7 @@ package com.emergetools.snapshots.compose
 
 import android.util.Log
 import androidx.compose.runtime.Composer
+import com.emergetools.snapshots.util.Profiler
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import kotlin.math.ceil
@@ -16,7 +17,7 @@ object ComposableInvoker {
     methodName: String,
     composer: Composer,
     vararg args: Any?
-  ) {
+  ) = Profiler.trace("invokeComposable") {
     try {
       val composableClass = Class.forName(className)
       val method = composableClass.findComposableMethod(methodName, *args)

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -74,7 +74,7 @@ private fun snapshot(
         previewParameter = previewConfig.previewParameter?.copy(index = index)
       )
 
-      Profiler.stopSpan()
+      Profiler.endSpan()
 
       // Update activity window size if device is specified
       if (deviceSpec != null) {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -22,7 +22,7 @@ fun snapshotComposable(
   snapshotRule: EmergeSnapshots,
   activity: PreviewActivity,
   previewConfig: ComposePreviewSnapshotConfig,
-) = Profiler.trace(previewConfig.keyName()) {
+) = Profiler.trace("snapshotComposable") {
   try {
     snapshot(
       activity = activity,
@@ -57,7 +57,7 @@ private fun snapshot(
   val deviceSpec = configToDeviceSpec(previewConfig)
 
   for (index in previewParameters.indices) {
-    Profiler.trace("snapshot preview param $index") {
+    Profiler.trace("previewParam_$index") {
 
       val prevParam = previewParameters[index]
       Log.d(

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -58,7 +58,6 @@ private fun snapshot(
 
   for (index in previewParameters.indices) {
     Profiler.trace("previewParam_$index") {
-
       val prevParam = previewParameters[index]
       Log.d(
         EmergeComposeSnapshotReflectiveParameterizedInvoker.TAG,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -4,6 +4,7 @@ package com.emergetools.snapshots.compose
 
 import android.util.DisplayMetrics
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import com.emergetools.snapshots.util.Profiler
 import kotlin.math.roundToInt
 
 data class DeviceSpec(
@@ -211,9 +212,9 @@ val KNOWN_DEVICE_SPECS = mapOf(
   ),
 )
 
-fun configToDeviceSpec(config: ComposePreviewSnapshotConfig): DeviceSpec? {
+fun configToDeviceSpec(config: ComposePreviewSnapshotConfig): DeviceSpec? = Profiler.trace("configToDeviceSpec") {
   val devicePreviewString = parseDevicePreviewString(config.device)
-  return when {
+  return@trace when {
     devicePreviewString?.name != null -> KNOWN_DEVICE_SPECS[devicePreviewString.name]
     devicePreviewString?.id != null -> KNOWN_DEVICE_SPECS[devicePreviewString.id]
     else -> {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -83,8 +83,15 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
   @get:Rule
   val profiler = Profiler.getInstance(parameter.previewConfig)
 
+  fun someMethod() {
+    Profiler.startSpan("someMethod")
+    // some code
+    Profiler.endSpan()
+  }
+
   @Test
   fun reflectiveComposableInvoker() {
+    Profiler.startSpan("reflectiveComposableInvoker")
     Log.i(TAG, "Running snapshot test ${parameter.previewConfig.keyName()}")
     // Force application to be debuggable to ensure PreviewActivity doesn't early exit
     val applicationInfo = InstrumentationRegistry.getInstrumentation().targetContext.applicationInfo
@@ -94,5 +101,6 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
     scenarioRule.scenario.onActivity { activity ->
       snapshotComposable(snapshotRule, activity, previewConfig)
     }
+    Profiler.endSpan()
   }
 }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -80,6 +80,9 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
   @get:Rule
   val snapshotRule: EmergeSnapshots = EmergeSnapshots()
 
+  @get:Rule
+  val profiler = Profiler.getInstance(parameter.previewConfig)
+
   @Test
   fun reflectiveComposableInvoker() {
     Log.i(TAG, "Running snapshot test ${parameter.previewConfig.keyName()}")

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -8,6 +8,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.emergetools.snapshots.EmergeSnapshots
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import com.emergetools.snapshots.shared.ComposeSnapshots
+import com.emergetools.snapshots.util.Profiler
 import kotlinx.serialization.json.Json
 import org.junit.Rule
 import org.junit.Test

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/previewparams/PreviewParamUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/previewparams/PreviewParamUtils.kt
@@ -3,6 +3,7 @@ package com.emergetools.snapshots.compose.previewparams
 import android.util.Log
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import com.emergetools.snapshots.util.Profiler
 
 // Inspired by https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui-tooling/src/androidMain/kotlin/androidx/compose/ui/tooling/PreviewUtils.android.kt
 object PreviewParamUtils {
@@ -11,15 +12,15 @@ object PreviewParamUtils {
   @Suppress("ReturnCount")
   internal fun getPreviewProviderParameters(
     previewConfig: ComposePreviewSnapshotConfig
-  ): Array<Any?>? {
+  ): Array<Any?>? = Profiler.trace("getPreviewProviderParameters") {
     if (previewConfig.previewParameter == null) {
       Log.d(TAG, "No PreviewParameterProvider found for ${previewConfig.originalFqn}")
-      return null
+      return@trace null
     }
 
     if (previewConfig.previewParameter?.providerClassFqn.isNullOrEmpty()) {
       Log.e(TAG, "PreviewParameterProvider class name is empty for ${previewConfig.originalFqn}")
-      return null
+      return@trace null
     }
 
     val paramProviderClass = try {
@@ -31,7 +32,7 @@ object PreviewParamUtils {
           " for ${previewConfig.originalFqn}",
         e
       )
-      return null
+      return@trace null
     }
 
     if (paramProviderClass == null) {
@@ -40,7 +41,7 @@ object PreviewParamUtils {
         "PreviewProvider '${previewConfig.previewParameter!!.providerClassFqn}'" +
           " is not a PreviewParameterProvider for ${previewConfig.originalFqn}"
       )
-      return null
+      return@trace null
     }
 
     val constructor = paramProviderClass.constructors
@@ -51,7 +52,7 @@ object PreviewParamUtils {
       )
     val params = constructor.newInstance() as PreviewParameterProvider<*>
 
-    return params.values.toArray(params.count)
+    return@trace params.values.toArray(params.count)
       .map { unwrapIfInline(it) }
       .take(previewConfig.previewParameter?.limit ?: params.count)
       .toTypedArray()

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
@@ -108,7 +108,6 @@ class Profiler(
       return
     }
 
-
     if (stack.isNotEmpty()) {
       val endTime = System.currentTimeMillis()
       val spanName = stack.removeAt(stack.size - 1)
@@ -151,4 +150,3 @@ class Profiler(
     outputFile.outputStream().use { it.write(profileData.toByteArray(Charset.defaultCharset())) }
   }
 }
-

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
@@ -28,15 +28,15 @@ class Profiler(
       }
 
     fun <T> trace(name: String, block: () -> T): T {
-      return instance!!.traceInternal(name, block)
+      return instance?.traceInternal(name, block) ?: block()
     }
 
     fun startSpan(name: String) {
-      return instance!!.startSpanInternal(name)
+      return instance?.startSpanInternal(name) ?: Unit
     }
 
     fun stopSpan() {
-      return instance!!.stopSpanInternal()
+      return instance?.stopSpanInternal() ?: Unit
     }
   }
 

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
@@ -76,7 +76,7 @@ class Profiler(
     }
   }
 
-  private inline fun <T> traceInternal(name: String, crossinline block: () -> T): T {
+  private inline fun <T> traceInternal(name: String, noinline block: () -> T): T {
     if (!profilingEnabled) {
       Log.d(TAG, "Profiling disabled, skipping trace")
       return block()

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
@@ -1,0 +1,89 @@
+package com.emergetools.snapshots.util
+
+class Profiler {
+
+  private val stack = object : ThreadLocal<MutableList<String>>() {
+    override fun initialValue(): MutableList<String> {
+      return mutableListOf()
+    }
+  }
+  private val foldedStacks = object : ThreadLocal<MutableList<String>>() {
+    override fun initialValue(): MutableList<String> {
+      return mutableListOf()
+    }
+  }
+
+  private val startTime = object : ThreadLocal<Long>() {
+    override fun initialValue(): Long {
+      return 0L
+    }
+  }
+
+  companion object {
+    private val INSTANCE = Profiler()
+
+    fun <T> trace(name: String, block: () -> T): T {
+      return INSTANCE.traceInternal(name, block)
+    }
+
+    fun startSpan(name: String) {
+      return INSTANCE.startSpanInternal(name)
+    }
+
+    fun stopSpan() {
+      return INSTANCE.stopSpanInternal()
+    }
+
+    fun export(): String? {
+      return INSTANCE.export()
+    }
+  }
+
+  private fun <T> traceInternal(name: String, block: () -> T): T {
+    startSpanInternal(name)
+    return try {
+      block()
+    } finally {
+      stopSpanInternal()
+    }
+  }
+
+  private fun startSpanInternal(name: String) {
+    val localStack = stack.get()
+    if (localStack.isEmpty()) {
+      startTime.set(System.currentTimeMillis())
+    }
+    localStack.add(name)
+  }
+
+  private fun stopSpanInternal() {
+    val localStack = stack.get()
+    val localFoldedStacks = foldedStacks.get()
+    val localStartTime = startTime.get()
+
+    if (localStack.isNotEmpty()) {
+      val endTime = System.currentTimeMillis()
+      val spanName = localStack.removeAt(localStack.size - 1)
+      var foldedStack = localStack.joinToString(";")
+      if (foldedStack.isNotEmpty()) {
+        foldedStack = "$foldedStack;"
+      }
+      val duration = endTime - localStartTime
+      localFoldedStacks.add("$foldedStack$spanName $duration")
+    }
+  }
+
+  fun export(): String? {
+    val localStack = stack.get()
+    val localFoldedStacks = foldedStacks.get()
+
+    while (localStack.isNotEmpty()) {
+      stopSpanInternal()
+    }
+    return if (localFoldedStacks.isNotEmpty()) {
+      localFoldedStacks.joinToString("\n")
+    } else {
+      null
+    }
+  }
+}

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
@@ -76,7 +76,7 @@ class Profiler(
     }
   }
 
-  private fun <T> traceInternal(name: String, block: () -> T): T {
+  private inline fun <T> traceInternal(name: String, crossinline block: () -> T): T {
     if (!profilingEnabled) {
       Log.d(TAG, "Profiling disabled, skipping trace")
       return block()

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
@@ -35,8 +35,8 @@ class Profiler(
       return instance?.startSpanInternal(name) ?: Unit
     }
 
-    fun stopSpan() {
-      return instance?.stopSpanInternal() ?: Unit
+    fun endSpan() {
+      return instance?.endSpanInternal() ?: Unit
     }
   }
 
@@ -76,7 +76,7 @@ class Profiler(
     }
   }
 
-  private inline fun <T> traceInternal(name: String, noinline block: () -> T): T {
+  private fun <T> traceInternal(name: String, block: () -> T): T {
     if (!profilingEnabled) {
       Log.d(TAG, "Profiling disabled, skipping trace")
       return block()
@@ -86,7 +86,7 @@ class Profiler(
     return try {
       block()
     } finally {
-      stopSpanInternal()
+      endSpanInternal()
     }
   }
 
@@ -102,7 +102,7 @@ class Profiler(
     stack.add(name)
   }
 
-  private fun stopSpanInternal() {
+  private fun endSpanInternal() {
     if (!profilingEnabled) {
       Log.d(TAG, "Profiling disabled, skipping stopSpan")
       return
@@ -123,7 +123,7 @@ class Profiler(
   fun saveProfile() {
     while (stack.isNotEmpty()) {
       // Finish any hanging stacks
-      stopSpanInternal()
+      endSpanInternal()
     }
 
     if (foldedStacks.isEmpty()) {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
@@ -1,45 +1,87 @@
 package com.emergetools.snapshots.util
 
-class Profiler {
+import android.content.Context
+import android.os.Bundle
+import android.util.Log
+import androidx.test.platform.app.InstrumentationRegistry
+import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import java.io.File
+import java.nio.charset.Charset
 
-  private val stack = object : ThreadLocal<MutableList<String>>() {
-    override fun initialValue(): MutableList<String> {
-      return mutableListOf()
-    }
-  }
-  private val foldedStacks = object : ThreadLocal<MutableList<String>>() {
-    override fun initialValue(): MutableList<String> {
-      return mutableListOf()
-    }
-  }
-
-  private val startTime = object : ThreadLocal<Long>() {
-    override fun initialValue(): Long {
-      return 0L
-    }
-  }
+class Profiler(
+  private val parameter: ComposePreviewSnapshotConfig,
+) : TestRule {
 
   companion object {
-    private val INSTANCE = Profiler()
+    private const val TAG = "Profiler"
+    private const val ARG_KEY_SAVE_PROFILE = "save_profile"
+
+    @Volatile
+    private var instance: Profiler? = null
+
+    fun getInstance(previewConfig: ComposePreviewSnapshotConfig): Profiler =
+      instance ?: synchronized(this) {
+        instance ?: Profiler(previewConfig).also { instance = it }
+      }
 
     fun <T> trace(name: String, block: () -> T): T {
-      return INSTANCE.traceInternal(name, block)
+      return instance!!.traceInternal(name, block)
     }
 
     fun startSpan(name: String) {
-      return INSTANCE.startSpanInternal(name)
+      return instance!!.startSpanInternal(name)
     }
 
     fun stopSpan() {
-      return INSTANCE.stopSpanInternal()
+      return instance!!.stopSpanInternal()
     }
+  }
 
-    fun export(): String? {
-      return INSTANCE.export()
+  private val targetContext: Context
+    get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+  private val filesDir: File
+    get() = targetContext.getExternalFilesDir(null) ?: error("External files dir is null")
+
+  private val args: Bundle
+    get() = InstrumentationRegistry.getArguments()
+
+  private val profilingEnabled: Boolean by lazy {
+    args.getBoolean(ARG_KEY_SAVE_PROFILE, false) ||
+      args.getString(ARG_KEY_SAVE_PROFILE, "false").toBoolean()
+  }
+
+  private val stack = mutableListOf<String>()
+  private val foldedStacks = mutableListOf<String>()
+
+  private var startTime = 0L
+
+  override fun apply(base: Statement, description: Description): Statement {
+    return object : Statement() {
+      @Throws(Throwable::class)
+      override fun evaluate() {
+        try {
+          traceInternal(parameter.keyName()) {
+            base.evaluate()
+          }
+        } finally {
+          saveProfile()
+          // Reset the instance to ensure future tests
+          instance = null
+        }
+      }
     }
   }
 
   private fun <T> traceInternal(name: String, block: () -> T): T {
+    if (!profilingEnabled) {
+      Log.d(TAG, "Profiling disabled, skipping trace")
+      return block()
+    }
+
     startSpanInternal(name)
     return try {
       block()
@@ -49,41 +91,64 @@ class Profiler {
   }
 
   private fun startSpanInternal(name: String) {
-    val localStack = stack.get()
-    if (localStack.isEmpty()) {
-      startTime.set(System.currentTimeMillis())
+    if (!profilingEnabled) {
+      Log.d(TAG, "Profiling disabled, skipping startSpan")
+      return
     }
-    localStack.add(name)
+
+    if (stack.isEmpty()) {
+      startTime = System.currentTimeMillis()
+    }
+    stack.add(name)
   }
 
   private fun stopSpanInternal() {
-    val localStack = stack.get()
-    val localFoldedStacks = foldedStacks.get()
-    val localStartTime = startTime.get()
+    if (!profilingEnabled) {
+      Log.d(TAG, "Profiling disabled, skipping stopSpan")
+      return
+    }
 
-    if (localStack.isNotEmpty()) {
+
+    if (stack.isNotEmpty()) {
       val endTime = System.currentTimeMillis()
-      val spanName = localStack.removeAt(localStack.size - 1)
-      var foldedStack = localStack.joinToString(";")
+      val spanName = stack.removeAt(stack.size - 1)
+      var foldedStack = stack.joinToString(";")
       if (foldedStack.isNotEmpty()) {
         foldedStack = "$foldedStack;"
       }
-      val duration = endTime - localStartTime
-      localFoldedStacks.add("$foldedStack$spanName $duration")
+      val duration = endTime - startTime
+      foldedStacks.add("$foldedStack$spanName $duration")
     }
   }
 
-  fun export(): String? {
-    val localStack = stack.get()
-    val localFoldedStacks = foldedStacks.get()
-
-    while (localStack.isNotEmpty()) {
+  fun saveProfile() {
+    while (stack.isNotEmpty()) {
+      // Finish any hanging stacks
       stopSpanInternal()
     }
-    return if (localFoldedStacks.isNotEmpty()) {
-      localFoldedStacks.joinToString("\n")
-    } else {
-      null
+
+    if (foldedStacks.isEmpty()) {
+      Log.d(TAG, "No profiling data to save")
+      return
     }
+
+    val snapshotsDir = File(filesDir, "snapshots")
+    if (!snapshotsDir.exists() && !snapshotsDir.mkdirs()) {
+      error("Unable to create snapshots storage directory.")
+    }
+
+    val outputFileName = "${parameter.keyName()}.folded"
+    val outputFile = File(snapshotsDir, outputFileName)
+
+    if (outputFile.exists()) {
+      Log.e(TAG, "File with name $outputFileName already exists, skipping save.")
+      return
+    }
+
+    Log.d(TAG, "Saving profile to ${outputFile.path}")
+
+    val profileData = foldedStacks.joinToString("\n")
+    outputFile.outputStream().use { it.write(profileData.toByteArray(Charset.defaultCharset())) }
   }
 }
+


### PR DESCRIPTION
![Screenshot 2024-12-17 at 9 21 44 AM](https://github.com/user-attachments/assets/231c9134-5075-42d6-8324-f297d751c113)

Generates a .folded profile file for each test when the `snapshotOptions.profile` property is set.