### PR TITLE
Introduce separate logExtension task to log VCS options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ captures/
 
 # Metadata used for plugin testing
 **/emerge_config.json
+
+.tool-versions

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -19,7 +19,6 @@ android {
 
     defaultConfig {
       minSdk = 26
-      targetSdk = 34
       // TODO(chromy): Should not be needed.
       manifestPlaceholders["emerge.reaper.enabled"] = false
       testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/EmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/EmergePluginTest.kt
@@ -5,6 +5,7 @@ import com.emergetools.android.gradle.mocks.getEmergeDispatcher
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert.assertTrue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 
@@ -21,13 +22,16 @@ abstract class EmergePluginTest {
     return task!!
   }
 
-  protected fun BuildResult.assertSuccessfulTask(name: String) {
+  protected fun BuildResult.assertSuccessfulTask(name: String) : BuildResult {
     val task = executedTask(name)
     assertEquals(TaskOutcome.SUCCESS, task.outcome, "Task \"$name\" was not successful")
+    assertTrue(output.contains("SUCCESSFUL"))
+    return this
   }
 
-  protected fun BuildResult.assertFailedTask(name: String) {
+  protected fun BuildResult.assertFailedTask(name: String) : BuildResult {
     val task = executedTask(name)
     assertEquals(TaskOutcome.FAILED, task.outcome, "Task \"$name\" did not fail")
+    return this
   }
 }

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/LoggingEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/LoggingEmergePluginTest.kt
@@ -1,17 +1,70 @@
 package com.emergetools.android.gradle
 
 import com.emergetools.android.gradle.base.EmergeGradleRunner
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class LoggingEmergePluginTest : EmergePluginTest() {
 
-  /**
-   * If the info logging level is enabled we print out the plugin configuration. This tests that it doesn't cause any crashes.
-   */
+  // Write a test that verifies that executing the task 'logExtension' prints the extension to the console.
   @Test
-  fun infoLogLevel() {
-    EmergeGradleRunner.create("simple")
-      .withArguments("tasks", "-i")
+  fun logExtension() {
+    val result = EmergeGradleRunner.create("simple")
+      .withArguments("logExtension")
       .build()
+      .assertSuccessfulTask(":logExtension")
+
+    Assertions.assertTrue(
+      result.output.contains(
+        "╔══════════════════════╗\n" +
+          "║ Emerge configuration ║\n" +
+          "╠══════════════════════╝\n" +
+          "╠═ apiToken: *****\n" +
+          "╠═ includeDependencyInformation: true\n" +
+          "╠═ dryRun (optional): false\n" +
+          "╠═ verbose (optional): false\n" +
+          "╔══════╗\n" +
+          "║ size ║\n" +
+          "╠══════╝\n" +
+          "╠═ tag (optional): \n" +
+          "╚═ enabled: true\n" +
+          "╔═══════════╗\n" +
+          "║ snapshots ║\n" +
+          "╠═══════════╝\n" +
+          "╠═ snapshotsStorageDirectory: \n" +
+          "╠═ apiVersion: \n" +
+          "╠═ includePrivatePreviews: \n" +
+          "╠═ includePreviewParamPreviews: \n" +
+          "╠═ tag (optional): \n" +
+          "╠═ enabled: true\n" +
+          "╚═ profile: false\n" +
+          "╔════════╗\n" +
+          "║ reaper ║\n" +
+          "╠════════╝\n" +
+          "╠═ enabledVariants: []\n" +
+          "╠═ publishableApiKey: MISSING\n" +
+          "╚═ tag (optional): \n" +
+          "╔═════════════╗\n" +
+          "║ performance ║\n" +
+          "╠═════════════╝\n" +
+          "╠═ projectPath: \n" +
+          "╠═ tag (optional): \n" +
+          "╚═ enabled: true\n" +
+          "╔═══════════════════════════════════════════════╗\n" +
+          "║ vcsOptions (optional, defaults to Git values) ║\n" +
+          "╠═══════════════════════════════════════════════╝\n" +
+          "╠═ sha: testSha\n" +
+          "╠═ baseSha: testBaseSha\n" +
+          "╠═ previousSha: testPreviousSha\n" +
+          "╠═ branchName: testBranchName\n" +
+          "╠═ prNumber: \n" +
+          "╠═ gitHubOptions\n" +
+          "╠═ repoOwner: repoOwner\n" +
+          "╠═ repoName: repoName\n" +
+          "╠═ includeEventInformation: true\n" +
+          "╠═ gitLabOptions\n" +
+          "╚═ projectId: "
+      )
+    )
   }
 }

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/LoggingEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/LoggingEmergePluginTest.kt
@@ -1,6 +1,7 @@
 package com.emergetools.android.gradle
 
 import com.emergetools.android.gradle.base.EmergeGradleRunner
+import com.emergetools.android.gradle.utils.EnvUtils.withGitHubPREvent
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -11,6 +12,7 @@ class LoggingEmergePluginTest : EmergePluginTest() {
   fun logExtension() {
     val result = EmergeGradleRunner.create("simple")
       .withArguments("logExtension")
+      .withGitHubPREvent()
       .build()
       .assertSuccessfulTask(":logExtension")
 
@@ -57,7 +59,7 @@ class LoggingEmergePluginTest : EmergePluginTest() {
           "╠═ baseSha: testBaseSha\n" +
           "╠═ previousSha: testPreviousSha\n" +
           "╠═ branchName: testBranchName\n" +
-          "╠═ prNumber: \n" +
+          "╠═ prNumber: 123\n" +
           "╠═ gitHubOptions\n" +
           "╠═ repoOwner: repoOwner\n" +
           "╠═ repoName: repoName\n" +

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/internal/LogExtensionTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/internal/LogExtensionTask.kt
@@ -1,0 +1,93 @@
+package com.emergetools.android.gradle.tasks.internal
+
+import com.emergetools.android.gradle.EmergePluginExtension
+import com.emergetools.android.gradle.util.orEmpty
+import com.emergetools.android.gradle.util.treePrinter
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+abstract class LogExtensionTask : DefaultTask() {
+
+  @get:Input
+  abstract val emergePluginExtension: Property<EmergePluginExtension>
+
+  @TaskAction
+  fun logExtension() {
+    val extension = emergePluginExtension.get()
+
+    val extensionTree = treePrinter("Emerge configuration") {
+
+      addItem("apiToken: ${if (extension.apiToken.isPresent) "*****" else "MISSING"}")
+      addItem("includeDependencyInformation: ${extension.includeDependencyInformation.getOrElse(true)}")
+      addItem("dryRun (optional): ${extension.dryRun.orEmpty()}")
+      addItem("verbose (optional): ${extension.verbose.orEmpty()}")
+
+      val sizeHeading = addHeading("size")
+      addItem("tag (optional): ${extension.sizeOptions.tag.orEmpty()}", sizeHeading)
+      addItem("enabled: ${extension.sizeOptions.enabled.getOrElse(true)}", sizeHeading)
+
+      val snapshotsHeading = addHeading("snapshots")
+      addItem(
+        "snapshotsStorageDirectory: ${extension.snapshotOptions.snapshotsStorageDirectory.orEmpty()}",
+        snapshotsHeading
+      )
+      addItem("apiVersion: ${extension.snapshotOptions.apiVersion.orEmpty()}", snapshotsHeading)
+      addItem(
+        "includePrivatePreviews: ${extension.snapshotOptions.includePrivatePreviews.orEmpty()}",
+        snapshotsHeading
+      )
+      addItem(
+        "includePreviewParamPreviews: ${extension.snapshotOptions.includePreviewParamPreviews.orEmpty()}",
+        snapshotsHeading
+      )
+      addItem("tag (optional): ${extension.snapshotOptions.tag.orEmpty()}", snapshotsHeading)
+      addItem("enabled: ${extension.snapshotOptions.enabled.getOrElse(true)}", snapshotsHeading)
+      addItem("profile: ${extension.snapshotOptions.profile.getOrElse(false)}", snapshotsHeading)
+
+      val reaperHeading = addHeading("reaper")
+      addItem(
+        "enabledVariants: ${extension.reaperOptions.enabledVariants.getOrElse(emptyList())}",
+        reaperHeading
+      )
+      addItem(
+        "publishableApiKey: ${if (extension.reaperOptions.publishableApiKey.isPresent) "*****" else "MISSING"}",
+        reaperHeading
+      )
+      addItem("tag (optional): ${extension.reaperOptions.tag.orEmpty()}", reaperHeading)
+
+      val performanceHeading = addHeading("performance")
+      addItem("projectPath: ${extension.perfOptions.projectPath.orEmpty()}", performanceHeading)
+      addItem("tag (optional): ${extension.perfOptions.tag.orEmpty()}", performanceHeading)
+      addItem("enabled: ${extension.perfOptions.enabled.getOrElse(true)}", performanceHeading)
+
+      val vcsOptionsHeading = addHeading("vcsOptions (optional, defaults to Git values)")
+      addItem("sha: ${extension.vcsOptions.sha.orEmpty()}", vcsOptionsHeading)
+      addItem("baseSha: ${extension.vcsOptions.baseSha.orEmpty()}", vcsOptionsHeading)
+      addItem("previousSha: ${extension.vcsOptions.previousSha.orEmpty()}", vcsOptionsHeading)
+      addItem("branchName: ${extension.vcsOptions.branchName.orEmpty()}", vcsOptionsHeading)
+      addItem("prNumber: ${extension.vcsOptions.prNumber.orEmpty()}", vcsOptionsHeading)
+      addItem("gitHubOptions", vcsOptionsHeading)
+      addItem(
+        "repoOwner: ${extension.vcsOptions.gitHubOptions.repoOwner.orEmpty()}",
+        vcsOptionsHeading
+      )
+      addItem(
+        "repoName: ${extension.vcsOptions.gitHubOptions.repoName.orEmpty()}",
+        vcsOptionsHeading
+      )
+      addItem(
+        "includeEventInformation: ${extension.vcsOptions.gitHubOptions.includeEventInformation.orEmpty()}",
+        vcsOptionsHeading
+      )
+      addItem("gitLabOptions", vcsOptionsHeading)
+      addItem(
+        "projectId: ${extension.vcsOptions.gitLabOptions.projectId.orEmpty()}",
+        vcsOptionsHeading
+      )
+    }
+
+    logger.lifecycle(extensionTree)
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8


### PR DESCRIPTION
Added a new `logExtension` Gradle task to debug Emerge plugin configuration instead of printing using `-i` flag in Gradle.
Previously this would cause git operations during the configuration phase when running a gradle build with the `-i` flag or info level logging enabled. This resolves #322 

### What changed?

- Created a new `LogExtensionTask` to display Emerge plugin configuration
- Moved configuration logging logic from `EmergePlugin` to dedicated task
- Added `.tool-versions` to `.gitignore`
- Removed `targetSdk` from benchmark module
- Enhanced test assertions with output verification
- Added Gradle performance optimization properties

### How to test?

Run `./gradlew logExtension` to view the current Emerge configuration

