### PR TITLE
Centralize android gradle plugin configuration with settings plugin

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 android {
     namespace = "com.emergetools.benchmark"
-    compileSdk = 34
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/distribution/distribution/build.gradle.kts
+++ b/distribution/distribution/build.gradle.kts
@@ -19,7 +19,6 @@ var metaInfDestDir = File(metaInfResDir, "META-INF/com/emergetools/distribution/
 
 android {
   namespace = "com.emergetools.distribution"
-  compileSdk = 34
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/distribution/sample/app/build.gradle.kts
+++ b/distribution/sample/app/build.gradle.kts
@@ -20,7 +20,6 @@ emerge {
 
 android {
   namespace = "com.emergetools.distribution.sample"
-  compileSdk = 34
 
   defaultConfig {
     applicationId = "com.emergetools.distribution.sample"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,6 @@ compose-bom = "2024.08.00"
 detekt = "1.22.0"
 kotlin = "2.1.0"
 kotlin-coroutines = "1.10.1"
-kotlinpoet = "1.14.2"
-kotlin-compile-testing = "1.5.0"
 okhttp = "4.12.0"
 junit-jupiter = "5.11.4"
 benchmark = "1.3.3"
@@ -40,7 +38,6 @@ emerge-distribution = "0.0.4"
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-android-lint = { id = "com.android.lint", version.ref = "agp" }
 android-test = { id = "com.android.test", version.ref = "agp" }
 benchmark = { id = "androidx.benchmark", version.ref = "benchmark" }
 buildconfig = "com.github.gmazzo.buildconfig:5.5.1"
@@ -51,7 +48,6 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 gradle-publish = { id = "com.gradle.plugin-publish", version = "0.21.0" }
 grgit = { id = "org.ajoberstar.grgit", version = "5.3.0" }
-plugin-best-practices = { id = "com.autonomousapps.plugin-best-practices-plugin", version = "0.10" }
 
 [libraries]
 android-gradle-plugin = "com.android.tools.build:gradle:7.3.1"

--- a/performance/performance/build.gradle.kts
+++ b/performance/performance/build.gradle.kts
@@ -19,8 +19,6 @@ var metaInfDestDir = File(metaInfResDir, "META-INF/com/emergetools/test/")
 android {
   namespace = "com.emergetools.test"
 
-  compileSdk = 34
-
   defaultConfig {
     minSdk = 23
 

--- a/performance/sample/app/build.gradle.kts
+++ b/performance/sample/app/build.gradle.kts
@@ -14,7 +14,6 @@ emerge {
 
 android {
   namespace = "com.emergetools.performance.sample"
-  compileSdk = 34
 
   defaultConfig {
     applicationId = "com.emergetools.performance.sample"

--- a/reaper/reaper/build.gradle.kts
+++ b/reaper/reaper/build.gradle.kts
@@ -19,7 +19,6 @@ var metaInfDestDir = File(metaInfResDir, "META-INF/com/emergetools/reaper/")
 
 android {
   namespace = "com.emergetools.reaper"
-  compileSdk = 34
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/reaper/sample/app/build.gradle.kts
+++ b/reaper/sample/app/build.gradle.kts
@@ -25,7 +25,6 @@ emerge {
 
 android {
   namespace = "com.emergetools.reaper.sample"
-  compileSdk = 34
 
   defaultConfig {
     applicationId = "com.emergetools.reaper.sample"

--- a/reaper/sample/manuallyInitializedApp/build.gradle.kts
+++ b/reaper/sample/manuallyInitializedApp/build.gradle.kts
@@ -25,7 +25,6 @@ emerge {
 
 android {
   namespace = "com.emergetools.reaper.sample.manuallyInitialized"
-  compileSdk = 34
 
   defaultConfig {
     applicationId = "com.emergetools.reaper.sample.manuallyInitialized"

--- a/reaper/sample/stress/build.gradle.kts
+++ b/reaper/sample/stress/build.gradle.kts
@@ -25,7 +25,6 @@ emerge {
 
 android {
   namespace = "com.emergetools.reaper.sample.stress"
-  compileSdk = 34
 
   defaultConfig {
     applicationId = "com.emergetools.reaper.sample.stress"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ pluginManagement {
 
 plugins {
   id("com.gradle.develocity") version("3.19")
+  id("com.android.settings") version "8.8.0" // Keep in sync with agp in libs.versions.toml
 }
 
 develocity {
@@ -17,6 +18,10 @@ develocity {
     termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
     termsOfUseAgree.set("yes")
   }
+}
+
+android {
+  compileSdk = 35
 }
 
 dependencyResolutionManagement {

--- a/snapshots/sample/app/build.gradle.kts
+++ b/snapshots/sample/app/build.gradle.kts
@@ -24,7 +24,6 @@ emerge {
 
 android {
   namespace = "com.emergetools.snapshots.sample"
-  compileSdk = 34
 
   defaultConfig {
     applicationId = "com.emergetools.snapshots.sample"

--- a/snapshots/sample/ui-module/build.gradle.kts
+++ b/snapshots/sample/ui-module/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 android {
   namespace = "com.emergetools.snapshots.sample.ui"
-  compileSdk = 34
 
   defaultConfig {
     minSdk = 23

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -19,7 +19,6 @@ var metaInfDestDir = File(metaInfResDir, "META-INF/com/emergetools/snapshots/")
 
 android {
   namespace = "com.emergetools.snapshots"
-  compileSdk = 34
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
This avoids repeatings the compileSdk version across the repo.
This settings plugin pattern might be a good pattern for our own plugin to be able to share configuration across projects.
