### PR TITLE
Remove mustrunafter test task configuration

### DIFF
--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -95,7 +95,6 @@ val functionalTestTask = tasks.register<Test>("functionalTest") {
   group = "verification"
   testClassesDirs = functionalTest.output.classesDirs
   classpath = functionalTest.runtimeClasspath
-  mustRunAfter(tasks.test)
 }
 
 tasks.check {


### PR DESCRIPTION
Remove mustrunafter test task configuration.
This should improve performance when configuration cache is enabled, allowing tasks within the same project to run in parallel.