### PR TITLE
Add custom EmergeActivityScenarioRule and use waitForActivitiesToComplete arg

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
@@ -143,6 +143,9 @@ abstract class LocalSnapshots : DefaultTask() {
             it.add(key)
             it.add(value)
           }
+          it.add("-e")
+          it.add("waitForActivitiesToComplete")
+          it.add("false")
           if (composeSnapshotsJson.exists()) {
             push(
               localFile = composeSnapshotsJson.absolutePath,

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -58,7 +58,6 @@ dependencies {
   api(projects.snapshots.snapshotsShared)
   api(libs.androidx.test.core)
   api(libs.androidx.test.core.ktx)
-  api(libs.androidx.test.ext.junit)
   api(libs.androidx.test.rules)
   api(libs.androidx.test.runner)
   api(libs.compose.ui.test.junit)

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/EmergeComposeSnapshotReflectiveParameterizedInvoker.kt
@@ -2,10 +2,9 @@ package com.emergetools.snapshots.compose
 
 import android.content.pm.ApplicationInfo
 import android.util.Log
-import androidx.compose.ui.tooling.PreviewActivity
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.emergetools.snapshots.EmergeSnapshots
+import com.emergetools.snapshots.rules.EmergeActivityScenarioRule
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import com.emergetools.snapshots.shared.ComposeSnapshots
 import com.emergetools.snapshots.util.Profiler
@@ -75,19 +74,13 @@ class EmergeComposeSnapshotReflectiveParameterizedInvoker(
   }
 
   @get:Rule
-  val scenarioRule = ActivityScenarioRule(PreviewActivity::class.java)
+  val scenarioRule = EmergeActivityScenarioRule()
 
   @get:Rule
   val snapshotRule: EmergeSnapshots = EmergeSnapshots()
 
   @get:Rule
   val profiler = Profiler.getInstance(parameter.previewConfig)
-
-  fun someMethod() {
-    Profiler.startSpan("someMethod")
-    // some code
-    Profiler.endSpan()
-  }
 
   @Test
   fun reflectiveComposableInvoker() {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/rules/EmergeActivityScenarioRule.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/rules/EmergeActivityScenarioRule.kt
@@ -1,0 +1,16 @@
+package com.emergetools.snapshots.rules
+
+import androidx.compose.ui.tooling.PreviewActivity
+import androidx.test.core.app.ActivityScenario
+import org.junit.rules.ExternalResource
+
+class EmergeActivityScenarioRule : ExternalResource() {
+  lateinit var scenario: ActivityScenario<PreviewActivity>
+
+  override fun before() {
+    super.before()
+    scenario = ActivityScenario.launch(PreviewActivity::class.java)
+  }
+
+  // Explicitly skip the after() method to avoid closing the activity
+}

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/util/Profiler.kt
@@ -84,6 +84,7 @@ class Profiler(
   }
 
   private fun startSpanInternal(name: String) {
+    Log.d(TAG, "Starting span: $name")
     if (!profilingEnabled) {
       Log.d(TAG, "Profiling disabled, skipping startSpan")
       return
@@ -98,6 +99,7 @@ class Profiler(
   }
 
   private fun endSpanInternal() {
+    Log.d(TAG, "Ending span ${stack.lastOrNull()?.name}")
     if (!profilingEnabled) {
       Log.d(TAG, "Profiling disabled, skipping stopSpan")
       return


### PR DESCRIPTION
After some benchmarking, most our test's time is taking place outside our actual test (i.e. @Before/@After functions). Looking into this a bit more, it seems the `ActivityScenarioRule` is starting and stopping an activity for every single test, an overly expensive operation.

To minimize the impact of the activity start/stop, this PR does 2 things:
- Adds a custom `EmergeActivityScenarioRule` that explicitly skips the `ActivityScenario.close()` invocation ([source1](https://cs.android.com/androidx/android-test/+/main:ext/junit/java/androidx/test/ext/junit/rules/ActivityScenarioRule.java;l=117?q=ActivityScenarioR), [source2](https://cs.android.com/androidx/android-test/+/main:core/java/androidx/test/core/app/ActivityScenario.java;l=419?q=ActivityScenario)) (finishing activity/moving to DESTROYED state).
- Explicitly sets `waitForActivitiesToComplete` to `false`. This forces the instrumentation to not automatically finish all activities. ([source](https://cs.android.com/androidx/android-test/+/main:runner/monitor/java/androidx/test/runner/MonitoringInstrumentation.java;l=415?q=MonitoringInstrumentation))

Local benchmarking has been pretty positive here, showing an improvement of ~10-20s for our sample app of ~140 snapshots (80s -> ~65s).

We'll need to pass `waitForActivitiesToComplete` on the backend and do some benchmarking there before fully confirming improvements.