### PR TITLE
Add setDefaultUncaughtExceptionHandler to catch exceptions that would previously take down process

### DIFF
--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -24,7 +24,7 @@ fun snapshotComposable(
   previewConfig: ComposePreviewSnapshotConfig,
 ) {
   activity.runOnUiThread {
-    val priorExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+    val priorExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
     Thread.setDefaultUncaughtExceptionHandler { t, e ->
       Log.e(
         EmergeComposeSnapshotReflectiveParameterizedInvoker.TAG,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -23,6 +23,23 @@ fun snapshotComposable(
   activity: PreviewActivity,
   previewConfig: ComposePreviewSnapshotConfig,
 ) {
+  activity.runOnUiThread {
+    val priorExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+    Thread.setDefaultUncaughtExceptionHandler { t, e ->
+      Log.e(
+        EmergeComposeSnapshotReflectiveParameterizedInvoker.TAG,
+        "Uncaught exception in UI thread",
+        e
+      )
+      snapshotRule.saveError(
+        errorType = SnapshotErrorType.GENERAL,
+        composePreviewSnapshotConfig = previewConfig
+      )
+      priorExceptionHandler?.uncaughtException(t, e)
+      activity.finish()
+    }
+  }
+
   Profiler.startSpan("snapshotComposable")
   try {
     snapshot(


### PR DESCRIPTION
In an effort to improve performance, I went back to question if we could remove test orchestrator again. Test orchestrator was added to get around pesky uncaught exceptions which would result in the overall instrumentation process being taken down.

This adds a default uncaught exception handler that will save error metadata and ensure we finish the preview activity. Testing against some repro cases (with orchestrator off), this seems to catch crashes that previously would take down the instrumentation process.