### PR TITLE
Run detekt on `:gradle-plugin`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,4 +29,5 @@ allprojects {
 
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
   exclude("**/reaper/sample/stress/**")
+  dependsOn(gradle.includedBuild("gradle-plugin").task(":plugin:detekt"))
 }

--- a/gradle-plugin/detekt/baseline.xml
+++ b/gradle-plugin/detekt/baseline.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>ArgumentListWrapping:com.emergetools.android.gradle.instrumentation.reaper.ReaperClassLoadTest.kt:30</ID>
+    <ID>ArgumentListWrapping:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:37</ID>
+    <ID>ArgumentListWrapping:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:53</ID>
+    <ID>ArgumentListWrapping:com.emergetools.android.gradle.tasks.size.SizePreflight.kt:33</ID>
+    <ID>ArgumentListWrapping:com.emergetools.android.gradle.tasks.size.SizePreflight.kt:40</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePlugin.kt:58</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePlugin.kt:59</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePlugin.kt:60</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:101</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:102</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:103</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:105</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:106</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:107</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:109</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:110</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:111</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:113</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:114</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:115</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:117</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:118</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:120</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:121</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:122</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:124</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:125</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:127</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:128</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:129</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:130</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:132</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:133</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:134</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:135</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:138</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:139</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:140</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:141</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:142</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:143</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:144</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:145</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:147</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:148</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:149</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:151</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:152</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:153</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:154</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:22</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:23</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:24</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:25</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:26</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:27</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:28</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:29</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:30</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:32</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:33</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:34</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:36</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:37</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:39</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:40</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:41</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:43</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:44</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:46</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:47</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:48</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:50</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:51</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:53</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:54</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:55</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:57</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:58</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:60</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:61</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:62</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:64</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:65</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:67</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:68</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:69</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:71</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:72</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:74</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:75</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:76</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:78</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:79</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:80</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:82</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:83</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:84</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:86</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:87</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:88</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:89</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:92</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:93</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:94</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:95</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:96</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:97</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:98</ID>
+    <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:99</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.base.BaseUploadTask.kt:219</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.base.BaseUploadTask.kt:220</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.base.BaseUploadTask.kt:221</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.LocalSnapshots.kt:34</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.LocalSnapshots.kt:35</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.UploadSnapshotBundle.kt:95</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.UploadSnapshotBundle.kt:96</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.UploadSnapshotBundle.kt:97</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:178</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:251</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:252</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:253</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:258</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:259</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:260</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:263</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:264</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:265</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:268</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:269</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:270</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:292</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:293</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:294</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:297</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:298</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:299</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:302</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:303</ID>
+    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:304</ID>
+    <ID>Indentation:com.emergetools.android.gradle.util.preflight.Preflight.kt:155</ID>
+    <ID>Indentation:com.emergetools.android.gradle.util.preflight.Preflight.kt:169</ID>
+    <ID>MagicNumber:BaseUploadTask.kt$BaseUploadTask$30</ID>
+    <ID>MagicNumber:DependencyUtils.kt$3</ID>
+    <ID>MagicNumber:PreviewUtils.kt$PreviewUtils$3</ID>
+    <ID>MagicNumber:ReaperClassLoadTransform.kt$0xFFL</ID>
+    <ID>MagicNumber:ReaperClassLoadTransform.kt$7</ID>
+    <ID>MagicNumber:ReaperClassLoadTransform.kt$8</ID>
+    <ID>MaxLineLength:DependencyUtils.kt$"Skipping invalid dependency: ${it.key}, expected format: group:name:version, please let the Emerge team know of this!"</ID>
+    <ID>MaxLineLength:InitializeReaper.kt$InitializeReaper$"publishableApiKey must be set for Reaper to work properly. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk."</ID>
+    <ID>MaxLineLength:ReaperClassLoadTest.kt$ReaperClassLoadTest$Assertions.assertEquals(-1167088121787636991L, topLong(byteArrayOf(0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xff, 0xff)))</ID>
+    <ID>MaxLineLength:ReaperPreflight.kt$ReaperPreflight$"Reaper not enabled for variant $variantName. Make sure \"${variantName}\" is included in `reaper.enabledVariants`"</ID>
+    <ID>MaxLineLength:ReaperPreflight.kt$ReaperPreflight$"Reaper runtime SDK missing as an implementation dependency. See https://docs.emergetools.com/docs/reaper-setup-android#install-the-sdk"</ID>
+    <ID>MaxLineLength:ReaperPreflight.kt$ReaperPreflight$"publishableApiKey must not be empty. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk"</ID>
+    <ID>MaxLineLength:ReaperPreflight.kt$ReaperPreflight$throw PreflightFailure("Emerge API token not set. See https://docs.emergetools.com/docs/uploading-basics#obtain-an-api-key")</ID>
+    <ID>MaxLineLength:ReaperPreflight.kt$ReaperPreflight$throw PreflightFailure("publishableApiKey not set. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")</ID>
+    <ID>MaxLineLength:SizePreflight.kt$SizePreflight$throw PreflightFailure("Emerge API token not set. See https://docs.emergetools.com/docs/uploading-basics#obtain-an-api-key")</ID>
+    <ID>MaxLineLength:SizePreflight.kt$SizePreflight$throw PreflightFailure("Size analysis not enabled. Make sure `size.enabled` is set to true in the emerge configuration block.")</ID>
+    <ID>MaxLineLength:SnapshotsPreviewRuntimeRetentionTransform.kt$SnapshotsPreviewRuntimeRetentionTransformFactory$abstract</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.instrumentation.reaper.ReaperClassLoadTest.kt:30</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.instrumentation.snapshots.SnapshotsPreviewRuntimeRetentionTransform.kt:16</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.InitializeReaper.kt:38</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:37</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:45</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:53</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:57</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:65</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.size.SizePreflight.kt:33</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.size.SizePreflight.kt:40</ID>
+    <ID>MaximumLineLength:com.emergetools.android.gradle.util.dependencies.DependencyUtils.kt:87</ID>
+    <ID>NestedBlockDepth:BaseUploadTask.kt$BaseUploadTask$protected fun upload( artifactMetadata: ArtifactMetadata, onSuccessfulUpload: (EmergeUploadResponse) -&gt; Unit, )</ID>
+    <ID>NestedBlockDepth:LocalSnapshots.kt$LocalSnapshots$private fun extractDexFromApk( apk: File, outputDir: File, )</ID>
+    <ID>ReturnCount:PreviewUtils.kt$PreviewUtils$private fun hasSupportedMethodParameters( method: DexBackedMethod, includePreviewParamPreviews: Boolean, logger: Logger, ): Boolean</ID>
+    <ID>ThrowsCount:BasePreflightTask.kt$BasePreflightTask$protected fun buildVcsPreflight(): Preflight</ID>
+    <ID>ThrowsCount:ReaperPreflight.kt$ReaperPreflight$@TaskAction fun execute()</ID>
+    <ID>ThrowsCount:SnapshotsPreflight.kt$SnapshotsPreflight$@TaskAction fun execute()</ID>
+    <ID>TooGenericExceptionCaught:Preflight.kt$e: Throwable</ID>
+    <ID>TooManyFunctions:GitHub.kt$GitHub</ID>
+    <ID>UnnecessaryAbstractClass:EmergePluginExtension.kt$GitHubOptions$GitHubOptions</ID>
+    <ID>UnnecessaryAbstractClass:EmergePluginExtension.kt$GitLabOptions$GitLabOptions</ID>
+    <ID>UnusedPrivateMember:Preflight.kt$Preflight$private fun getHeadingBottom(heading: String): String</ID>
+    <ID>UnusedPrivateMember:Preflight.kt$Preflight$private fun getHeadingTop(heading: String): String</ID>
+    <ID>UnusedPrivateMember:Preflight.kt$Result.Success$value: T</ID>
+    <ID>UseCheckOrError:EmergeUploadRequest.kt$throw IllegalStateException("Could not resolve /upload for baseUrl: $baseUrl")</ID>
+    <ID>UseCheckOrError:PreviewUtils.kt$PreviewUtils$throw IllegalStateException("Preview parameter must have a name")</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -33,52 +33,58 @@ java {
   }
 }
 
-tasks.withType<KotlinCompile> {
+tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
     jvmTarget = JavaVersion.VERSION_11.toString()
   }
 }
 
 // This directory will contain one file per version of the Android Gradle Plugin that we wish to test against.
-val agpClasspathDir = project.buildDir.resolve("agp-classpath").apply {
-  mkdir()
-}
+val agpClasspathDir =
+  project.buildDir.resolve("agp-classpath").apply {
+    mkdir()
+  }
 
-val kgpClasspathDir = project.buildDir.resolve("kgp-classpath").apply {
-  mkdir()
-}
+val kgpClasspathDir =
+  project.buildDir.resolve("kgp-classpath").apply {
+    mkdir()
+  }
 
 // Versions prior to 7.0.0 do not have an official API, supporting them would require considerably more work.
 // ATTENTION: Must be kept in sync with the EmergeGradleRunner list.
-val supportedAgpVersions = setOf(
-  "7.0.0",
-  "7.1.0",
-  "7.2.0",
-  "7.3.0",
-  "8.0.0",
-)
+val supportedAgpVersions =
+  setOf(
+    "7.0.0",
+    "7.1.0",
+    "7.2.0",
+    "7.3.0",
+    "8.0.0",
+  )
 
-val supportedKotlinVersions = setOf(
-  "1.8.21",
-)
+val supportedKotlinVersions =
+  setOf(
+    "1.8.21",
+  )
 
 // Creates a classpath file for each version of AGP we wish to test against. This allows the functional tests to target
 // a particular version using the GradleRunner.
 supportedAgpVersions.forEach { version ->
   val configuration = configurations.create("agp$version")
   dependencies.add(configuration.name, "com.android.tools.build:gradle:$version")
-  val classpathFile = agpClasspathDir.resolve("agp-classpath-$version.txt").apply {
-    ensureParentDirsCreated()
-  }
+  val classpathFile =
+    agpClasspathDir.resolve("agp-classpath-$version.txt").apply {
+      ensureParentDirsCreated()
+    }
   classpathFile.writeText(configuration.joinToString(separator = "\n"))
 }
 
 supportedKotlinVersions.forEach { version ->
   val configuration = configurations.create("kgp$version")
   dependencies.add(configuration.name, "org.jetbrains.kotlin:kotlin-gradle-plugin:$version")
-  val classpathFile = kgpClasspathDir.resolve("kgp-classpath-$version.txt").apply {
-    ensureParentDirsCreated()
-  }
+  val classpathFile =
+    kgpClasspathDir.resolve("kgp-classpath-$version.txt").apply {
+      ensureParentDirsCreated()
+    }
   classpathFile.writeText(configuration.joinToString(separator = "\n"))
 }
 
@@ -90,12 +96,13 @@ val functionalTest: SourceSet by sourceSets.creating {
   }
 }
 
-val functionalTestTask = tasks.register<Test>("functionalTest") {
-  description = "Runs the functional tests."
-  group = "verification"
-  testClassesDirs = functionalTest.output.classesDirs
-  classpath = functionalTest.runtimeClasspath
-}
+val functionalTestTask =
+  tasks.register<Test>("functionalTest") {
+    description = "Runs the functional tests."
+    group = "verification"
+    testClassesDirs = functionalTest.output.classesDirs
+    classpath = functionalTest.runtimeClasspath
+  }
 
 tasks.check {
   dependsOn(functionalTestTask)
@@ -115,8 +122,8 @@ afterEvaluate {
 
 detekt {
   buildUponDefaultConfig = true
-  config.setFrom("$rootDir/detekt/detekt.yml")
-  baseline = file("$rootDir/detekt/baseline.xml")
+  config.setFrom(rootProject.layout.projectDirectory.file("../detekt/detekt.yml"))
+  baseline = rootProject.layout.projectDirectory.file("detekt/baseline.xml").asFile
 }
 
 dependencies {
@@ -166,10 +173,6 @@ gradlePlugin {
     }
   }
   testSourceSets(functionalTest)
-}
-
-tasks.withType<Wrapper> {
-  distributionType = Wrapper.DistributionType.ALL
 }
 
 val emergeBaseUrl: String? by project

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/ConfigurationCacheTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/ConfigurationCacheTest.kt
@@ -5,7 +5,6 @@ import com.emergetools.android.gradle.mocks.assertSuccessfulUploadRequests
 import org.junit.jupiter.api.Test
 
 class ConfigurationCacheTest : EmergePluginTest() {
-
   @Test
   fun simpleConfigurationCache() {
     EmergeGradleRunner.create("simple")

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/EmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/EmergePluginTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 
 abstract class EmergePluginTest {
-
   protected fun EmergeGradleRunner.withDefaultServer(timeout: Boolean = false) =
     withServer { baseUrl ->
       this.dispatcher = getEmergeDispatcher(baseUrl, timeout)
@@ -22,14 +21,14 @@ abstract class EmergePluginTest {
     return task!!
   }
 
-  protected fun BuildResult.assertSuccessfulTask(name: String) : BuildResult {
+  protected fun BuildResult.assertSuccessfulTask(name: String): BuildResult {
     val task = executedTask(name)
     assertEquals(TaskOutcome.SUCCESS, task.outcome, "Task \"$name\" was not successful")
     assertTrue(output.contains("SUCCESSFUL"))
     return this
   }
 
-  protected fun BuildResult.assertFailedTask(name: String) : BuildResult {
+  protected fun BuildResult.assertFailedTask(name: String): BuildResult {
     val task = executedTask(name)
     assertEquals(TaskOutcome.FAILED, task.outcome, "Task \"$name\" did not fail")
     return this

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/LoggingEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/LoggingEmergePluginTest.kt
@@ -6,15 +6,15 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class LoggingEmergePluginTest : EmergePluginTest() {
-
   // Write a test that verifies that executing the task 'logExtension' prints the extension to the console.
   @Test
   fun logExtension() {
-    val result = EmergeGradleRunner.create("simple")
-      .withArguments("logExtension")
-      .withGitHubPREvent()
-      .build()
-      .assertSuccessfulTask(":logExtension")
+    val result =
+      EmergeGradleRunner.create("simple")
+        .withArguments("logExtension")
+        .withGitHubPREvent()
+        .build()
+        .assertSuccessfulTask(":logExtension")
 
     Assertions.assertTrue(
       result.output.contains(
@@ -65,8 +65,8 @@ class LoggingEmergePluginTest : EmergePluginTest() {
           "╠═ repoName: repoName\n" +
           "╠═ includeEventInformation: true\n" +
           "╠═ gitLabOptions\n" +
-          "╚═ projectId: "
-      )
+          "╚═ projectId: ",
+      ),
     )
   }
 }

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/MultiProjectEmergePluginAGP7_2_0Test.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/MultiProjectEmergePluginAGP7_2_0Test.kt
@@ -2,13 +2,11 @@ package com.emergetools.android.gradle
 
 import com.emergetools.android.gradle.base.EmergeGradleRunner
 import com.emergetools.android.gradle.mocks.assertSuccessfulUploadRequests
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 @Suppress("ClassName")
 class MultiProjectEmergePluginAGP7_2_0Test : EmergePluginTest() {
-
   @Test
   fun multiProjectUpload() {
     EmergeGradleRunner.create("multi-project-agp-7.2.0")
@@ -47,8 +45,8 @@ class MultiProjectEmergePluginAGP7_2_0Test : EmergePluginTest() {
       .assert { result, _ ->
         assertTrue(
           result.output.contains(
-            "Task 'emergeGeneratePerformanceProject' not found in project ':app'"
-          )
+            "Task 'emergeGeneratePerformanceProject' not found in project ':app'",
+          ),
         )
       }
       .buildAndFail()

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/MultiProjectEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/MultiProjectEmergePluginTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class MultiProjectEmergePluginTest : EmergePluginTest() {
-
   @Test
   fun multiProjectUpload() {
     EmergeGradleRunner.create("multi-project")
@@ -39,8 +38,8 @@ class MultiProjectEmergePluginTest : EmergePluginTest() {
       .assert { result, _ ->
         assertTrue(
           result.output.contains(
-            "task 'emergeGeneratePerformanceProject' not found in project ':app'"
-          )
+            "task 'emergeGeneratePerformanceProject' not found in project ':app'",
+          ),
         )
       }
       .buildAndFail()

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/MultiProjectFlavorsBuildTypesEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/MultiProjectFlavorsBuildTypesEmergePluginTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class MultiProjectFlavorsBuildTypesEmergePluginTest : EmergePluginTest() {
-
   @Test
   fun multiProjectUpload() {
     EmergeGradleRunner.create("multi-project-with-flavors-buildtypes")
@@ -39,8 +38,8 @@ class MultiProjectFlavorsBuildTypesEmergePluginTest : EmergePluginTest() {
       .assert { result, _ ->
         assertTrue(
           result.output.contains(
-            "task 'emergeGeneratePerformanceProject' not found in project ':app'"
-          )
+            "task 'emergeGeneratePerformanceProject' not found in project ':app'",
+          ),
         )
       }
       .buildAndFail()

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/NoAppProjectPathPluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/NoAppProjectPathPluginTest.kt
@@ -4,7 +4,6 @@ import com.emergetools.android.gradle.base.EmergeGradleRunner
 import org.junit.jupiter.api.Test
 
 class NoAppProjectPathPluginTest : EmergePluginTest() {
-
   @Test
   fun noAppProjectPath() {
     EmergeGradleRunner.create("no-app-project-path")

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/NoVcsEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/NoVcsEmergePluginTest.kt
@@ -4,7 +4,6 @@ import com.emergetools.android.gradle.base.EmergeGradleRunner
 import com.emergetools.android.gradle.mocks.assertSuccessfulUploadRequests
 import com.emergetools.android.gradle.tasks.internal.SaveExtensionConfigTask.Companion.EmergePluginExtensionData
 import com.emergetools.android.gradle.utils.EnvUtils.withGitHubPREvent
-import com.emergetools.android.gradle.utils.EnvUtils.withGitHubPREventNoBefore
 import com.emergetools.android.gradle.utils.EnvUtils.withGitHubPushEvent
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.Test
 import java.io.File
 
 class NoVcsEmergePluginTest : EmergePluginTest() {
-
   @Test
   fun noVcsBundle() {
     EmergeGradleRunner.create("no-vcs-params")
@@ -61,18 +59,20 @@ class NoVcsEmergePluginTest : EmergePluginTest() {
 
   @Test
   fun androidTasksRunBundle() {
-    val result = EmergeGradleRunner.create("no-vcs-params")
-      .withArguments("packageReleaseBundle", "signReleaseBundle")
-      .build()
+    val result =
+      EmergeGradleRunner.create("no-vcs-params")
+        .withArguments("packageReleaseBundle", "signReleaseBundle")
+        .build()
     result.assertSuccessfulTask(":packageReleaseBundle")
     result.assertSuccessfulTask(":signReleaseBundle")
   }
 
   @Test
   fun androidTasksRunAssemble() {
-    val result = EmergeGradleRunner.create("no-vcs-params")
-      .withArguments("packageRelease")
-      .build()
+    val result =
+      EmergeGradleRunner.create("no-vcs-params")
+        .withArguments("packageRelease")
+        .build()
     result.assertSuccessfulTask(":packageRelease")
   }
 
@@ -94,9 +94,10 @@ class NoVcsEmergePluginTest : EmergePluginTest() {
       }
       .build()
 
-    val configuration = Json.decodeFromStream<EmergePluginExtensionData>(
-      configurationJson.inputStream()
-    )
+    val configuration =
+      Json.decodeFromStream<EmergePluginExtensionData>(
+        configurationJson.inputStream(),
+      )
 
     assertEquals("github_head_sha", configuration.vcsOptions!!.sha)
     assertEquals("github_base_sha", configuration.vcsOptions!!.baseSha)
@@ -122,9 +123,10 @@ class NoVcsEmergePluginTest : EmergePluginTest() {
       }
       .build()
 
-    val configuration = Json.decodeFromStream<EmergePluginExtensionData>(
-      configurationJson.inputStream()
-    )
+    val configuration =
+      Json.decodeFromStream<EmergePluginExtensionData>(
+        configurationJson.inputStream(),
+      )
 
     assertEquals("github_env_sha", configuration.vcsOptions!!.sha)
     assertEquals("github_previous_sha", configuration.vcsOptions!!.previousSha)

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/SimpleEmergePluginAGP7_2_0Test.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/SimpleEmergePluginAGP7_2_0Test.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 
 @Suppress("ClassName")
 class SimpleEmergePluginAGP7_2_0Test : EmergePluginTest() {
-
   @Test
   fun simpleBundle() {
     EmergeGradleRunner.create("simple-agp-7.2.0")
@@ -23,12 +22,13 @@ class SimpleEmergePluginAGP7_2_0Test : EmergePluginTest() {
 
   @Test
   fun simpleBundleTimeout() {
-    val result = EmergeGradleRunner.create("simple-agp-7.2.0")
-      .withAndroidGradlePluginVersion("7.2.0")
-      .withGradleVersion("7.5.1")
-      .withArguments("emergeUploadReleaseAab")
-      .withDefaultServer(true)
-      .buildAndFail()
+    val result =
+      EmergeGradleRunner.create("simple-agp-7.2.0")
+        .withAndroidGradlePluginVersion("7.2.0")
+        .withGradleVersion("7.5.1")
+        .withArguments("emergeUploadReleaseAab")
+        .withDefaultServer(true)
+        .buildAndFail()
     result.assertFailedTask(":emergeUploadReleaseAab")
   }
 
@@ -48,12 +48,13 @@ class SimpleEmergePluginAGP7_2_0Test : EmergePluginTest() {
 
   @Test
   fun simpleAssembleTimeout() {
-    val result = EmergeGradleRunner.create("simple-agp-7.2.0")
-      .withAndroidGradlePluginVersion("7.2.0")
-      .withGradleVersion("7.5.1")
-      .withArguments("emergeUploadReleaseApk")
-      .withDefaultServer(true)
-      .buildAndFail()
+    val result =
+      EmergeGradleRunner.create("simple-agp-7.2.0")
+        .withAndroidGradlePluginVersion("7.2.0")
+        .withGradleVersion("7.5.1")
+        .withArguments("emergeUploadReleaseApk")
+        .withDefaultServer(true)
+        .buildAndFail()
     result.assertFailedTask(":emergeUploadReleaseApk")
   }
 
@@ -87,21 +88,23 @@ class SimpleEmergePluginAGP7_2_0Test : EmergePluginTest() {
 
   @Test
   fun androidTasksRunBundle() {
-    val result = EmergeGradleRunner.create("simple-agp-7.2.0")
-      .withAndroidGradlePluginVersion("7.2.0")
-      .withGradleVersion("7.5.1")
-      .withArguments("signReleaseBundle")
-      .build()
+    val result =
+      EmergeGradleRunner.create("simple-agp-7.2.0")
+        .withAndroidGradlePluginVersion("7.2.0")
+        .withGradleVersion("7.5.1")
+        .withArguments("signReleaseBundle")
+        .build()
     result.assertSuccessfulTask(":signReleaseBundle")
   }
 
   @Test
   fun androidTasksRunAssemble() {
-    val result = EmergeGradleRunner.create("simple-agp-7.2.0")
-      .withAndroidGradlePluginVersion("7.2.0")
-      .withGradleVersion("7.5.1")
-      .withArguments("packageRelease")
-      .build()
+    val result =
+      EmergeGradleRunner.create("simple-agp-7.2.0")
+        .withAndroidGradlePluginVersion("7.2.0")
+        .withGradleVersion("7.5.1")
+        .withArguments("packageRelease")
+        .build()
     result.assertSuccessfulTask(":packageRelease")
   }
 }

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/SimpleEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/SimpleEmergePluginTest.kt
@@ -4,7 +4,6 @@ import com.emergetools.android.gradle.base.EmergeGradleRunner
 import com.emergetools.android.gradle.mocks.assertSuccessfulUploadRequests
 import com.emergetools.android.gradle.tasks.internal.SaveExtensionConfigTask.Companion.EmergePluginExtensionData
 import com.emergetools.android.gradle.utils.EnvUtils.withGitHubPREvent
-import com.emergetools.android.gradle.utils.EnvUtils.withGitHubPREventNoBefore
 import junit.framework.TestCase.assertEquals
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.Test
 import java.io.File
 
 class SimpleEmergePluginTest : EmergePluginTest() {
-
   @Test
   fun simpleBundle() {
     EmergeGradleRunner.create("simple")
@@ -41,10 +39,11 @@ class SimpleEmergePluginTest : EmergePluginTest() {
 
   @Test
   fun simpleBundleTimeout() {
-    val result = EmergeGradleRunner.create("simple")
-      .withArguments("emergeUploadReleaseAab")
-      .withDefaultServer(true)
-      .buildAndFail()
+    val result =
+      EmergeGradleRunner.create("simple")
+        .withArguments("emergeUploadReleaseAab")
+        .withDefaultServer(true)
+        .buildAndFail()
     result.assertFailedTask(":emergeUploadReleaseAab")
   }
 
@@ -62,10 +61,11 @@ class SimpleEmergePluginTest : EmergePluginTest() {
 
   @Test
   fun simpleAssembleTimeout() {
-    val result = EmergeGradleRunner.create("simple")
-      .withArguments("emergeUploadReleaseApk")
-      .withDefaultServer(true)
-      .buildAndFail()
+    val result =
+      EmergeGradleRunner.create("simple")
+        .withArguments("emergeUploadReleaseApk")
+        .withDefaultServer(true)
+        .buildAndFail()
     result.assertFailedTask(":emergeUploadReleaseApk")
   }
 
@@ -95,18 +95,20 @@ class SimpleEmergePluginTest : EmergePluginTest() {
 
   @Test
   fun androidTasksRunBundle() {
-    val result = EmergeGradleRunner.create("simple")
-      .withArguments("packageReleaseBundle", "signReleaseBundle")
-      .build()
+    val result =
+      EmergeGradleRunner.create("simple")
+        .withArguments("packageReleaseBundle", "signReleaseBundle")
+        .build()
     result.assertSuccessfulTask(":packageReleaseBundle")
     result.assertSuccessfulTask(":signReleaseBundle")
   }
 
   @Test
   fun androidTasksRunAssemble() {
-    val result = EmergeGradleRunner.create("simple")
-      .withArguments("packageRelease")
-      .build()
+    val result =
+      EmergeGradleRunner.create("simple")
+        .withArguments("packageRelease")
+        .build()
     result.assertSuccessfulTask(":packageRelease")
   }
 
@@ -124,9 +126,10 @@ class SimpleEmergePluginTest : EmergePluginTest() {
       }
       .build()
 
-    val configuration = Json.decodeFromStream<EmergePluginExtensionData>(
-      configurationJson.inputStream()
-    )
+    val configuration =
+      Json.decodeFromStream<EmergePluginExtensionData>(
+        configurationJson.inputStream(),
+      )
 
     assertEquals("testSha", configuration.vcsOptions!!.sha)
     assertEquals("testBaseSha", configuration.vcsOptions!!.baseSha)

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/SingleProjectPerfNotSetupEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/SingleProjectPerfNotSetupEmergePluginTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class SingleProjectPerfNotSetupEmergePluginTest : EmergePluginTest() {
-
   @Test
   fun singleProjectPerfNotSetupUpload() {
     EmergeGradleRunner.create("single-project-perf-not-setup")
@@ -37,7 +36,7 @@ class SingleProjectPerfNotSetupEmergePluginTest : EmergePluginTest() {
       .withDefaultServer()
       .assert { result, _ ->
         assertTrue(
-          result.output.contains("Task 'emergeUploadReleasePerfBundle' not found")
+          result.output.contains("Task 'emergeUploadReleasePerfBundle' not found"),
         )
       }
       .buildAndFail()
@@ -52,8 +51,8 @@ class SingleProjectPerfNotSetupEmergePluginTest : EmergePluginTest() {
         println("result.output: ${result.output}")
         assertTrue(
           result.output.contains(
-            "Package name is missing. Make sure to pass the --package command line argument."
-          )
+            "Package name is missing. Make sure to pass the --package command line argument.",
+          ),
         )
       }
       .buildAndFail()

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/VariantsEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/VariantsEmergePluginTest.kt
@@ -5,7 +5,6 @@ import com.emergetools.android.gradle.mocks.assertSuccessfulUploadRequests
 import org.junit.jupiter.api.Test
 
 class VariantsEmergePluginTest : EmergePluginTest() {
-
   @Test
   fun customBuildTypeBundle() {
     EmergeGradleRunner.create("custom-build-type")

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/base/EmergeGradleRunner.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/base/EmergeGradleRunner.kt
@@ -16,21 +16,21 @@ class EmergeGradleRunner private constructor(
   private val projectDir: String,
   private val server: MockWebServer = MockWebServer(),
 ) {
-
   companion object {
-
     /** Must be kept in sync with the build.gradle list. */
-    val SUPPORTED_ANDROID_GRADLE_PLUGIN_VERSIONS = sortedSetOf(
-      "7.0.0",
-      "7.1.0",
-      "7.2.0",
-      "7.3.0",
-      "8.0.0"
-    )
+    val SUPPORTED_ANDROID_GRADLE_PLUGIN_VERSIONS =
+      sortedSetOf(
+        "7.0.0",
+        "7.1.0",
+        "7.2.0",
+        "7.3.0",
+        "8.0.0",
+      )
 
-    val SUPPORTED_KOTLIN_ANDROID_GRADLE_PLUGIN_VERSIONS = sortedSetOf(
-      "1.8.21",
-    )
+    val SUPPORTED_KOTLIN_ANDROID_GRADLE_PLUGIN_VERSIONS =
+      sortedSetOf(
+        "1.8.21",
+      )
 
     fun create(projectDir: String): EmergeGradleRunner = EmergeGradleRunner(projectDir)
   }
@@ -53,49 +53,58 @@ class EmergeGradleRunner private constructor(
 
   private var environment: Map<String, String> = emptyMap()
 
-  fun withArguments(vararg arguments: String) = apply {
-    this.arguments = arguments.toList()
-  }
-
-  fun withDebugTasks() = apply {
-    arguments = arguments + "-PemergeDebug"
-  }
-
-  fun withGradleVersion(version: String) = apply {
-    gradleRunner.withGradleVersion(version)
-  }
-
-  fun withAndroidGradlePluginVersion(version: String) = apply {
-    check(version in SUPPORTED_ANDROID_GRADLE_PLUGIN_VERSIONS) {
-      "This version of the Android Gradle Plugin is not currently supported."
+  fun withArguments(vararg arguments: String) =
+    apply {
+      this.arguments = arguments.toList()
     }
-    androidGradlePluginVersion = version
-  }
 
-  fun withKotlinAndroidGradlePluginVersion(version: String) = apply {
-    check(version in SUPPORTED_KOTLIN_ANDROID_GRADLE_PLUGIN_VERSIONS) {
-      "This version of the Kotlin Android Gradle Plugin is not currently supported."
+  fun withDebugTasks() =
+    apply {
+      arguments = arguments + "-PemergeDebug"
     }
-    kotlinAndroidGradlePluginVersion = version
-  }
 
-  private fun withJavaVersion(version: String) = apply {
-    val arch = if (System.getProperty("os.arch") == "aarch64") "aarch64" else "X64"
-    val javaHomeEnvKey = "JAVA_HOME_${version}_$arch"
-    arguments = arguments + "-Dorg.gradle.java.home=${System.getenv(javaHomeEnvKey)}"
-  }
+  fun withGradleVersion(version: String) =
+    apply {
+      gradleRunner.withGradleVersion(version)
+    }
 
-  fun withServer(serverReceiver: MockWebServer.(HttpUrl) -> Unit) = apply {
-    server.apply { serverReceiver(baseUrl) }
-  }
+  fun withAndroidGradlePluginVersion(version: String) =
+    apply {
+      check(version in SUPPORTED_ANDROID_GRADLE_PLUGIN_VERSIONS) {
+        "This version of the Android Gradle Plugin is not currently supported."
+      }
+      androidGradlePluginVersion = version
+    }
 
-  fun assert(assertions: (BuildResult, MockWebServer) -> Unit) = apply {
-    this.assertions = assertions
-  }
+  fun withKotlinAndroidGradlePluginVersion(version: String) =
+    apply {
+      check(version in SUPPORTED_KOTLIN_ANDROID_GRADLE_PLUGIN_VERSIONS) {
+        "This version of the Kotlin Android Gradle Plugin is not currently supported."
+      }
+      kotlinAndroidGradlePluginVersion = version
+    }
 
-  fun withEnvironment(vararg pairs: Pair<String, String>) = apply {
-    this.environment = mapOf(*pairs)
-  }
+  private fun withJavaVersion(version: String) =
+    apply {
+      val arch = if (System.getProperty("os.arch") == "aarch64") "aarch64" else "X64"
+      val javaHomeEnvKey = "JAVA_HOME_${version}_$arch"
+      arguments = arguments + "-Dorg.gradle.java.home=${System.getenv(javaHomeEnvKey)}"
+    }
+
+  fun withServer(serverReceiver: MockWebServer.(HttpUrl) -> Unit) =
+    apply {
+      server.apply { serverReceiver(baseUrl) }
+    }
+
+  fun assert(assertions: (BuildResult, MockWebServer) -> Unit) =
+    apply {
+      this.assertions = assertions
+    }
+
+  fun withEnvironment(vararg pairs: Pair<String, String>) =
+    apply {
+      this.environment = mapOf(*pairs)
+    }
 
   private fun preBuild() {
     @Suppress("DEPRECATION")
@@ -113,11 +122,12 @@ class EmergeGradleRunner private constructor(
       withJavaVersion("11")
     }
 
-    val customEnvironment = mapOf(
-      *environment.toList().toTypedArray(),
-      // Turns off repository discovery to test projects that don't use Git
-      "GIT_DIR" to tempProjectDir!!.path,
-    )
+    val customEnvironment =
+      mapOf(
+        *environment.toList().toTypedArray(),
+        // Turns off repository discovery to test projects that don't use Git
+        "GIT_DIR" to tempProjectDir!!.path,
+      )
     gradleRunner
       .withProjectDir(tempProjectDir)
       .withArguments(arguments)
@@ -125,9 +135,9 @@ class EmergeGradleRunner private constructor(
       // Must be called first in order to set the default plugin classpath.
       .withPluginClasspath()
       .withPluginClasspath(
-        gradleRunner.pluginClasspath
-          + androidGradlePluginClasspath(androidGradlePluginVersion)
-          + kotlinAndroidGradlePluginClasspath(kotlinAndroidGradlePluginVersion)
+        gradleRunner.pluginClasspath +
+          androidGradlePluginClasspath(androidGradlePluginVersion) +
+          kotlinAndroidGradlePluginClasspath(kotlinAndroidGradlePluginVersion),
       )
   }
 

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/base/EmergePluginExtensionTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/base/EmergePluginExtensionTest.kt
@@ -4,7 +4,6 @@ import com.emergetools.android.gradle.EmergePluginTest
 import org.junit.jupiter.api.Test
 
 class EmergePluginExtensionTest : EmergePluginTest() {
-
   @Test
   fun noApiTokenBundle() {
     EmergeGradleRunner.create("no-api-token")

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/mocks/MockResponses.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/mocks/MockResponses.kt
@@ -18,9 +18,10 @@ fun getSuccessfulUpload(baseUrl: HttpUrl): MockResponse {
   }
 }
 
-val mockSuccessfulSignedUrlUpload = MockResponse().apply {
-  setResponseCode(200)
-}
+val mockSuccessfulSignedUrlUpload =
+  MockResponse().apply {
+    setResponseCode(200)
+  }
 
 fun getEmergeDispatcher(
   baseUrl: HttpUrl,
@@ -29,15 +30,17 @@ fun getEmergeDispatcher(
   return object : Dispatcher() {
     @Throws(InterruptedException::class)
     override fun dispatch(request: RecordedRequest): MockResponse {
-      val response = when (request.requestUrl?.host) {
-        "localhost" -> when (request.path?.substringBefore("?")) {
-          "/upload" -> getSuccessfulUpload(baseUrl)
-          "/signed_url" -> mockSuccessfulSignedUrlUpload
+      val response =
+        when (request.requestUrl?.host) {
+          "localhost" ->
+            when (request.path?.substringBefore("?")) {
+              "/upload" -> getSuccessfulUpload(baseUrl)
+              "/signed_url" -> mockSuccessfulSignedUrlUpload
+              else -> MockResponse().setResponseCode(404)
+            }
+
           else -> MockResponse().setResponseCode(404)
         }
-
-        else -> MockResponse().setResponseCode(404)
-      }
 
       if (timeout) {
         response.setSocketPolicy(SocketPolicy.NO_RESPONSE)

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/snapshots/MultiProjectSnapshotUploadTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/snapshots/MultiProjectSnapshotUploadTest.kt
@@ -6,7 +6,6 @@ import com.emergetools.android.gradle.mocks.assertSuccessfulUploadRequests
 import org.junit.jupiter.api.Test
 
 class MultiProjectSnapshotUploadTest : EmergePluginTest() {
-
   @Test
   fun multiProjectUploadSnapshotBundle() {
     EmergeGradleRunner.create("multi-project")

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/snapshots/SimpleSnapshotUploadTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/snapshots/SimpleSnapshotUploadTest.kt
@@ -6,7 +6,6 @@ import com.emergetools.android.gradle.mocks.assertSuccessfulUploadRequests
 import org.junit.jupiter.api.Test
 
 class SimpleSnapshotUploadTest : EmergePluginTest() {
-
   @Test
   fun simpleUploadSnapshotBundle() {
     EmergeGradleRunner.create("simple")

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/utils/EnvUtils.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/utils/EnvUtils.kt
@@ -4,9 +4,7 @@ import com.emergetools.android.gradle.base.EmergeGradleRunner
 import java.io.File
 
 object EnvUtils {
-
   fun EmergeGradleRunner.withGitHubPREvent(): EmergeGradleRunner {
-
     val resource = this.javaClass.getResource("/github-event-mocks/mock_pr_event.json")
     val jsonFile = File(resource.toURI())
 
@@ -17,7 +15,6 @@ object EnvUtils {
   }
 
   fun EmergeGradleRunner.withGitHubPREventNoBefore(): EmergeGradleRunner {
-
     val resource = this.javaClass.getResource("/github-event-mocks/mock_pr_event_no_before.json")
     val jsonFile = File(resource.toURI())
 
@@ -28,7 +25,6 @@ object EnvUtils {
   }
 
   fun EmergeGradleRunner.withGitHubPushEvent(): EmergeGradleRunner {
-
     val resource = this.javaClass.getResource("/github-event-mocks/mock_push_event.json")
     val jsonFile = File(resource.toURI())
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/EmergePluginExtension.kt
@@ -18,125 +18,140 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Nested
 import javax.inject.Inject
 
-abstract class EmergePluginExtension @Inject constructor(objects: ObjectFactory) {
+abstract class EmergePluginExtension
+  @Inject
+  constructor(objects: ObjectFactory) {
+    /**
+     * Emerge API token generated from the Emerge profile page.
+     * Required.
+     */
+    val apiToken: Property<String> =
+      objects.property<String>()
+        .convention(System.getenv(BaseUploadTask.DEFAULT_API_TOKEN_ENV_KEY))
 
-  /**
-   * Emerge API token generated from the Emerge profile page.
-   * Required.
-   */
-  val apiToken: Property<String> = objects.property<String>()
-    .convention(System.getenv(BaseUploadTask.DEFAULT_API_TOKEN_ENV_KEY))
+    val includeDependencyInformation: Property<Boolean> =
+      objects.property<Boolean>()
+        .convention(true)
 
-  val includeDependencyInformation: Property<Boolean> = objects.property<Boolean>()
-    .convention(true)
+    @get:Nested
+    abstract val sizeOptions: SizeOptions
 
-  @get:Nested
-  abstract val sizeOptions: SizeOptions
+    fun size(action: Action<SizeOptions>) {
+      action.execute(sizeOptions)
+    }
 
-  fun size(action: Action<SizeOptions>) {
-    action.execute(sizeOptions)
+    @get:Nested
+    abstract val perfOptions: PerfOptions
+
+    fun performance(action: Action<PerfOptions>) {
+      action.execute(perfOptions)
+    }
+
+    @get:Nested
+    abstract val snapshotOptions: SnapshotOptions
+
+    fun snapshots(action: Action<SnapshotOptions>) {
+      action.execute(snapshotOptions)
+    }
+
+    @get:Nested
+    abstract val reaperOptions: ReaperOptions
+
+    fun reaper(action: Action<ReaperOptions>) {
+      action.execute(reaperOptions)
+    }
+
+    @get:Nested
+    abstract val vcsOptions: VCSOptions
+
+    fun vcs(action: Action<VCSOptions>) {
+      action.execute(vcsOptions)
+    }
+
+    @get:Nested
+    abstract val debugOptions: DebugOptions
+
+    fun debug(action: Action<DebugOptions>) {
+      action.execute(debugOptions)
+    }
+
+    /**
+     * Optional inputs.
+     */
+
+    val dryRun: Property<Boolean> =
+      objects.property<Boolean>()
+        .convention(false)
+
+    val verbose: Property<Boolean> =
+      objects.property<Boolean>()
+        .convention(false)
   }
 
-  @get:Nested
-  abstract val perfOptions: PerfOptions
+abstract class VCSOptions
+  @Inject
+  constructor(
+    objects: ObjectFactory,
+    providers: ProviderFactory,
+  ) {
+    val sha: Property<String> =
+      objects.property(String::class.java)
+        .convention(providers.of(GitShaValueSource::class.java) {})
 
-  fun performance(action: Action<PerfOptions>) {
-    action.execute(perfOptions)
+    val baseSha: Property<String> =
+      objects.property(String::class.java)
+        .convention(providers.of(GitBaseShaValueSource::class.java) {})
+
+    val previousSha: Property<String> =
+      objects.property(String::class.java)
+        .convention(providers.of(GitPreviousShaValueSource::class.java) {})
+
+    val branchName: Property<String> =
+      objects.property(String::class.java)
+        .convention(providers.of(GitCurrentBranchValueSource::class.java) {})
+
+    val prNumber: Property<String> =
+      objects.property(String::class.java)
+        .convention(providers.of(GitHubPrNumberValueSource::class.java) {})
+
+    @get:Nested
+    abstract val gitHubOptions: GitHubOptions
+
+    fun gitHub(action: Action<GitHubOptions>) {
+      action.execute(gitHubOptions)
+    }
+
+    @get:Nested
+    abstract val gitLabOptions: GitLabOptions
+
+    // TODO: Remove in future major version release
+    fun gitLabOptions(action: Action<GitLabOptions>) {
+      action.execute(gitLabOptions)
+    }
+
+    fun gitLab(action: Action<GitLabOptions>) {
+      action.execute(gitLabOptions)
+    }
   }
 
-  @get:Nested
-  abstract val snapshotOptions: SnapshotOptions
+abstract class GitHubOptions
+  @Inject
+  constructor(
+    objects: ObjectFactory,
+    providers: ProviderFactory,
+  ) {
+    val repoOwner: Property<String> =
+      objects.property(String::class.java)
+        .convention(providers.of(GitHubRepoOwnerValueSource::class.java) {})
 
-  fun snapshots(action: Action<SnapshotOptions>) {
-    action.execute(snapshotOptions)
+    val repoName: Property<String> =
+      objects.property(String::class.java)
+        .convention(providers.of(GitHubRepoNameValueSource::class.java) {})
+
+    val includeEventInformation =
+      objects.property(Boolean::class.java)
+        .convention(true)
   }
-
-  @get:Nested
-  abstract val reaperOptions: ReaperOptions
-
-  fun reaper(action: Action<ReaperOptions>) {
-    action.execute(reaperOptions)
-  }
-
-  @get:Nested
-  abstract val vcsOptions: VCSOptions
-
-  fun vcs(action: Action<VCSOptions>) {
-    action.execute(vcsOptions)
-  }
-
-  @get:Nested
-  abstract val debugOptions: DebugOptions
-
-  fun debug(action: Action<DebugOptions>) {
-    action.execute(debugOptions)
-  }
-
-  /**
-   * Optional inputs.
-   */
-
-  val dryRun: Property<Boolean> = objects.property<Boolean>()
-    .convention(false)
-
-  val verbose: Property<Boolean> = objects.property<Boolean>()
-    .convention(false)
-}
-
-abstract class VCSOptions @Inject constructor(
-  objects: ObjectFactory,
-  providers: ProviderFactory,
-) {
-
-  val sha: Property<String> = objects.property(String::class.java)
-    .convention(providers.of(GitShaValueSource::class.java) {})
-
-  val baseSha: Property<String> = objects.property(String::class.java)
-    .convention(providers.of(GitBaseShaValueSource::class.java) {})
-
-  val previousSha: Property<String> = objects.property(String::class.java)
-    .convention(providers.of(GitPreviousShaValueSource::class.java) {})
-
-  val branchName: Property<String> = objects.property(String::class.java)
-    .convention(providers.of(GitCurrentBranchValueSource::class.java) {})
-
-  val prNumber: Property<String> = objects.property(String::class.java)
-    .convention(providers.of(GitHubPrNumberValueSource::class.java) {})
-
-  @get:Nested
-  abstract val gitHubOptions: GitHubOptions
-
-  fun gitHub(action: Action<GitHubOptions>) {
-    action.execute(gitHubOptions)
-  }
-
-  @get:Nested
-  abstract val gitLabOptions: GitLabOptions
-
-  // TODO: Remove in future major version release
-  fun gitLabOptions(action: Action<GitLabOptions>) {
-    action.execute(gitLabOptions)
-  }
-
-  fun gitLab(action: Action<GitLabOptions>) {
-    action.execute(gitLabOptions)
-  }
-}
-
-abstract class GitHubOptions @Inject constructor(
-  objects: ObjectFactory,
-  providers: ProviderFactory,
-) {
-
-  val repoOwner: Property<String> = objects.property(String::class.java)
-    .convention(providers.of(GitHubRepoOwnerValueSource::class.java) {})
-
-  val repoName: Property<String> = objects.property(String::class.java)
-    .convention(providers.of(GitHubRepoNameValueSource::class.java) {})
-
-  val includeEventInformation = objects.property(Boolean::class.java)
-    .convention(true)
-}
 
 abstract class GitLabOptions {
   abstract val projectId: Property<String>
@@ -154,7 +169,6 @@ abstract class ProductOptions {
 }
 
 abstract class SizeOptions : ProductOptions() {
-
   /**
    * Whether or not to generate size analysis tasks.
    */
@@ -162,7 +176,6 @@ abstract class SizeOptions : ProductOptions() {
 }
 
 abstract class PerfOptions : ProductOptions() {
-
   /**
    * Whether or not to generate performance analysis tasks.
    */
@@ -175,7 +188,6 @@ abstract class PerfOptions : ProductOptions() {
 }
 
 abstract class SnapshotOptions : ProductOptions() {
-
   /**
    * Whether or not to generate snapshot testing tasks.
    */
@@ -209,7 +221,6 @@ abstract class SnapshotOptions : ProductOptions() {
 }
 
 abstract class ReaperOptions : ProductOptions() {
-
   /**
    * The list of build variants Reaper is enabled for.
    *
@@ -229,7 +240,6 @@ abstract class ReaperOptions : ProductOptions() {
 }
 
 abstract class DebugOptions : ProductOptions() {
-
   /**
    * Forces any ASM instrumentation to be applied to the application bytecode even if cached.
    */

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/instrumentation/reaper/ReaperClassLoadTransform.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/instrumentation/reaper/ReaperClassLoadTransform.kt
@@ -13,9 +13,7 @@ import java.security.MessageDigest
 
 abstract class ReaperClassLoadClassVisitorFactory :
   AsmClassVisitorFactory<InstrumentationParameters.None> {
-
   companion object {
-
     private val logger by lazy {
       LoggerFactory.getLogger(ReaperClassLoadClassVisitorFactory::class.java)
     }
@@ -26,7 +24,7 @@ abstract class ReaperClassLoadClassVisitorFactory :
     nextClassVisitor: ClassVisitor,
   ): ClassVisitor {
     logger.info(
-      "ReaperClassVisitorFactory processing class: ${classContext.currentClassData.className}"
+      "ReaperClassVisitorFactory processing class: ${classContext.currentClassData.className}",
     )
 
     return ReaperClassLoadClassVisitor(
@@ -38,22 +36,21 @@ abstract class ReaperClassLoadClassVisitorFactory :
   }
 
   override fun isInstrumentable(classData: ClassData): Boolean {
-
     // This includes classes like kotlin.jvm.internal.Lambda which are used in
     // the <clinit> setup path of Reaper itself.
     val isKotlinStdlib = classData.className.startsWith("kotlin.")
     if (isKotlinStdlib) {
-      return false;
+      return false
     }
 
     // Don't instrument our own code but do instrument the sample.
     val isReaper = classData.className.startsWith("com.emergetools.reaper.")
     val isSample = classData.className.startsWith("com.emergetools.reaper.sample.")
     if (isReaper && !isSample) {
-      return false;
+      return false
     }
 
-    return true;
+    return true
   }
 }
 
@@ -64,7 +61,6 @@ class ReaperClassLoadClassVisitor(
   val logger: Logger,
   // private val writer: PrintWriter,
 ) : ClassVisitor(api, cv) {
-
   private var sourceFileName: String? = null
 
   override fun visitSource(
@@ -99,7 +95,6 @@ class ReaperClassLoadMethodVisitor(
   // private val writer: PrintWriter,
   private val name: String?,
 ) : MethodVisitor(api, methodVisitor) {
-
   override fun visitCode() {
     super.visitCode()
     if (name == "<clinit>" || name == "<init>") {
@@ -115,7 +110,7 @@ class ReaperClassLoadMethodVisitor(
         "com/emergetools/reaper/ReaperInternal",
         "logMethodEntry",
         "(J)V",
-        false
+        false,
       )
     }
   }
@@ -130,8 +125,7 @@ fun toSha256(s: String): ByteArray {
 fun topLong(buf: ByteArray): Long {
   var l: Long = 0L
   for (i in 0..7) {
-    l = l or ((buf[i].toLong() and 0xFFL) shl i*8)
+    l = l or ((buf[i].toLong() and 0xFFL) shl i * 8)
   }
   return l
 }
-

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/instrumentation/snapshots/SnapshotsPreviewRuntimeRetentionTransform.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/instrumentation/snapshots/SnapshotsPreviewRuntimeRetentionTransform.kt
@@ -14,7 +14,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 abstract class SnapshotsPreviewRuntimeRetentionTransformFactory : AsmClassVisitorFactory<SnapshotsPreviewRuntimeRetentionTransformFactory.Params> {
-
   interface Params : InstrumentationParameters {
     @get:Input
     @get:Optional
@@ -49,7 +48,6 @@ class SnapshotsPreviewRuntimeRetentionTransform(
   classVisitor: ClassVisitor?,
   private val logger: Logger,
 ) : ClassVisitor(api, classVisitor) {
-
   companion object {
     const val TAG = "SnapshotRuntimePreviewClassVisitor"
 
@@ -63,12 +61,13 @@ class SnapshotsPreviewRuntimeRetentionTransform(
     const val PREVIEW_FONT_SCALE_ANNOTATION_DESC =
       "Landroidx/compose/ui/tooling/preview/PreviewFontScale;"
 
-    val ANNOTATIONS_TO_TRANSFORM = arrayOf(
-      PREVIEW_ANNOTATION_DESC,
-      PREVIEW_CONTAINER_ANNOTATION_DESC,
-      PREVIEW_LIGHT_DARK_ANNOTATION_DESC,
-      PREVIEW_FONT_SCALE_ANNOTATION_DESC,
-    )
+    val ANNOTATIONS_TO_TRANSFORM =
+      arrayOf(
+        PREVIEW_ANNOTATION_DESC,
+        PREVIEW_CONTAINER_ANNOTATION_DESC,
+        PREVIEW_LIGHT_DARK_ANNOTATION_DESC,
+        PREVIEW_FONT_SCALE_ANNOTATION_DESC,
+      )
   }
 
   override fun visitMethod(
@@ -87,7 +86,7 @@ class SnapshotsPreviewRuntimeRetentionTransform(
       ): AnnotationVisitor? {
         if (ANNOTATIONS_TO_TRANSFORM.contains(desc)) {
           logger.info(
-            "$TAG: Modifying method annotation visible at runtime to true for annotation $desc $visible"
+            "$TAG: Modifying method annotation visible at runtime to true for annotation $desc $visible",
           )
 
           // Force the annotation to be visible at runtime
@@ -105,7 +104,7 @@ class SnapshotsPreviewRuntimeRetentionTransform(
   ): AnnotationVisitor? {
     if (ANNOTATIONS_TO_TRANSFORM.contains(desc)) {
       logger.info(
-        "$TAG: Modifying class annotation visible at runtime to true for annotation $desc $visible"
+        "$TAG: Modifying class annotation visible at runtime to true for annotation $desc $visible",
       )
 
       // Force the annotation to be visible at runtime

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BasePreflightTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BasePreflightTask.kt
@@ -8,9 +8,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 
-
 abstract class BasePreflightTask : DefaultTask() {
-
   @get:Input
   @get:Optional
   abstract val sha: Property<String>
@@ -55,7 +53,10 @@ abstract class BasePreflightTask : DefaultTask() {
 
     vcsPreflight.add("Branch name: ${branchName.getOrElse("Not set")}") {
       if (branchName.getOrElse("") == "HEAD") {
-        throw PreflightWarning("Branch could be in a detached head state which could lead to trouble posting status checks. Make sure to check your sha matches the commit sha on your branch.")
+        throw PreflightWarning(
+          "Branch could be in a detached head state which could lead to trouble posting status " +
+            "checks. Make sure to check your sha matches the commit sha on your branch.",
+        )
       }
 
       if (branchName.getOrElse("").isBlank()) {
@@ -65,14 +66,16 @@ abstract class BasePreflightTask : DefaultTask() {
 
     vcsPreflight.add("PR number: ${prNumber.getOrElse("Not set")}") {
       if (prNumber.getOrElse("").isBlank()) {
-        throw PreflightWarning("Emerge is unable to post status checks/comments without a value. Emerge will try to set automatically in GitHub environments using PR event data.")
+        throw PreflightWarning(
+          "Emerge is unable to post status checks/comments without a value. Emerge will try to " +
+            "set automatically in GitHub environments using PR event data.",
+        )
       }
     }
 
     val hasGitLabProjectId = gitLabProjectId.getOrElse("").isBlank()
     // Don't add if GitLab info set
     if (!hasGitLabProjectId) {
-
       vcsPreflight.add("[GitHub only] GitHub repo name: ${gitHubRepoName.getOrElse("Not set")}") {
         if (gitHubRepoName.getOrElse("").isBlank()) {
           throw PreflightWarning("Emerge is unable to post status checks/comments without a value.")
@@ -101,10 +104,7 @@ abstract class BasePreflightTask : DefaultTask() {
   }
 
   companion object {
-
-    fun BasePreflightTask.setPreflightTaskInputs(
-      extension: EmergePluginExtension,
-    ) {
+    fun BasePreflightTask.setPreflightTaskInputs(extension: EmergePluginExtension) {
       sha.set(extension.vcsOptions.sha)
       baseSha.set(extension.vcsOptions.baseSha)
       branchName.set(extension.vcsOptions.branchName)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/internal/LogExtensionTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/internal/LogExtensionTask.kt
@@ -9,7 +9,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 abstract class LogExtensionTask : DefaultTask() {
-
   @get:Input
   abstract val emergePluginExtension: Property<EmergePluginExtension>
 
@@ -17,76 +16,76 @@ abstract class LogExtensionTask : DefaultTask() {
   fun logExtension() {
     val extension = emergePluginExtension.get()
 
-    val extensionTree = treePrinter("Emerge configuration") {
+    val extensionTree =
+      treePrinter("Emerge configuration") {
+        addItem("apiToken: ${if (extension.apiToken.isPresent) "*****" else "MISSING"}")
+        addItem("includeDependencyInformation: ${extension.includeDependencyInformation.getOrElse(true)}")
+        addItem("dryRun (optional): ${extension.dryRun.orEmpty()}")
+        addItem("verbose (optional): ${extension.verbose.orEmpty()}")
 
-      addItem("apiToken: ${if (extension.apiToken.isPresent) "*****" else "MISSING"}")
-      addItem("includeDependencyInformation: ${extension.includeDependencyInformation.getOrElse(true)}")
-      addItem("dryRun (optional): ${extension.dryRun.orEmpty()}")
-      addItem("verbose (optional): ${extension.verbose.orEmpty()}")
+        val sizeHeading = addHeading("size")
+        addItem("tag (optional): ${extension.sizeOptions.tag.orEmpty()}", sizeHeading)
+        addItem("enabled: ${extension.sizeOptions.enabled.getOrElse(true)}", sizeHeading)
 
-      val sizeHeading = addHeading("size")
-      addItem("tag (optional): ${extension.sizeOptions.tag.orEmpty()}", sizeHeading)
-      addItem("enabled: ${extension.sizeOptions.enabled.getOrElse(true)}", sizeHeading)
+        val snapshotsHeading = addHeading("snapshots")
+        addItem(
+          "snapshotsStorageDirectory: ${extension.snapshotOptions.snapshotsStorageDirectory.orEmpty()}",
+          snapshotsHeading,
+        )
+        addItem("apiVersion: ${extension.snapshotOptions.apiVersion.orEmpty()}", snapshotsHeading)
+        addItem(
+          "includePrivatePreviews: ${extension.snapshotOptions.includePrivatePreviews.orEmpty()}",
+          snapshotsHeading,
+        )
+        addItem(
+          "includePreviewParamPreviews: ${extension.snapshotOptions.includePreviewParamPreviews.orEmpty()}",
+          snapshotsHeading,
+        )
+        addItem("tag (optional): ${extension.snapshotOptions.tag.orEmpty()}", snapshotsHeading)
+        addItem("enabled: ${extension.snapshotOptions.enabled.getOrElse(true)}", snapshotsHeading)
+        addItem("profile: ${extension.snapshotOptions.profile.getOrElse(false)}", snapshotsHeading)
 
-      val snapshotsHeading = addHeading("snapshots")
-      addItem(
-        "snapshotsStorageDirectory: ${extension.snapshotOptions.snapshotsStorageDirectory.orEmpty()}",
-        snapshotsHeading
-      )
-      addItem("apiVersion: ${extension.snapshotOptions.apiVersion.orEmpty()}", snapshotsHeading)
-      addItem(
-        "includePrivatePreviews: ${extension.snapshotOptions.includePrivatePreviews.orEmpty()}",
-        snapshotsHeading
-      )
-      addItem(
-        "includePreviewParamPreviews: ${extension.snapshotOptions.includePreviewParamPreviews.orEmpty()}",
-        snapshotsHeading
-      )
-      addItem("tag (optional): ${extension.snapshotOptions.tag.orEmpty()}", snapshotsHeading)
-      addItem("enabled: ${extension.snapshotOptions.enabled.getOrElse(true)}", snapshotsHeading)
-      addItem("profile: ${extension.snapshotOptions.profile.getOrElse(false)}", snapshotsHeading)
+        val reaperHeading = addHeading("reaper")
+        addItem(
+          "enabledVariants: ${extension.reaperOptions.enabledVariants.getOrElse(emptyList())}",
+          reaperHeading,
+        )
+        addItem(
+          "publishableApiKey: ${if (extension.reaperOptions.publishableApiKey.isPresent) "*****" else "MISSING"}",
+          reaperHeading,
+        )
+        addItem("tag (optional): ${extension.reaperOptions.tag.orEmpty()}", reaperHeading)
 
-      val reaperHeading = addHeading("reaper")
-      addItem(
-        "enabledVariants: ${extension.reaperOptions.enabledVariants.getOrElse(emptyList())}",
-        reaperHeading
-      )
-      addItem(
-        "publishableApiKey: ${if (extension.reaperOptions.publishableApiKey.isPresent) "*****" else "MISSING"}",
-        reaperHeading
-      )
-      addItem("tag (optional): ${extension.reaperOptions.tag.orEmpty()}", reaperHeading)
+        val performanceHeading = addHeading("performance")
+        addItem("projectPath: ${extension.perfOptions.projectPath.orEmpty()}", performanceHeading)
+        addItem("tag (optional): ${extension.perfOptions.tag.orEmpty()}", performanceHeading)
+        addItem("enabled: ${extension.perfOptions.enabled.getOrElse(true)}", performanceHeading)
 
-      val performanceHeading = addHeading("performance")
-      addItem("projectPath: ${extension.perfOptions.projectPath.orEmpty()}", performanceHeading)
-      addItem("tag (optional): ${extension.perfOptions.tag.orEmpty()}", performanceHeading)
-      addItem("enabled: ${extension.perfOptions.enabled.getOrElse(true)}", performanceHeading)
-
-      val vcsOptionsHeading = addHeading("vcsOptions (optional, defaults to Git values)")
-      addItem("sha: ${extension.vcsOptions.sha.orEmpty()}", vcsOptionsHeading)
-      addItem("baseSha: ${extension.vcsOptions.baseSha.orEmpty()}", vcsOptionsHeading)
-      addItem("previousSha: ${extension.vcsOptions.previousSha.orEmpty()}", vcsOptionsHeading)
-      addItem("branchName: ${extension.vcsOptions.branchName.orEmpty()}", vcsOptionsHeading)
-      addItem("prNumber: ${extension.vcsOptions.prNumber.orEmpty()}", vcsOptionsHeading)
-      addItem("gitHubOptions", vcsOptionsHeading)
-      addItem(
-        "repoOwner: ${extension.vcsOptions.gitHubOptions.repoOwner.orEmpty()}",
-        vcsOptionsHeading
-      )
-      addItem(
-        "repoName: ${extension.vcsOptions.gitHubOptions.repoName.orEmpty()}",
-        vcsOptionsHeading
-      )
-      addItem(
-        "includeEventInformation: ${extension.vcsOptions.gitHubOptions.includeEventInformation.orEmpty()}",
-        vcsOptionsHeading
-      )
-      addItem("gitLabOptions", vcsOptionsHeading)
-      addItem(
-        "projectId: ${extension.vcsOptions.gitLabOptions.projectId.orEmpty()}",
-        vcsOptionsHeading
-      )
-    }
+        val vcsOptionsHeading = addHeading("vcsOptions (optional, defaults to Git values)")
+        addItem("sha: ${extension.vcsOptions.sha.orEmpty()}", vcsOptionsHeading)
+        addItem("baseSha: ${extension.vcsOptions.baseSha.orEmpty()}", vcsOptionsHeading)
+        addItem("previousSha: ${extension.vcsOptions.previousSha.orEmpty()}", vcsOptionsHeading)
+        addItem("branchName: ${extension.vcsOptions.branchName.orEmpty()}", vcsOptionsHeading)
+        addItem("prNumber: ${extension.vcsOptions.prNumber.orEmpty()}", vcsOptionsHeading)
+        addItem("gitHubOptions", vcsOptionsHeading)
+        addItem(
+          "repoOwner: ${extension.vcsOptions.gitHubOptions.repoOwner.orEmpty()}",
+          vcsOptionsHeading,
+        )
+        addItem(
+          "repoName: ${extension.vcsOptions.gitHubOptions.repoName.orEmpty()}",
+          vcsOptionsHeading,
+        )
+        addItem(
+          "includeEventInformation: ${extension.vcsOptions.gitHubOptions.includeEventInformation.orEmpty()}",
+          vcsOptionsHeading,
+        )
+        addItem("gitLabOptions", vcsOptionsHeading)
+        addItem(
+          "projectId: ${extension.vcsOptions.gitLabOptions.projectId.orEmpty()}",
+          vcsOptionsHeading,
+        )
+      }
 
     logger.lifecycle(extensionTree)
   }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/internal/SaveExtensionConfigTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/internal/SaveExtensionConfigTask.kt
@@ -26,7 +26,6 @@ import java.io.File
  * contents of the JSON file to ensure our config is handled properly.
  */
 abstract class SaveExtensionConfigTask : DefaultTask() {
-
   @get:Input
   abstract val emergePluginExtension: Property<EmergePluginExtension>
 
@@ -42,15 +41,15 @@ abstract class SaveExtensionConfigTask : DefaultTask() {
   fun saveConfig() {
     val extensionData = emergePluginExtension.get().dataFromExtension()
     val configJson = Json.encodeToString(extensionData)
-    val outputFile = File(outputPath).also {
-      it.createNewFile()
-      it.writeText(configJson)
-    }
+    val outputFile =
+      File(outputPath).also {
+        it.createNewFile()
+        it.writeText(configJson)
+      }
     logger.lifecycle("Saved extension config to $outputFile")
   }
 
   companion object {
-
     @Serializable
     data class EmergePluginExtensionData(
       val apiToken: String?,
@@ -89,7 +88,7 @@ abstract class SaveExtensionConfigTask : DefaultTask() {
         branchName = branchName.orNull,
         prNumber = prNumber.orNull,
         gitHubOptions = gitHubOptions.dataFromExtension(),
-        gitLabOptions = gitLabOptions.dataFromExtension()
+        gitLabOptions = gitLabOptions.dataFromExtension(),
       )
     }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/GeneratePerfProject.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/GeneratePerfProject.kt
@@ -15,7 +15,6 @@ import java.io.File
 import java.util.zip.ZipInputStream
 
 abstract class GeneratePerfProject : DefaultTask() {
-
   private var packageName: String? = null
 
   @Option(option = "package", description = "Package name for the performance project")
@@ -27,8 +26,9 @@ abstract class GeneratePerfProject : DefaultTask() {
   }
 
   @get:Input
-  val appPackageName: Property<String> = project.objects.property<String>()
-    .convention("<REPLACE WITH APP PACKAGE NAME>")
+  val appPackageName: Property<String> =
+    project.objects.property<String>()
+      .convention("<REPLACE WITH APP PACKAGE NAME>")
 
   @get:Input
   abstract val performanceProjectPath: Property<String>
@@ -42,9 +42,10 @@ abstract class GeneratePerfProject : DefaultTask() {
   @TaskAction
   fun execute() {
     val projectName = performanceProjectPath.get().removePrefix(":")
-    val packageName = checkNotNull(packageName) {
-      "Package name is missing. Make sure to pass the --package command line argument."
-    }
+    val packageName =
+      checkNotNull(packageName) {
+        "Package name is missing. Make sure to pass the --package command line argument."
+      }
 
     generateProject(projectName, packageName)
     addProjectToRootProject(projectName)
@@ -64,10 +65,11 @@ abstract class GeneratePerfProject : DefaultTask() {
         "Project template is missing"
       }
 
-    val replacements = mapOf(
-      "package_name" to packageName,
-      "app_package_name" to appPackageName.get()
-    )
+    val replacements =
+      mapOf(
+        "package_name" to packageName,
+        "app_package_name" to appPackageName.get(),
+      )
 
     ZipInputStream(stream).use { zipStream ->
       generateSequence { zipStream.nextEntry }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/LocalPerfTest.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/LocalPerfTest.kt
@@ -12,12 +12,11 @@ import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
 abstract class LocalPerfTest : DefaultTask() {
-
   private val arguments = mutableMapOf<String, String>()
 
   @Option(
     option = "class",
-    description = "A single class, a single method or a comma-separated list of classes"
+    description = "A single class, a single method or a comma-separated list of classes",
   )
   fun setClazz(clazz: String) {
     arguments["class"] = clazz
@@ -25,7 +24,7 @@ abstract class LocalPerfTest : DefaultTask() {
 
   @Option(
     option = "notClass",
-    description = "A single class, a single method or a comma-separated list of classes"
+    description = "A single class, a single method or a comma-separated list of classes",
   )
   fun setNotClass(notClass: String) {
     arguments["notClass"] = notClass
@@ -33,7 +32,7 @@ abstract class LocalPerfTest : DefaultTask() {
 
   @Option(
     option = "annotation",
-    description = "A single annotation or a comma-separated list of annotations"
+    description = "A single annotation or a comma-separated list of annotations",
   )
   fun setAnnotation(annotation: String) {
     arguments["annotation"] = annotation
@@ -41,7 +40,7 @@ abstract class LocalPerfTest : DefaultTask() {
 
   @Option(
     option = "notAnnotation",
-    description = "A single annotation or a comma-separated list of annotations"
+    description = "A single annotation or a comma-separated list of annotations",
   )
   fun setNotAnnotation(notAnnotation: String) {
     arguments["notAnnotation"] = notAnnotation
@@ -67,19 +66,20 @@ abstract class LocalPerfTest : DefaultTask() {
     adbHelper.apply {
       shell("am", "force-stop", appPackageName.get())
 
-      val instrumentationArgs = mutableListOf("am", "instrument", "-w").also {
-        arguments.forEach { (key, value) ->
-          it.add("-e")
-          it.add(key)
-          it.add(value)
+      val instrumentationArgs =
+        mutableListOf("am", "instrument", "-w").also {
+          arguments.forEach { (key, value) ->
+            it.add("-e")
+            it.add(key)
+            it.add(value)
+          }
+          if (appPackageName.isPresent) {
+            it.add("-e")
+            it.add("packageName")
+            it.add(appPackageName.get())
+          }
+          it.add("${testPackageName.get()}/${EmergePlugin.EMERGE_JUNIT_RUNNER}")
         }
-        if (appPackageName.isPresent) {
-          it.add("-e")
-          it.add("packageName")
-          it.add(appPackageName.get())
-        }
-        it.add("${testPackageName.get()}/${EmergePlugin.EMERGE_JUNIT_RUNNER}")
-      }
       val output = shell(instrumentationArgs)
       logger.lifecycle(output)
     }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/Register.kt
@@ -23,7 +23,7 @@ fun registerPerformanceTasks(
   appVariants: List<ApplicationVariant>,
 ) {
   appProject.logger.debug(
-    "Registering performance tasks for variant ${perfVariant.name} in project ${appProject.path}"
+    "Registering performance tasks for variant ${perfVariant.name} in project ${appProject.path}",
   )
 
   // We're not concerned with the variants of the performance project, rather the app variants,
@@ -31,7 +31,11 @@ fun registerPerformanceTasks(
   appVariants.forEach { appVariant ->
     registerEmergeLocalTestTask(appProject, performanceProject, appVariant, perfVariant)
     registerUploadPerfBundleTask(
-      appProject, performanceProject, appVariant, perfVariant, extension
+      appProject,
+      performanceProject,
+      appVariant,
+      perfVariant,
+      extension,
     )
   }
 }
@@ -65,13 +69,14 @@ private fun registerEmergeLocalTestTask(
   val perfVariantName = performanceVariant.name.capitalize()
 
   val taskName = "emergeLocal${appVariantName}Test"
-  val task = appProject.tasks.register(taskName, LocalPerfTest::class.java) {
-    it.group = EMERGE_PERFORMANCE_TASK_GROUP
-    it.description = "Installs and runs tests for ${performanceVariant.name} on" +
-      " connected devices. For testing and debugging."
-    it.appPackageName.set(appVariant.applicationId)
-    it.testPackageName.set(performanceVariant.namespace)
-  }
+  val task =
+    appProject.tasks.register(taskName, LocalPerfTest::class.java) {
+      it.group = EMERGE_PERFORMANCE_TASK_GROUP
+      it.description = "Installs and runs tests for ${performanceVariant.name} on" +
+        " connected devices. For testing and debugging."
+      it.appPackageName.set(appVariant.applicationId)
+      it.testPackageName.set(performanceVariant.namespace)
+    }
 
   val uninstallAppTaskPath = "${appProject.path}:uninstall$appVariantName"
   val installAppTaskPath = "${appProject.path}:install$appVariantName"
@@ -97,7 +102,7 @@ fun registerGeneratePerfProjectTask(
   appVariants: List<ApplicationVariant>,
 ) {
   appProject.logger.debug(
-    "Registering generate perf project tasks in project ${appProject.path}"
+    "Registering generate perf project tasks in project ${appProject.path}",
   )
 
   val rootDir = appProject.rootDir
@@ -110,7 +115,7 @@ fun registerGeneratePerfProjectTask(
         val appVariant =
           appVariants.find { appVariant -> appVariant.name == "release" } ?: appVariants.first()
         appVariant.applicationId.get()
-      }
+      },
     )
     it.performanceProjectPath.set(performanceProjectPath)
     it.rootDir.set(rootDir)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/UploadPerfBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/UploadPerfBundle.kt
@@ -1,10 +1,10 @@
 package com.emergetools.android.gradle.tasks.perf
 
 import com.emergetools.android.gradle.BuildConfig
-import com.emergetools.android.gradle.tasks.size.UploadAAB
-import com.emergetools.android.gradle.tasks.size.UploadAPK
 import com.emergetools.android.gradle.tasks.base.ArtifactMetadata
 import com.emergetools.android.gradle.tasks.base.BaseUploadTask
+import com.emergetools.android.gradle.tasks.size.UploadAAB
+import com.emergetools.android.gradle.tasks.size.UploadAPK
 import kotlinx.datetime.Clock
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -18,7 +18,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 abstract class UploadPerfBundle : BaseUploadTask() {
-
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NAME_ONLY)
   abstract val artifact: RegularFileProperty
@@ -55,20 +54,21 @@ abstract class UploadPerfBundle : BaseUploadTask() {
   @TaskAction
   fun execute() {
     val artifactName = artifact.get().asFile.name
-    val artifactMetadata = ArtifactMetadata(
-      created = Clock.System.now(),
-      emergeGradlePluginVersion = BuildConfig.VERSION,
-      androidGradlePluginVersion = agpVersion.get(),
-      targetArtifactZipPath = artifactName,
-      testArtifactZipPath = perfArtifact.name,
-      // Primary artifact is always an AAB for this task
-      proguardMappingsZipPath = "$artifactName/${UploadAAB.AAB_PROGUARD_PATH}",
-    )
+    val artifactMetadata =
+      ArtifactMetadata(
+        created = Clock.System.now(),
+        emergeGradlePluginVersion = BuildConfig.VERSION,
+        androidGradlePluginVersion = agpVersion.get(),
+        targetArtifactZipPath = artifactName,
+        testArtifactZipPath = perfArtifact.name,
+        // Primary artifact is always an AAB for this task
+        proguardMappingsZipPath = "$artifactName/${UploadAAB.AAB_PROGUARD_PATH}",
+      )
 
     upload(artifactMetadata) { response ->
       logger.lifecycle(
         "Performance bundle upload successful! " +
-          "View Emerge's performance analysis at the following url:"
+          "View Emerge's performance analysis at the following url:",
       )
       logger.lifecycle("https://emergetools.com/performance/compare/${response.uploadId}")
       logger.lifecycle("Performance testing usually takes around 30 minutes or less.")

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/InitializeReaper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/InitializeReaper.kt
@@ -16,7 +16,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 abstract class InitializeReaper : BaseUploadTask() {
-
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NAME_ONLY)
   abstract val artifact: RegularFileProperty
@@ -35,17 +34,20 @@ abstract class InitializeReaper : BaseUploadTask() {
   @TaskAction
   fun execute() {
     if (publishableApiKey.orNull == null) {
-      throw StopExecutionException("publishableApiKey must be set for Reaper to work properly. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk.")
+      throw StopExecutionException(
+        "publishableApiKey must be set for Reaper to work properly. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk.",
+      )
     }
 
     val artifactName = artifact.get().asFile.name
-    val artifactMetadata = ArtifactMetadata(
-      created = Clock.System.now(),
-      emergeGradlePluginVersion = BuildConfig.VERSION,
-      androidGradlePluginVersion = agpVersion.get(),
-      targetArtifactZipPath = artifactName,
-      proguardMappingsZipPath = "$artifactName/$AAB_PROGUARD_PATH",
-    )
+    val artifactMetadata =
+      ArtifactMetadata(
+        created = Clock.System.now(),
+        emergeGradlePluginVersion = BuildConfig.VERSION,
+        androidGradlePluginVersion = agpVersion.get(),
+        targetArtifactZipPath = artifactName,
+        proguardMappingsZipPath = "$artifactName/$AAB_PROGUARD_PATH",
+      )
 
     upload(artifactMetadata) { response ->
       logger.lifecycle("Reaper initialized! View Reaper reports for this version at the following url:")

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/ReaperPreflight.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/ReaperPreflight.kt
@@ -9,7 +9,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
 abstract class ReaperPreflight : DefaultTask() {
-
   @get:Input
   @get:Optional
   abstract val hasEmergeApiToken: Property<Boolean>
@@ -28,7 +27,6 @@ abstract class ReaperPreflight : DefaultTask() {
   @get:Optional
   abstract val reaperPublishableApiKey: Property<String>
 
-
   @TaskAction
   fun execute() {
     val preflight = Preflight("Reaper preflight check")
@@ -43,7 +41,9 @@ abstract class ReaperPreflight : DefaultTask() {
     val variantName = variantName.get()
     preflight.add("enabled for variant: $variantName") {
       if (!reaperEnabled.getOrElse(false)) {
-        throw PreflightFailure("Reaper not enabled for variant $variantName. Make sure \"${variantName}\" is included in `reaper.enabledVariants`")
+        throw PreflightFailure(
+          "Reaper not enabled for variant $variantName. Make sure \"${variantName}\" is included in `reaper.enabledVariants`",
+        )
       }
     }
 
@@ -53,13 +53,17 @@ abstract class ReaperPreflight : DefaultTask() {
         throw PreflightFailure("publishableApiKey not set. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
       }
       if (key == "") {
-        throw PreflightFailure("publishableApiKey must not be empty. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
+        throw PreflightFailure(
+          "publishableApiKey must not be empty. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk",
+        )
       }
     }
 
     preflight.add("Runtime SDK added") {
       if (!hasReaperImplementationDependency.getOrElse(false)) {
-        throw PreflightFailure("Reaper runtime SDK missing as an implementation dependency. See https://docs.emergetools.com/docs/reaper-setup-android#install-the-sdk")
+        throw PreflightFailure(
+          "Reaper runtime SDK missing as an implementation dependency. See https://docs.emergetools.com/docs/reaper-setup-android#install-the-sdk",
+        )
       }
     }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/Register.kt
@@ -20,7 +20,7 @@ fun registerReaperTasks(
   variant: Variant,
 ) {
   appProject.logger.debug(
-    "Registering reaper tasks for variant ${variant.name} in project ${appProject.path}"
+    "Registering reaper tasks for variant ${variant.name} in project ${appProject.path}",
   )
 
   registerReaperPreflightTask(appProject, extension, variant)
@@ -47,7 +47,7 @@ private fun registerReaperPreflightTask(
     it.reaperEnabled.set(extension.reaperOptions.enabledVariants.getOrElse(emptyList()).contains(variant.name))
     it.reaperPublishableApiKey.set(extension.reaperOptions.publishableApiKey)
     it.hasReaperImplementationDependency.set(
-      hasDependency(appProject, variant, REAPER_DEP_GROUP, REAPER_DEP_NAME)
+      hasDependency(appProject, variant, REAPER_DEP_GROUP, REAPER_DEP_NAME),
     )
   }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/Register.kt
@@ -18,7 +18,7 @@ fun registerSizeTasks(
   variant: Variant,
 ) {
   appProject.logger.debug(
-    "Registering size tasks for variant ${variant.name} in project ${appProject.path}"
+    "Registering size tasks for variant ${variant.name} in project ${appProject.path}",
   )
 
   registerSizeAnalysisPreflightTask(appProject, extension, variant)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/SizePreflight.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/SizePreflight.kt
@@ -9,7 +9,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
 abstract class SizePreflight : BasePreflightTask() {
-
   @get:Input
   @get:Optional
   abstract val sizeEnabled: Property<Boolean>
@@ -49,7 +48,7 @@ abstract class SizePreflight : BasePreflightTask() {
       additionalSuccessLogging = {
         val uploadTaskName = getUploadAabTaskName(variantName.get())
         val uploadTaskInstructions =
-          "Upload & run size analysis on Emerge with ./gradlew ${appProjectPath.get()}:${uploadTaskName}"
+          "Upload & run size analysis on Emerge with ./gradlew ${appProjectPath.get()}:$uploadTaskName"
 
         buildString {
           append("Size analysis preflight was successful!")
@@ -57,7 +56,7 @@ abstract class SizePreflight : BasePreflightTask() {
           append(uploadTaskInstructions)
           append("\n")
         }
-      }
+      },
     )
   }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAAB.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAAB.kt
@@ -13,7 +13,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 abstract class UploadAAB : BaseUploadTask() {
-
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NAME_ONLY)
   abstract val artifact: RegularFileProperty
@@ -29,13 +28,14 @@ abstract class UploadAAB : BaseUploadTask() {
   @TaskAction
   fun execute() {
     val artifactName = artifact.get().asFile.name
-    val artifactMetadata = ArtifactMetadata(
-      created = Clock.System.now(),
-      emergeGradlePluginVersion = BuildConfig.VERSION,
-      androidGradlePluginVersion = agpVersion.get(),
-      targetArtifactZipPath = artifactName,
-      proguardMappingsZipPath = "$artifactName/$AAB_PROGUARD_PATH",
-    )
+    val artifactMetadata =
+      ArtifactMetadata(
+        created = Clock.System.now(),
+        emergeGradlePluginVersion = BuildConfig.VERSION,
+        androidGradlePluginVersion = agpVersion.get(),
+        targetArtifactZipPath = artifactName,
+        proguardMappingsZipPath = "$artifactName/$AAB_PROGUARD_PATH",
+      )
 
     upload(artifactMetadata) { response ->
       logger.lifecycle("AAB Upload successful! View Emerge's size analysis at the following url:")

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAPK.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAPK.kt
@@ -17,7 +17,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 abstract class UploadAPK : BaseUploadTask() {
-
   @get:InputDirectory
   @get:PathSensitive(PathSensitivity.NAME_ONLY)
   abstract val artifactDir: DirectoryProperty
@@ -57,13 +56,14 @@ abstract class UploadAPK : BaseUploadTask() {
   fun doExecute() {
     val artifactName = primaryArtifact.name
     val proguardMappingName = proguardMapping.asFile.orNull?.name
-    val artifactMetadata = ArtifactMetadata(
-      created = Clock.System.now(),
-      emergeGradlePluginVersion = BuildConfig.VERSION,
-      androidGradlePluginVersion = agpVersion.get(),
-      targetArtifactZipPath = artifactName,
-      proguardMappingsZipPath = proguardMappingName,
-    )
+    val artifactMetadata =
+      ArtifactMetadata(
+        created = Clock.System.now(),
+        emergeGradlePluginVersion = BuildConfig.VERSION,
+        androidGradlePluginVersion = agpVersion.get(),
+        targetArtifactZipPath = artifactName,
+        proguardMappingsZipPath = proguardMappingName,
+      )
 
     upload(artifactMetadata) { response ->
       logger.lifecycle("APK Upload successful! View Emerge's size analysis at the following url:")

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/PackageSnapshotArtifacts.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/PackageSnapshotArtifacts.kt
@@ -22,7 +22,6 @@ import org.gradle.api.tasks.TaskAction
  * Intended to be dependent of LocalSnapshot task and UploadSnapshots task.
  */
 abstract class PackageSnapshotArtifacts : DefaultTask() {
-
   @get:Input
   abstract val agpVersion: Property<String>
 
@@ -54,12 +53,13 @@ abstract class PackageSnapshotArtifacts : DefaultTask() {
     targetApk.copyTo(outputDirectory.get().asFile.resolve(targetApk.name), overwrite = true)
     testApk.copyTo(outputDirectory.get().asFile.resolve(testApk.name), overwrite = true)
 
-    val metadata = ArtifactMetadata(
-      emergeGradlePluginVersion = BuildConfig.VERSION,
-      androidGradlePluginVersion = agpVersion.get(),
-      targetArtifactZipPath = targetApk.name,
-      testArtifactZipPath = testApk.name,
-    )
+    val metadata =
+      ArtifactMetadata(
+        emergeGradlePluginVersion = BuildConfig.VERSION,
+        androidGradlePluginVersion = agpVersion.get(),
+        targetArtifactZipPath = targetApk.name,
+        testArtifactZipPath = testApk.name,
+      )
     val metadataString = Json.encodeToString(metadata)
     artifactMetadataPath.asFile.get().let {
       if (!it.exists()) {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
@@ -29,7 +29,7 @@ fun registerSnapshotTasks(
   androidTest: AndroidTest,
 ) {
   appProject.logger.debug(
-    "Registering snapshot tasks for variant ${variant.name} in project ${appProject.path}"
+    "Registering snapshot tasks for variant ${variant.name} in project ${appProject.path}",
   )
 
   registerSnapshotPreflightTask(appProject, extension, variant)
@@ -63,12 +63,12 @@ private fun registerSnapshotPackageTask(
     it.artifactDir.set(variant.artifacts.get(SingleArtifact.APK))
     it.testArtifactDir.set(androidTest.artifacts.get(SingleArtifact.APK))
     it.outputDirectory.set(
-      appProject.layout.buildDirectory.dir("$BUILD_OUTPUT_DIR_NAME/snapshots/artifacts")
+      appProject.layout.buildDirectory.dir("$BUILD_OUTPUT_DIR_NAME/snapshots/artifacts"),
     )
     it.artifactMetadataPath.set(
       appProject.layout.buildDirectory.file(
-        "$BUILD_OUTPUT_DIR_NAME/snapshots/artifacts/${ArtifactMetadata.JSON_FILE_NAME}"
-      )
+        "$BUILD_OUTPUT_DIR_NAME/snapshots/artifacts/${ArtifactMetadata.JSON_FILE_NAME}",
+      ),
     )
     it.agpVersion.set(AgpVersions.CURRENT.toString())
   }
@@ -88,7 +88,7 @@ private fun registerSnapshotPreflightTask(
     it.hasEmergeApiToken.set(!extension.apiToken.orNull.isNullOrBlank())
     it.snapshotsEnabled.set(extension.snapshotOptions.enabled.getOrElse(true))
     it.hasSnapshotsAndroidTestImplementationDependency.set(
-      hasDependency(appProject, variant, SNAPSHOTS_DEP_GROUP, SNAPSHOTS_DEP_NAME, variant.androidTest)
+      hasDependency(appProject, variant, SNAPSHOTS_DEP_GROUP, SNAPSHOTS_DEP_NAME, variant.androidTest),
     )
     it.setPreflightTaskInputs(extension)
   }
@@ -104,9 +104,10 @@ private fun registerSnapshotLocalTask(
   val variantName = variant.name.capitalize()
 
   val buildDirectory = appProject.layout.buildDirectory
-  val snapshotStorageDirectory = extension.snapshotOptions.snapshotsStorageDirectory.orElse(
-    buildDirectory.dir("$BUILD_OUTPUT_DIR_NAME/snapshots/outputs")
-  )
+  val snapshotStorageDirectory =
+    extension.snapshotOptions.snapshotsStorageDirectory.orElse(
+      buildDirectory.dir("$BUILD_OUTPUT_DIR_NAME/snapshots/outputs"),
+    )
 
   val targetAppId = variant.applicationId
   val testAppId = androidTest.applicationId
@@ -114,7 +115,7 @@ private fun registerSnapshotLocalTask(
 
   appProject.tasks.register(
     getSnapshotLocalTaskName(variant.name),
-    LocalSnapshots::class.java
+    LocalSnapshots::class.java,
   ) {
     it.group = EMERGE_SNAPSHOTS_TASK_GROUP
     it.description = "Generate snapshots locally for variant $variantName." +
@@ -144,7 +145,7 @@ private fun registerSnapshotUploadTask(
 ) {
   appProject.tasks.register(
     getSnapshotUploadTaskName(variant.name),
-    UploadSnapshotBundle::class.java
+    UploadSnapshotBundle::class.java,
   ) {
     it.group = EMERGE_SNAPSHOTS_TASK_GROUP
     it.description = "Builds and uploads a snapshot bundle to Emerge. Snapshots will be" +
@@ -152,7 +153,8 @@ private fun registerSnapshotUploadTask(
       " in the Emerge plugin extension."
     it.packageDir.set(packageTask.flatMap { packageTask -> packageTask.outputDirectory })
     it.artifactMetadataPath.set(
-      packageTask.flatMap { packageTask -> packageTask.artifactMetadataPath })
+      packageTask.flatMap { packageTask -> packageTask.artifactMetadataPath },
+    )
     it.apiVersion.set(extension.snapshotOptions.apiVersion)
     it.includePrivatePreviews.set(extension.snapshotOptions.includePrivatePreviews)
     it.includePreviewParamPreviews.set(extension.snapshotOptions.includePreviewParamPreviews)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/SnapshotsPreflight.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/SnapshotsPreflight.kt
@@ -9,7 +9,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
 abstract class SnapshotsPreflight : BasePreflightTask() {
-
   @get:Input
   @get:Optional
   abstract val snapshotsEnabled: Property<Boolean>
@@ -34,14 +33,20 @@ abstract class SnapshotsPreflight : BasePreflightTask() {
     val hasEmergeApiToken = hasEmergeApiToken.getOrElse(false)
     preflight.add("Emerge API token set") {
       if (!hasEmergeApiToken) {
-        throw PreflightFailure("Emerge API token not set. See https://docs.emergetools.com/docs/uploading-basics#obtain-an-api-key")
+        throw PreflightFailure(
+          "Emerge API token not set. See " +
+            "https://docs.emergetools.com/docs/uploading-basics#obtain-an-api-key",
+        )
       }
     }
 
     val snapshotsEnabled = snapshotsEnabled.getOrElse(false)
     preflight.add("Snapshots enabled") {
       if (!snapshotsEnabled) {
-        throw PreflightFailure("Snapshots not enabled. Make sure `snapshots.enabled` is set to true in the emerge configuration block.")
+        throw PreflightFailure(
+          "Snapshots not enabled. Make sure `snapshots.enabled` is set to " +
+            "true in the emerge configuration block.",
+        )
       }
     }
 
@@ -49,7 +54,10 @@ abstract class SnapshotsPreflight : BasePreflightTask() {
       hasSnapshotsAndroidTestImplementationDependency.getOrElse(false)
     preflight.add("Snapshots SDK is an androidTestImplementation dependency") {
       if (!hasSnapshotsAndroidTestImplementationDependency) {
-        throw PreflightFailure("Snapshots androidTestImplementation dependency not set. See https://docs.emergetools.com/docs/android-snapshots-v1#add-snapshot-sdk")
+        throw PreflightFailure(
+          "Snapshots androidTestImplementation dependency not set. See " +
+            "https://docs.emergetools.com/docs/android-snapshots-v1#add-snapshot-sdk",
+        )
       }
     }
 
@@ -60,11 +68,12 @@ abstract class SnapshotsPreflight : BasePreflightTask() {
       additionalSuccessLogging = {
         val localTaskName = getSnapshotLocalTaskName(variantName.get())
         val localTaskInstructions =
-          "Check snapshots locally with ./gradlew ${appProjectPath.get()}:${localTaskName} (make sure to have an emulator or connected device running)"
+          "Check snapshots locally with ./gradlew ${appProjectPath.get()}:$localTaskName " +
+            "(make sure to have an emulator or connected device running)"
 
         val uploadTaskName = getSnapshotUploadTaskName(variantName.get())
         val uploadTaskInstructions =
-          "Upload & run snapshots on Emerge with ./gradlew ${appProjectPath.get()}:${uploadTaskName}"
+          "Upload & run snapshots on Emerge with ./gradlew ${appProjectPath.get()}:$uploadTaskName"
 
         buildString {
           append("Snapshots preflight was successful!")
@@ -74,7 +83,7 @@ abstract class SnapshotsPreflight : BasePreflightTask() {
           append(uploadTaskInstructions)
           append("\n")
         }
-      }
+      },
     )
   }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
@@ -20,7 +20,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 abstract class UploadSnapshotBundle : BaseUploadTask() {
-
   @get:InputDirectory
   @get:PathSensitive(PathSensitivity.NAME_ONLY)
   abstract val packageDir: DirectoryProperty
@@ -40,21 +39,23 @@ abstract class UploadSnapshotBundle : BaseUploadTask() {
   @get:InputFile
   abstract val artifactMetadataPath: RegularFileProperty
 
-
   override fun includeFilesInUpload(zos: ZipOutputStream) {
-    val artifactMetadataFilePath = checkNotNull(artifactMetadataPath.asFile.orNull) {
-      "Artifact metadata file must be provided to upload snapshot bundle."
-    }
+    val artifactMetadataFilePath =
+      checkNotNull(artifactMetadataPath.asFile.orNull) {
+        "Artifact metadata file must be provided to upload snapshot bundle."
+      }
     check(artifactMetadataFilePath.exists()) {
       "Artifact metadata file does not exist: ${artifactMetadataFilePath.absolutePath}"
     }
     val artifactMetadata: ArtifactMetadata = Json.decodeFromString(artifactMetadataFilePath.readText())
 
-    val targetApk = packageDir.asFileTree.matching { it.include("*.apk") }.files
-      .first { it.name == artifactMetadata.targetArtifactZipPath }
+    val targetApk =
+      packageDir.asFileTree.matching { it.include("*.apk") }.files
+        .first { it.name == artifactMetadata.targetArtifactZipPath }
 
-    val testApk = packageDir.asFileTree.matching { it.include("*.apk") }.files
-      .first { it.name == artifactMetadata.testArtifactZipPath }
+    val testApk =
+      packageDir.asFileTree.matching { it.include("*.apk") }.files
+        .first { it.name == artifactMetadata.testArtifactZipPath }
 
     targetApk.inputStream().use {
       zos.putNextEntry(ZipEntry(targetApk.name))
@@ -80,21 +81,23 @@ abstract class UploadSnapshotBundle : BaseUploadTask() {
 
   @TaskAction
   fun execute() {
-    val artifactMetadataFilePath = checkNotNull(artifactMetadataPath.asFile.orNull) {
-      "Artifact metadata file must be provided to upload snapshot bundle."
-    }
+    val artifactMetadataFilePath =
+      checkNotNull(artifactMetadataPath.asFile.orNull) {
+        "Artifact metadata file must be provided to upload snapshot bundle."
+      }
     check(artifactMetadataFilePath.exists()) {
       "Artifact metadata file does not exist: ${artifactMetadataFilePath.absolutePath}"
     }
     val artifactMetadata: ArtifactMetadata = Json.decodeFromString(artifactMetadataFilePath.readText())
 
     upload(
-      artifactMetadata = artifactMetadata.copy(
-        created = Clock.System.now()
-      )
+      artifactMetadata =
+        artifactMetadata.copy(
+          created = Clock.System.now(),
+        ),
     ) { response ->
       logger.lifecycle(
-        "Snapshot bundle upload successful! View snapshots at the following url:"
+        "Snapshot bundle upload successful! View snapshots at the following url:",
       )
       logger.lifecycle("https://emergetools.com/snapshot/${response.uploadId}")
       logger.lifecycle("Snapshot generations usually take ~10 minutes or less.")

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Git.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Git.kt
@@ -3,7 +3,6 @@ package com.emergetools.android.gradle.util
 import org.gradle.process.ExecOperations
 
 internal class Git(private val execOperations: ExecOperations) {
-
   fun currentBranch(): String? {
     return execOperations.execute("git rev-parse --abbrev-ref HEAD")
   }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
@@ -7,14 +7,14 @@ import org.gradle.process.ExecOperations
 import java.io.File
 
 internal class GitHub(private val execOperations: ExecOperations) {
-
   private val git by lazy {
     Git(execOperations)
   }
 
-  private val json = Json {
-    ignoreUnknownKeys = true
-  }
+  private val json =
+    Json {
+      ignoreUnknownKeys = true
+    }
 
   private fun repoId(): String? {
     val remoteUrl = git.remoteUrl() ?: return null
@@ -90,9 +90,10 @@ internal class GitHub(private val execOperations: ExecOperations) {
   }
 
   private fun getEventDataString(): String {
-    val gitHubEventPath = checkNotNull(System.getenv("GITHUB_EVENT_PATH")) {
-      "GITHUB_EVENT_PATH is not set"
-    }
+    val gitHubEventPath =
+      checkNotNull(System.getenv("GITHUB_EVENT_PATH")) {
+        "GITHUB_EVENT_PATH is not set"
+      }
     val file = File(gitHubEventPath)
     check(file.exists()) {
       "File $gitHubEventPath doesn't exist"

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/PropertyUtils.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/PropertyUtils.kt
@@ -3,7 +3,6 @@ package com.emergetools.android.gradle.util
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 
-internal inline fun <reified T : Any> ObjectFactory.property(): Property<T> =
-  property(T::class.javaObjectType)
+internal inline fun <reified T : Any> ObjectFactory.property(): Property<T> = property(T::class.javaObjectType)
 
 internal fun <T> Property<T>.orEmpty() = orNull ?: ""

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/StringExtension.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/StringExtension.kt
@@ -6,8 +6,10 @@ internal fun String.capitalize(): String {
   return this.replaceFirstChar {
     if (it.isLowerCase()) {
       it.titlecase(
-        Locale.getDefault()
+        Locale.getDefault(),
       )
-    } else it.toString()
+    } else {
+      it.toString()
+    }
   }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/TreePrinter.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/TreePrinter.kt
@@ -4,19 +4,26 @@ sealed class Node(val content: String) {
   class Heading(content: String) : Node(content) {
     val children = mutableListOf<Node>()
   }
+
   class Item(content: String) : Node(content)
 }
 
 class TreePrinter(private val rootHeading: String) {
   private val root = Node.Heading(rootHeading)
 
-  fun addHeading(content: String, parent: Node.Heading = root): Node.Heading {
+  fun addHeading(
+    content: String,
+    parent: Node.Heading = root,
+  ): Node.Heading {
     val node = Node.Heading(content)
     parent.children.add(node)
     return node
   }
 
-  fun addItem(content: String, parent: Node.Heading = root) {
+  fun addItem(
+    content: String,
+    parent: Node.Heading = root,
+  ) {
     val node = Node.Item(content)
     parent.children.add(node)
   }
@@ -25,7 +32,10 @@ class TreePrinter(private val rootHeading: String) {
     return formatNode(root)
   }
 
-  private fun formatNode(node: Node, isLast: Boolean = false): String {
+  private fun formatNode(
+    node: Node,
+    isLast: Boolean = false,
+  ): String {
     return when (node) {
       is Node.Heading -> formatHeading(node)
       is Node.Item -> formatItem(node, isLast)
@@ -50,13 +60,19 @@ class TreePrinter(private val rootHeading: String) {
     }
   }
 
-  private fun formatItem(node: Node.Item, isLast: Boolean): String {
+  private fun formatItem(
+    node: Node.Item,
+    isLast: Boolean,
+  ): String {
     val prefix = if (isLast) "╚═ " else "╠═ "
     return "$prefix${node.content}"
   }
 }
 
-fun treePrinter(rootTitle: String, build: TreePrinter.() -> Unit): String {
+fun treePrinter(
+  rootTitle: String,
+  build: TreePrinter.() -> Unit,
+): String {
   val treePrinter = TreePrinter(rootTitle)
   treePrinter.build()
   return treePrinter.print()

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/VariantUtils.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/VariantUtils.kt
@@ -11,22 +11,26 @@ fun hasDependency(
   dependencyName: String,
   androidTest: AndroidTest? = null,
 ): Boolean {
-  fun MutableList<String>.addIfNotBlank(value: String?, formatter: (String) -> String) {
+  fun MutableList<String>.addIfNotBlank(
+    value: String?,
+    formatter: (String) -> String,
+  ) {
     value?.takeIf { it.isNotBlank() }?.let { add(formatter(it)) }
   }
 
-  val configsToCheck = buildList {
-    add("implementation")
-    addIfNotBlank(variant.flavorName) { "${it}Implementation" }
-    addIfNotBlank(variant.buildType) { "${it}Implementation" }
-    addIfNotBlank(variant.name) { "${it}Implementation" }
-    androidTest?.let { test ->
-      add("androidTestImplementation")
-      addIfNotBlank(test.flavorName) { "${it}Implementation" }
-      addIfNotBlank(test.buildType) { "${it}Implementation" }
-      addIfNotBlank(test.name) { "${it}Implementation" }
+  val configsToCheck =
+    buildList {
+      add("implementation")
+      addIfNotBlank(variant.flavorName) { "${it}Implementation" }
+      addIfNotBlank(variant.buildType) { "${it}Implementation" }
+      addIfNotBlank(variant.name) { "${it}Implementation" }
+      androidTest?.let { test ->
+        add("androidTestImplementation")
+        addIfNotBlank(test.flavorName) { "${it}Implementation" }
+        addIfNotBlank(test.buildType) { "${it}Implementation" }
+        addIfNotBlank(test.name) { "${it}Implementation" }
+      }
     }
-  }
 
   project.logger.lifecycle("Checking for dependency $dependencyGroup:$dependencyName in configurations $configsToCheck")
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/adb/AdbHelper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/adb/AdbHelper.kt
@@ -11,20 +11,21 @@ class AdbHelper(
   private val logger: Logger,
   private val path: Path = Path.of("${System.getenv("ANDROID_HOME")}/platform-tools/adb"),
 ) {
-
   init {
     check(Files.exists(path)) { "ADB not found at path: $path" }
     logger.debug("ADB Helper initialized with path: $path")
   }
 
   fun devices(): List<String> {
-    val result = checkNotNull(exec("devices")) {
-      "Error running adb devices"
-    }
+    val result =
+      checkNotNull(exec("devices")) {
+        "Error running adb devices"
+      }
 
-    val lines = result.lines()
-      .filter { it.isNotBlank() }
-      .drop(1)
+    val lines =
+      result.lines()
+        .filter { it.isNotBlank() }
+        .drop(1)
     return lines.map { it.split("\t").first() }
   }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/dependencies/Dependencies.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/dependencies/Dependencies.kt
@@ -7,7 +7,6 @@ data class Dependencies(
   val modules: List<Module>,
   val libraries: List<Library>,
 ) {
-
   companion object {
     const val JSON_FILE_NAME = "dependencies.json"
   }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/network/EmergeUploadRequest.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/network/EmergeUploadRequest.kt
@@ -11,7 +11,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.internal.userAgent
 import java.io.File
 
 const val SOURCE_GRADLE_PLUGIN = "gradle_plugin"
@@ -47,29 +46,33 @@ fun fetchSignedUrl(
   baseUrl: HttpUrl,
 ): EmergeUploadResponse {
   val mediaType = "application/json".toMediaType()
-  val json = Json {
-    ignoreUnknownKeys = true
-    encodeDefaults = false
-  }
+  val json =
+    Json {
+      ignoreUnknownKeys = true
+      encodeDefaults = false
+    }
   val body = json.encodeToString(uploadData).toRequestBody(mediaType)
-  val url = baseUrl.resolve("/upload")
-    ?: throw IllegalStateException("Could not resolve /upload for baseUrl: $baseUrl")
-  val request: Request = Request.Builder().apply {
-    url(url)
-    post(body)
-    addHeader("User-Agent", "${SOURCE_GRADLE_PLUGIN}_${BuildConfig.VERSION}")
-    addHeader("Accept", "application/json")
-    addHeader("Content-Type", "application/json")
-    addHeader("X-API-Token", uploadData.apiToken)
-  }.build()
+  val url =
+    baseUrl.resolve("/upload")
+      ?: throw IllegalStateException("Could not resolve /upload for baseUrl: $baseUrl")
+  val request: Request =
+    Request.Builder().apply {
+      url(url)
+      post(body)
+      addHeader("User-Agent", "${SOURCE_GRADLE_PLUGIN}_${BuildConfig.VERSION}")
+      addHeader("Accept", "application/json")
+      addHeader("Content-Type", "application/json")
+      addHeader("X-API-Token", uploadData.apiToken)
+    }.build()
 
   client.newCall(request).execute().use { response ->
     check(response.isSuccessful) {
       "Unexpected code $response"
     }
-    val responseString = checkNotNull(response.body?.string()) {
-      "Received null body from upload request"
-    }
+    val responseString =
+      checkNotNull(response.body?.string()) {
+        "Received null body from upload request"
+      }
     return json.decodeFromString(responseString)
   }
 }
@@ -80,11 +83,12 @@ fun postFile(
   signedUrl: HttpUrl,
 ) {
   val mediaType = "application/zip".toMediaType()
-  val request = Request.Builder().apply {
-    addHeader("Content-Type", "application/zip")
-    url(signedUrl)
-    put(file.asRequestBody(mediaType))
-  }.build()
+  val request =
+    Request.Builder().apply {
+      addHeader("Content-Type", "application/zip")
+      url(signedUrl)
+      put(file.asRequestBody(mediaType))
+    }.build()
 
   client.newCall(request).execute().use { response ->
     check(response.isSuccessful) {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitBaseShaValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitBaseShaValueSource.kt
@@ -8,7 +8,6 @@ import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
 abstract class GitBaseShaValueSource : ValueSource<String?, None> {
-
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitCurrentBranchValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitCurrentBranchValueSource.kt
@@ -1,14 +1,12 @@
 package com.emergetools.android.gradle.util.providers
 
 import com.emergetools.android.gradle.util.Git
-import com.emergetools.android.gradle.util.GitHub
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters.None
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
 abstract class GitCurrentBranchValueSource : ValueSource<String?, None> {
-
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubPrNumberValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubPrNumberValueSource.kt
@@ -7,7 +7,6 @@ import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
 abstract class GitHubPrNumberValueSource : ValueSource<String?, None> {
-
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoNameValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoNameValueSource.kt
@@ -7,7 +7,6 @@ import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
 abstract class GitHubRepoNameValueSource : ValueSource<String?, None> {
-
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoOwnerValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoOwnerValueSource.kt
@@ -7,7 +7,6 @@ import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
 abstract class GitHubRepoOwnerValueSource : ValueSource<String?, None> {
-
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitPreviousShaValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitPreviousShaValueSource.kt
@@ -8,7 +8,6 @@ import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
 abstract class GitPreviousShaValueSource : ValueSource<String?, None> {
-
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitShaValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitShaValueSource.kt
@@ -8,7 +8,6 @@ import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
 abstract class GitShaValueSource : ValueSource<String?, None> {
-
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/instrumentation/reaper/ReaperClassLoadTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/instrumentation/reaper/ReaperClassLoadTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test
 import java.util.Base64
 
 class ReaperClassLoadTest {
-
   private fun byteArrayOf(vararg elements: Int): ByteArray {
     return elements.map { it.toByte() }.toByteArray()
   }
@@ -15,8 +14,8 @@ class ReaperClassLoadTest {
     val hash = toSha256("Lcom/example/ExampleKt;")
     val base64 = Base64.getEncoder().encode(hash).toString(Charsets.UTF_8)
     Assertions.assertEquals(
-        "eJstGDKanIhi3JzCGQ2w3x5We26SD1B1TPzVsups6fY=",
-        base64
+      "eJstGDKanIhi3JzCGQ2w3x5We26SD1B1TPzVsups6fY=",
+      base64,
     )
   }
 
@@ -30,5 +29,4 @@ class ReaperClassLoadTest {
     Assertions.assertEquals(-1167088121787636991L, topLong(byteArrayOf(0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef)))
     Assertions.assertEquals(-1167088121787636991L, topLong(byteArrayOf(0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xff, 0xff)))
   }
-
 }

--- a/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/instrumentation/snapshots/SnapshotsPreviewRuntimeRetentionTransformTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/instrumentation/snapshots/SnapshotsPreviewRuntimeRetentionTransformTest.kt
@@ -13,7 +13,6 @@ import java.io.File
 import java.io.InputStream
 
 class SnapshotsPreviewRuntimeRetentionTransformTest {
-
   @Test
   fun `test transform applied correctly on method with preview annotation`() {
     val originalClassBytes = loadClassFile("snapshot-test-classes/TextRowWithIconKt.class")
@@ -24,7 +23,7 @@ class SnapshotsPreviewRuntimeRetentionTransformTest {
         originalClassBytes,
         "Landroidx/compose/ui/tooling/preview/Preview;",
         "TextRowWithIconPreviewFromMainIgnored",
-      )
+      ),
     )
 
     val transformedClassBytes = applyTransform(originalClassBytes)
@@ -34,7 +33,7 @@ class SnapshotsPreviewRuntimeRetentionTransformTest {
         transformedClassBytes,
         "Landroidx/compose/ui/tooling/preview/Preview;",
         "TextRowWithIconPreviewFromMainIgnored",
-      )
+      ),
     )
   }
 
@@ -48,7 +47,7 @@ class SnapshotsPreviewRuntimeRetentionTransformTest {
         originalClassBytes,
         "Landroidx/compose/ui/tooling/preview/Preview\$Container;",
         "TextRowWithIconPreviewFromMain",
-      )
+      ),
     )
 
     val transformedClassBytes = applyTransform(originalClassBytes)
@@ -58,7 +57,7 @@ class SnapshotsPreviewRuntimeRetentionTransformTest {
         transformedClassBytes,
         "Landroidx/compose/ui/tooling/preview/Preview\$Container;",
         "TextRowWithIconPreviewFromMain",
-      )
+      ),
     )
   }
 
@@ -72,7 +71,7 @@ class SnapshotsPreviewRuntimeRetentionTransformTest {
       isClassAnnotationRuntimeVisible(
         originalClassBytes,
         "Landroidx/compose/ui/tooling/preview/Preview;",
-      )
+      ),
     )
 
     val transformedClassBytes = applyTransform(originalClassBytes)
@@ -81,7 +80,7 @@ class SnapshotsPreviewRuntimeRetentionTransformTest {
       isClassAnnotationRuntimeVisible(
         transformedClassBytes,
         "Landroidx/compose/ui/tooling/preview/Preview;",
-      )
+      ),
     )
   }
 
@@ -94,7 +93,7 @@ class SnapshotsPreviewRuntimeRetentionTransformTest {
       isClassAnnotationRuntimeVisible(
         originalClassBytes,
         "Landroidx/compose/ui/tooling/preview/Preview\$Container;",
-      )
+      ),
     )
 
     val transformedClassBytes = applyTransform(originalClassBytes)
@@ -103,7 +102,7 @@ class SnapshotsPreviewRuntimeRetentionTransformTest {
       isClassAnnotationRuntimeVisible(
         transformedClassBytes,
         "Landroidx/compose/ui/tooling/preview/Preview\$Container;",
-      )
+      ),
     )
   }
 
@@ -117,11 +116,12 @@ class SnapshotsPreviewRuntimeRetentionTransformTest {
     val classReader = ClassReader(originalClassBytes)
     val classWriter = ClassWriter(classReader, 0)
 
-    val classVisitor = SnapshotsPreviewRuntimeRetentionTransform(
-      Opcodes.ASM9,
-      classWriter,
-      LoggerFactory.getLogger(SnapshotsPreviewRuntimeRetentionTransformTest::class.java)
-    )
+    val classVisitor =
+      SnapshotsPreviewRuntimeRetentionTransform(
+        Opcodes.ASM9,
+        classWriter,
+        LoggerFactory.getLogger(SnapshotsPreviewRuntimeRetentionTransformTest::class.java),
+      )
     classReader.accept(classVisitor, ClassReader.SKIP_FRAMES)
     return classWriter.toByteArray()
   }

--- a/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/util/preflight/PreflightTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/util/preflight/PreflightTest.kt
@@ -6,17 +6,16 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class PreflightTest {
-
   @Test
   fun `marks successful checks as succeeded`() {
-    val preflight = Preflight("Douglas Adams");
+    val preflight = Preflight("Douglas Adams")
     preflight.add("Always succeeds") {}
     assertTrue(preflight.isSuccessful())
   }
 
   @Test
   fun `marks failed checks as failed`() {
-    val preflight = Preflight("Douglas Adams");
+    val preflight = Preflight("Douglas Adams")
     preflight.add("Always fails") {
       throw PreflightFailure("failure")
     }
@@ -25,7 +24,7 @@ class PreflightTest {
 
   @Test
   fun `mixed checks are failures`() {
-    val preflight = Preflight("Douglas Adams");
+    val preflight = Preflight("Douglas Adams")
     preflight.add("Always succeeds") {}
     preflight.add("Always fails") {
       throw PreflightFailure("failure")
@@ -35,63 +34,73 @@ class PreflightTest {
 
   @Test
   fun `renders successful preflight nicely`() {
-    val preflight = Preflight("Douglas Adams");
+    val preflight = Preflight("Douglas Adams")
     preflight.add("HHGTTG open to page 42") {}
     preflight.add("Towel on person") {}
     preflight.add("Tea hot") {}
-    assertEquals("""
-    ╔════════════════════════════════════╗
-    ║ Douglas Adams was successful (3/3) ║
-    ╠════════════════════════════════════╝
-    ╠═ ✅ HHGTTG open to page 42
-    ╠═ ✅ Towel on person
-    ╚═ ✅ Tea hot
-    """.trimIndent(), preflight.render())
+    assertEquals(
+      """
+      ╔════════════════════════════════════╗
+      ║ Douglas Adams was successful (3/3) ║
+      ╠════════════════════════════════════╝
+      ╠═ ✅ HHGTTG open to page 42
+      ╠═ ✅ Towel on person
+      ╚═ ✅ Tea hot
+      """.trimIndent(),
+      preflight.render(),
+    )
   }
 
   @Test
   fun `renders unsuccessful preflight nicely`() {
-    val preflight = Preflight("Douglas Adams");
+    val preflight = Preflight("Douglas Adams")
     preflight.add("HHGTTG open to page 42") {}
     preflight.add("Towel on person") {
       throw PreflightFailure("Towel missing!")
     }
     preflight.add("Tea hot") {}
-    assertEquals("""
-    ╔════════════════════════════╗
-    ║ Douglas Adams failed (2/3) ║
-    ╠════════════════════════════╝
-    ╠═ ✅ HHGTTG open to page 42
-    ╠═ ❌ Towel on person
-    ╚═ ✅ Tea hot
-    """.trimIndent(), preflight.render())
+    assertEquals(
+      """
+      ╔════════════════════════════╗
+      ║ Douglas Adams failed (2/3) ║
+      ╠════════════════════════════╝
+      ╠═ ✅ HHGTTG open to page 42
+      ╠═ ❌ Towel on person
+      ╚═ ✅ Tea hot
+      """.trimIndent(),
+      preflight.render(),
+    )
   }
 
   @Test
   fun `renders errors nicely`() {
-    val preflight = Preflight("Douglas Adams");
+    val preflight = Preflight("Douglas Adams")
     preflight.add("HHGTTG open to page 42") {}
     preflight.add("Towel on person") {
       throw PreflightFailure("Towel missing!")
     }
     preflight.add("Tea hot") {
-      throw PreflightFailure("""
+      throw PreflightFailure(
+        """
         Tea cold!
         Expected:
           boiling
         was
           lukewarm
-      """.trimIndent())
+        """.trimIndent(),
+      )
     }
-    assertEquals("""
-    Errors:
-      ❌ Towel missing!
-      ❌ Tea cold!
-    Expected:
-      boiling
-    was
-      lukewarm
-    """.trimIndent(), preflight.renderErrors())
+    assertEquals(
+      """
+      Errors:
+        ❌ Towel missing!
+        ❌ Tea cold!
+      Expected:
+        boiling
+      was
+        lukewarm
+      """.trimIndent(),
+      preflight.renderErrors(),
+    )
   }
-
 }

--- a/gradle-plugin/settings.gradle.kts
+++ b/gradle-plugin/settings.gradle.kts
@@ -21,3 +21,4 @@ dependencyResolutionManagement {
 }
 
 include(":plugin")
+rootProject.name = "emerge-gradle-plugin"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
 android.useAndroidX=true
 org.gradle.configuration.cache=true
+org.gradle.configuration.cache.parallel=true


### PR DESCRIPTION
This runs detekt on the `:gradle-plugin` project where it was not previously run before.
I autoformatted a lot of the code that was easily auto-formatted and set a baseline for the rest.

This also enables the gradle configuration cache parallel flag for parallel load and store to improve performance.

I recommend using the non-whitespace diff: https://github.com/EmergeTools/emerge-android/pull/372/files?diff=split&w=1