### PR TITLE
Add cacheable task annotations and proper inputs

### DIFF
--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -26,40 +26,8 @@ jobs:
           java-version: 17
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Run build
-        run: ./gradlew :gradle-plugin:build
-
-  unit_tests:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDKs
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'adopt'
-          java-version: 17
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-      - name: Run unit tests
-        run: ./gradlew :gradle-plugin:plugin:test
-
-  functional_tests:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDKs
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'adopt'
-          java-version: |
-            11
-            17
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-      - name: Run functional tests
-        run: ./gradlew :gradle-plugin:plugin:functionalTest --stacktrace
+      - name: Check
+        run: ./gradlew :gradle-plugin:plugin:check
       - name: Archive test reports
         uses: actions/upload-artifact@v4
         if: always()

--- a/gradle-plugin/detekt/baseline.xml
+++ b/gradle-plugin/detekt/baseline.xml
@@ -3,10 +3,8 @@
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ArgumentListWrapping:com.emergetools.android.gradle.instrumentation.reaper.ReaperClassLoadTest.kt:30</ID>
-    <ID>ArgumentListWrapping:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:37</ID>
-    <ID>ArgumentListWrapping:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:53</ID>
-    <ID>ArgumentListWrapping:com.emergetools.android.gradle.tasks.size.SizePreflight.kt:33</ID>
-    <ID>ArgumentListWrapping:com.emergetools.android.gradle.tasks.size.SizePreflight.kt:40</ID>
+    <ID>ArgumentListWrapping:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:59</ID>
+    <ID>ArgumentListWrapping:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:60</ID>
     <ID>Indentation:com.emergetools.android.gradle.EmergePlugin.kt:58</ID>
     <ID>Indentation:com.emergetools.android.gradle.EmergePlugin.kt:59</ID>
     <ID>Indentation:com.emergetools.android.gradle.EmergePlugin.kt:60</ID>
@@ -112,14 +110,6 @@
     <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:97</ID>
     <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:98</ID>
     <ID>Indentation:com.emergetools.android.gradle.EmergePluginExtension.kt:99</ID>
-    <ID>Indentation:com.emergetools.android.gradle.tasks.base.BaseUploadTask.kt:219</ID>
-    <ID>Indentation:com.emergetools.android.gradle.tasks.base.BaseUploadTask.kt:220</ID>
-    <ID>Indentation:com.emergetools.android.gradle.tasks.base.BaseUploadTask.kt:221</ID>
-    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.LocalSnapshots.kt:34</ID>
-    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.LocalSnapshots.kt:35</ID>
-    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.UploadSnapshotBundle.kt:95</ID>
-    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.UploadSnapshotBundle.kt:96</ID>
-    <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.UploadSnapshotBundle.kt:97</ID>
     <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:178</ID>
     <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:251</ID>
     <ID>Indentation:com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils.kt:252</ID>
@@ -151,26 +141,10 @@
     <ID>MagicNumber:ReaperClassLoadTransform.kt$7</ID>
     <ID>MagicNumber:ReaperClassLoadTransform.kt$8</ID>
     <ID>MaxLineLength:DependencyUtils.kt$"Skipping invalid dependency: ${it.key}, expected format: group:name:version, please let the Emerge team know of this!"</ID>
-    <ID>MaxLineLength:InitializeReaper.kt$InitializeReaper$"publishableApiKey must be set for Reaper to work properly. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk."</ID>
     <ID>MaxLineLength:ReaperClassLoadTest.kt$ReaperClassLoadTest$Assertions.assertEquals(-1167088121787636991L, topLong(byteArrayOf(0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xff, 0xff)))</ID>
-    <ID>MaxLineLength:ReaperPreflight.kt$ReaperPreflight$"Reaper not enabled for variant $variantName. Make sure \"${variantName}\" is included in `reaper.enabledVariants`"</ID>
-    <ID>MaxLineLength:ReaperPreflight.kt$ReaperPreflight$"Reaper runtime SDK missing as an implementation dependency. See https://docs.emergetools.com/docs/reaper-setup-android#install-the-sdk"</ID>
-    <ID>MaxLineLength:ReaperPreflight.kt$ReaperPreflight$"publishableApiKey must not be empty. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk"</ID>
-    <ID>MaxLineLength:ReaperPreflight.kt$ReaperPreflight$throw PreflightFailure("Emerge API token not set. See https://docs.emergetools.com/docs/uploading-basics#obtain-an-api-key")</ID>
-    <ID>MaxLineLength:ReaperPreflight.kt$ReaperPreflight$throw PreflightFailure("publishableApiKey not set. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")</ID>
-    <ID>MaxLineLength:SizePreflight.kt$SizePreflight$throw PreflightFailure("Emerge API token not set. See https://docs.emergetools.com/docs/uploading-basics#obtain-an-api-key")</ID>
-    <ID>MaxLineLength:SizePreflight.kt$SizePreflight$throw PreflightFailure("Size analysis not enabled. Make sure `size.enabled` is set to true in the emerge configuration block.")</ID>
     <ID>MaxLineLength:SnapshotsPreviewRuntimeRetentionTransform.kt$SnapshotsPreviewRuntimeRetentionTransformFactory$abstract</ID>
     <ID>MaximumLineLength:com.emergetools.android.gradle.instrumentation.reaper.ReaperClassLoadTest.kt:30</ID>
     <ID>MaximumLineLength:com.emergetools.android.gradle.instrumentation.snapshots.SnapshotsPreviewRuntimeRetentionTransform.kt:16</ID>
-    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.InitializeReaper.kt:38</ID>
-    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:37</ID>
-    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:45</ID>
-    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:53</ID>
-    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:57</ID>
-    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:65</ID>
-    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.size.SizePreflight.kt:33</ID>
-    <ID>MaximumLineLength:com.emergetools.android.gradle.tasks.size.SizePreflight.kt:40</ID>
     <ID>MaximumLineLength:com.emergetools.android.gradle.util.dependencies.DependencyUtils.kt:87</ID>
     <ID>NestedBlockDepth:BaseUploadTask.kt$BaseUploadTask$protected fun upload( artifactMetadata: ArtifactMetadata, onSuccessfulUpload: (EmergeUploadResponse) -&gt; Unit, )</ID>
     <ID>NestedBlockDepth:LocalSnapshots.kt$LocalSnapshots$private fun extractDexFromApk( apk: File, outputDir: File, )</ID>
@@ -187,5 +161,7 @@
     <ID>UnusedPrivateMember:Preflight.kt$Result.Success$value: T</ID>
     <ID>UseCheckOrError:EmergeUploadRequest.kt$throw IllegalStateException("Could not resolve /upload for baseUrl: $baseUrl")</ID>
     <ID>UseCheckOrError:PreviewUtils.kt$PreviewUtils$throw IllegalStateException("Preview parameter must have a name")</ID>
+    <ID>Wrapping:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:59</ID>
+    <ID>Wrapping:com.emergetools.android.gradle.tasks.reaper.ReaperPreflight.kt:60</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.internal.ensureParentDirsCreated
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -27,26 +28,23 @@ java {
         srcDir(perfProjectTemplateResDir)
       }
     }
-    test {
-      java.srcDir("src/test/kotlin")
-    }
   }
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
   }
 }
 
 // This directory will contain one file per version of the Android Gradle Plugin that we wish to test against.
 val agpClasspathDir =
-  project.buildDir.resolve("agp-classpath").apply {
+  project.layout.buildDirectory.dir("agp-classpath").get().asFile.apply {
     mkdir()
   }
 
 val kgpClasspathDir =
-  project.buildDir.resolve("kgp-classpath").apply {
+  project.layout.buildDirectory.dir("kgp-classpath").get().asFile.apply {
     mkdir()
   }
 
@@ -105,7 +103,7 @@ val functionalTestTask =
   }
 
 tasks.check {
-  dependsOn(functionalTestTask)
+  dependsOn(functionalTestTask, tasks.validatePlugins)
 }
 
 val packagePerformanceProjectTemplateTask =
@@ -187,4 +185,9 @@ buildConfig {
 
 tasks.withType<Test> {
   useJUnitPlatform()
+}
+
+tasks.withType<ValidatePlugins>().configureEach {
+  failOnWarning = true
+  enableStricterValidation = true
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BasePreflightTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BasePreflightTask.kt
@@ -7,7 +7,9 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "This task must always run as a check and has no outputs.")
 abstract class BasePreflightTask : DefaultTask() {
   @get:Input
   @get:Optional

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BaseUploadTask.kt
@@ -32,6 +32,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.work.DisableCachingByDefault
 import java.io.BufferedOutputStream
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -69,6 +70,7 @@ data class CIDebugData(
   }
 }
 
+@DisableCachingByDefault(because = "Task has no outputs and should always run.")
 abstract class BaseUploadTask : DefaultTask() {
   @get:Input
   abstract val apiToken: Property<String>
@@ -216,9 +218,9 @@ abstract class BaseUploadTask : DefaultTask() {
             finalArtifactMetadata =
               artifactMetadata.copy(
                 ciDebugData =
-                  CIDebugData(
-                    gitHubEventDataPath = CIDebugData.GITHUB_EVENT_DATA_FILE_NAME,
-                  ),
+                CIDebugData(
+                  gitHubEventDataPath = CIDebugData.GITHUB_EVENT_DATA_FILE_NAME,
+                ),
               )
           }
         }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/internal/LogExtensionTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/internal/LogExtensionTask.kt
@@ -7,7 +7,9 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "This is a debugging task and should always run.")
 abstract class LogExtensionTask : DefaultTask() {
   @get:Input
   abstract val emergePluginExtension: Property<EmergePluginExtension>

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/GeneratePerfProject.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/GeneratePerfProject.kt
@@ -8,12 +8,16 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.gradle.internal.ensureParentDirsCreated
 import java.io.File
 import java.util.zip.ZipInputStream
 
+@DisableCachingByDefault(because = "Generating the performance project should not be cached")
 abstract class GeneratePerfProject : DefaultTask() {
   private var packageName: String? = null
 
@@ -34,9 +38,11 @@ abstract class GeneratePerfProject : DefaultTask() {
   abstract val performanceProjectPath: Property<String>
 
   @get:InputDirectory
+  @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val rootDir: DirectoryProperty
 
   @get:InputFile
+  @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val gradleSettingsFile: RegularFileProperty
 
   @TaskAction

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/LocalPerfTest.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/LocalPerfTest.kt
@@ -9,8 +9,10 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.process.ExecOperations
+import org.gradle.work.DisableCachingByDefault
 import javax.inject.Inject
 
+@DisableCachingByDefault(because = "This task runs on a device and should not be cached")
 abstract class LocalPerfTest : DefaultTask() {
   private val arguments = mutableMapOf<String, String>()
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/UploadPerfBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/UploadPerfBundle.kt
@@ -13,10 +13,12 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
+@DisableCachingByDefault(because = "Uploading performance bundles should not be cached.")
 abstract class UploadPerfBundle : BaseUploadTask() {
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NAME_ONLY)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/InitializeReaper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/InitializeReaper.kt
@@ -12,9 +12,11 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
+@DisableCachingByDefault(because = "Reaper initialization should not be cached.")
 abstract class InitializeReaper : BaseUploadTask() {
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NAME_ONLY)
@@ -35,7 +37,8 @@ abstract class InitializeReaper : BaseUploadTask() {
   fun execute() {
     if (publishableApiKey.orNull == null) {
       throw StopExecutionException(
-        "publishableApiKey must be set for Reaper to work properly. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk.",
+        "publishableApiKey must be set for Reaper to work properly. See " +
+          "https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk.",
       )
     }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/ReaperPreflight.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/ReaperPreflight.kt
@@ -7,7 +7,9 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Always runs as a check and has no outputs.")
 abstract class ReaperPreflight : DefaultTask() {
   @get:Input
   @get:Optional
@@ -34,7 +36,10 @@ abstract class ReaperPreflight : DefaultTask() {
     val hasEmergeApiToken = hasEmergeApiToken.getOrElse(false)
     preflight.add("Emerge API token set") {
       if (!hasEmergeApiToken) {
-        throw PreflightFailure("Emerge API token not set. See https://docs.emergetools.com/docs/uploading-basics#obtain-an-api-key")
+        throw PreflightFailure(
+          "Emerge API token not set. See " +
+            "https://docs.emergetools.com/docs/uploading-basics#obtain-an-api-key"
+        )
       }
     }
 
@@ -42,7 +47,8 @@ abstract class ReaperPreflight : DefaultTask() {
     preflight.add("enabled for variant: $variantName") {
       if (!reaperEnabled.getOrElse(false)) {
         throw PreflightFailure(
-          "Reaper not enabled for variant $variantName. Make sure \"${variantName}\" is included in `reaper.enabledVariants`",
+          "Reaper not enabled for variant $variantName. Make sure \"${variantName}\" is included " +
+            "in `reaper.enabledVariants`",
         )
       }
     }
@@ -50,11 +56,13 @@ abstract class ReaperPreflight : DefaultTask() {
     preflight.add("publishableApiKey set") {
       val key = reaperPublishableApiKey.orNull
       if (key == null) {
-        throw PreflightFailure("publishableApiKey not set. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
+        throw PreflightFailure("publishableApiKey not set. See " +
+          "https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk")
       }
       if (key == "") {
         throw PreflightFailure(
-          "publishableApiKey must not be empty. See https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk",
+          "publishableApiKey must not be empty. See " +
+            "https://docs.emergetools.com/docs/reaper-setup-android#configure-the-sdk",
         )
       }
     }
@@ -62,7 +70,8 @@ abstract class ReaperPreflight : DefaultTask() {
     preflight.add("Runtime SDK added") {
       if (!hasReaperImplementationDependency.getOrElse(false)) {
         throw PreflightFailure(
-          "Reaper runtime SDK missing as an implementation dependency. See https://docs.emergetools.com/docs/reaper-setup-android#install-the-sdk",
+          "Reaper runtime SDK missing as an implementation dependency. See " +
+            "https://docs.emergetools.com/docs/reaper-setup-android#install-the-sdk",
         )
       }
     }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/SizePreflight.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/SizePreflight.kt
@@ -7,7 +7,9 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Always runs as a check and has no outputs.")
 abstract class SizePreflight : BasePreflightTask() {
   @get:Input
   @get:Optional
@@ -30,14 +32,20 @@ abstract class SizePreflight : BasePreflightTask() {
     val hasEmergeApiToken = hasEmergeApiToken.getOrElse(false)
     preflight.add("Emerge API token set") {
       if (!hasEmergeApiToken) {
-        throw PreflightFailure("Emerge API token not set. See https://docs.emergetools.com/docs/uploading-basics#obtain-an-api-key")
+        throw PreflightFailure(
+          "Emerge API token not set. See " +
+            "https://docs.emergetools.com/docs/uploading-basics#obtain-an-api-key"
+        )
       }
     }
 
     val sizeEnabled = sizeEnabled.getOrElse(false)
     preflight.add("Size analysis enabled") {
       if (!sizeEnabled) {
-        throw PreflightFailure("Size analysis not enabled. Make sure `size.enabled` is set to true in the emerge configuration block.")
+        throw PreflightFailure(
+          "Size analysis not enabled. Make sure `size.enabled` is set to true" +
+            " in the emerge configuration block."
+        )
       }
     }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAAB.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAAB.kt
@@ -9,9 +9,11 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
+@DisableCachingByDefault(because = "Uploading AABs should not be cached.")
 abstract class UploadAAB : BaseUploadTask() {
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NAME_ONLY)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAPK.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAPK.kt
@@ -12,10 +12,12 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
+@DisableCachingByDefault(because = "Uploading APKs should not be cached.")
 abstract class UploadAPK : BaseUploadTask() {
   @get:InputDirectory
   @get:PathSensitive(PathSensitivity.NAME_ONLY)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/PackageSnapshotArtifacts.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/PackageSnapshotArtifacts.kt
@@ -8,6 +8,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
@@ -21,6 +22,7 @@ import org.gradle.api.tasks.TaskAction
  * proper metadata associated.
  * Intended to be dependent of LocalSnapshot task and UploadSnapshots task.
  */
+@CacheableTask
 abstract class PackageSnapshotArtifacts : DefaultTask() {
   @get:Input
   abstract val agpVersion: Property<String>
@@ -49,7 +51,6 @@ abstract class PackageSnapshotArtifacts : DefaultTask() {
     check(testApks.files.size < 2) { "Cannot run snapshots with more than one test APK" }
     val testApk = testApks.singleFile
 
-    outputDirectory.get().asFile.mkdirs()
     targetApk.copyTo(outputDirectory.get().asFile.resolve(targetApk.name), overwrite = true)
     testApk.copyTo(outputDirectory.get().asFile.resolve(testApk.name), overwrite = true)
 
@@ -61,12 +62,7 @@ abstract class PackageSnapshotArtifacts : DefaultTask() {
         testArtifactZipPath = testApk.name,
       )
     val metadataString = Json.encodeToString(metadata)
-    artifactMetadataPath.asFile.get().let {
-      if (!it.exists()) {
-        it.createNewFile()
-      }
-      it.writeText(metadataString)
-    }
+    artifactMetadataPath.asFile.get().writeText(metadataString)
   }
 
   companion object {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/SnapshotsPreflight.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/SnapshotsPreflight.kt
@@ -7,7 +7,9 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Always runs as a check and has no outputs.")
 abstract class SnapshotsPreflight : BasePreflightTask() {
   @get:Input
   @get:Optional

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
@@ -15,10 +15,12 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
+@DisableCachingByDefault(because = "Uploading snapshot bundles should not be cached.")
 abstract class UploadSnapshotBundle : BaseUploadTask() {
   @get:InputDirectory
   @get:PathSensitive(PathSensitivity.NAME_ONLY)
@@ -37,6 +39,7 @@ abstract class UploadSnapshotBundle : BaseUploadTask() {
   abstract val includePreviewParamPreviews: Property<Boolean>
 
   @get:InputFile
+  @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val artifactMetadataPath: RegularFileProperty
 
   override fun includeFilesInUpload(zos: ZipOutputStream) {
@@ -92,9 +95,9 @@ abstract class UploadSnapshotBundle : BaseUploadTask() {
 
     upload(
       artifactMetadata =
-        artifactMetadata.copy(
-          created = Clock.System.now(),
-        ),
+      artifactMetadata.copy(
+        created = Clock.System.now(),
+      ),
     ) { response ->
       logger.lifecycle(
         "Snapshot bundle upload successful! View snapshots at the following url:",


### PR DESCRIPTION
This PR:
* Enables stricter plugin validation to ensure all future added tasks are marked correctly.
* Adds DisableCachingByDefault for all tasks which should not be cached.
* Adds CacheableTask to all Gradle tasks with well defined inputs and outputs
* Removes some code to create output directories since Gradle does this for you
* Removes some lines of code that might delete task outputs (causing the task to rerun)

