### PR TITLE
Add universal snapshot APK

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,7 @@ include(
   ":snapshots",
   ":snapshots:snapshots",
   ":snapshots:snapshots-annotations",
+  ":snapshots:snapshots-universal-invoker",
   ":snapshots:sample",
   ":snapshots:sample:app",
   ":snapshots:sample:ui-module",

--- a/snapshots/snapshots-universal-invoker/build.gradle.kts
+++ b/snapshots/snapshots-universal-invoker/build.gradle.kts
@@ -1,0 +1,51 @@
+plugins {
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+  namespace = "com.emergetools.snapshots.universalinvoker"
+  compileSdk = 35
+
+  defaultConfig {
+    minSdk = 29
+    targetSdk = 35
+
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  }
+
+  buildTypes {
+    release {
+      isMinifyEnabled = false
+      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+      signingConfig = signingConfigs.getByName("debug")
+    }
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_17.toString()
+  }
+
+  buildFeatures {
+    compose = true
+  }
+}
+
+dependencies {
+
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.runtime)
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation.android)
+
+  implementation(projects.snapshots.snapshots)
+  implementation(libs.androidx.test.ext.junit)
+  implementation(libs.kotlinx.serialization)
+}

--- a/snapshots/snapshots-universal-invoker/build.gradle.kts
+++ b/snapshots/snapshots-universal-invoker/build.gradle.kts
@@ -12,8 +12,10 @@ android {
   defaultConfig {
     minSdk = 29
     targetSdk = 35
-
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+    val targetPackage = project.properties["targetPackage"] as? String ?: "placeholder"
+    manifestPlaceholders["targetPackage"] = targetPackage
   }
 
   buildTypes {

--- a/snapshots/snapshots-universal-invoker/src/main/AndroidManifest.xml
+++ b/snapshots/snapshots-universal-invoker/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
+
+  <application tools:ignore="MissingApplicationIcon">
+    <activity
+      android:name="androidx.activity.ComponentActivity"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+
+  <instrumentation
+    android:name="androidx.test.runner.AndroidJUnitRunner"
+    android:targetPackage="com.classpass.classpass.dev" />
+
+</manifest>

--- a/snapshots/snapshots-universal-invoker/src/main/AndroidManifest.xml
+++ b/snapshots/snapshots-universal-invoker/src/main/AndroidManifest.xml
@@ -15,6 +15,6 @@
 
   <instrumentation
     android:name="androidx.test.runner.AndroidJUnitRunner"
-    android:targetPackage="com.classpass.classpass.dev" />
+    android:targetPackage="placeholder" />
 
 </manifest>

--- a/snapshots/snapshots-universal-invoker/src/main/AndroidManifest.xml
+++ b/snapshots/snapshots-universal-invoker/src/main/AndroidManifest.xml
@@ -15,6 +15,6 @@
 
   <instrumentation
     android:name="androidx.test.runner.AndroidJUnitRunner"
-    android:targetPackage="placeholder" />
+    android:targetPackage="${targetPackage}" />
 
 </manifest>


### PR DESCRIPTION
Adds a universal invoker app that we can use to target any arbitrary client app for testing. Build with:
```
./gradlew :snapshots:snapshots-universal-invoker:assembleDebug -PtargetPackage=com.test.app
```

Install then run the snapshots instrumentation with ADB. Docs to come