### PR TITLE
Fix resolving dependencies at configuration time

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/Register.kt
@@ -39,14 +39,14 @@ private fun registerReaperPreflightTask(
   variant: Variant,
 ) {
   val preflightTaskName = "${EMERGE_TASK_PREFIX}ReaperPreflight${variant.name.capitalize()}"
-  appProject.tasks.register(preflightTaskName, ReaperPreflight::class.java) {
-    it.group = EMERGE_REAPER_TASK_GROUP
-    it.description = "Validate Reaper is properly set up for variant ${variant.name}"
-    it.variantName.set(variant.name)
-    it.hasEmergeApiToken.set(!extension.apiToken.orNull.isNullOrBlank())
-    it.reaperEnabled.set(extension.reaperOptions.enabledVariants.getOrElse(emptyList()).contains(variant.name))
-    it.reaperPublishableApiKey.set(extension.reaperOptions.publishableApiKey)
-    it.hasReaperImplementationDependency.set(
+  appProject.tasks.register(preflightTaskName, ReaperPreflight::class.java) { task ->
+    task.group = EMERGE_REAPER_TASK_GROUP
+    task.description = "Validate Reaper is properly set up for variant ${variant.name}"
+    task.variantName.set(variant.name)
+    task.hasEmergeApiToken.set(!extension.apiToken.orNull.isNullOrBlank())
+    task.reaperEnabled.set(extension.reaperOptions.enabledVariants.getOrElse(emptyList()).contains(variant.name))
+    task.reaperPublishableApiKey.set(extension.reaperOptions.publishableApiKey)
+    task.hasReaperImplementationDependency.set(
       hasDependency(appProject, variant, REAPER_DEP_GROUP, REAPER_DEP_NAME),
     )
   }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
@@ -80,17 +80,23 @@ private fun registerSnapshotPreflightTask(
   variant: ApplicationVariant,
 ) {
   val preflightTaskName = "${EMERGE_TASK_PREFIX}SnapshotsPreflight${variant.name.capitalize()}"
-  appProject.tasks.register(preflightTaskName, SnapshotsPreflight::class.java) {
-    it.group = EMERGE_SNAPSHOTS_TASK_GROUP
-    it.description = "Validate Snapshots is properly set up for variant ${variant.name}"
-    it.variantName.set(variant.name)
-    it.appProjectPath.set(appProject.path)
-    it.hasEmergeApiToken.set(!extension.apiToken.orNull.isNullOrBlank())
-    it.snapshotsEnabled.set(extension.snapshotOptions.enabled.getOrElse(true))
-    it.hasSnapshotsAndroidTestImplementationDependency.set(
-      hasDependency(appProject, variant, SNAPSHOTS_DEP_GROUP, SNAPSHOTS_DEP_NAME, variant.androidTest),
+  appProject.tasks.register(preflightTaskName, SnapshotsPreflight::class.java) { task ->
+    task.group = EMERGE_SNAPSHOTS_TASK_GROUP
+    task.description = "Validate Snapshots is properly set up for variant ${variant.name}"
+    task.variantName.set(variant.name)
+    task.appProjectPath.set(appProject.path)
+    task.hasEmergeApiToken.set(!extension.apiToken.orNull.isNullOrBlank())
+    task.snapshotsEnabled.set(extension.snapshotOptions.enabled.getOrElse(true))
+    task.hasSnapshotsAndroidTestImplementationDependency.set(
+      hasDependency(
+        appProject,
+        variant,
+        SNAPSHOTS_DEP_GROUP,
+        SNAPSHOTS_DEP_NAME,
+        variant.androidTest
+      ),
     )
-    it.setPreflightTaskInputs(extension)
+    task.setPreflightTaskInputs(extension)
   }
 }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/VariantUtils.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/VariantUtils.kt
@@ -3,6 +3,7 @@ package com.emergetools.android.gradle.util
 import com.android.build.api.variant.AndroidTest
 import com.android.build.api.variant.Variant
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 
 fun hasDependency(
   project: Project,
@@ -10,33 +11,38 @@ fun hasDependency(
   dependencyGroup: String,
   dependencyName: String,
   androidTest: AndroidTest? = null,
-): Boolean {
-  fun MutableList<String>.addIfNotBlank(
-    value: String?,
-    formatter: (String) -> String,
-  ) {
-    value?.takeIf { it.isNotBlank() }?.let { add(formatter(it)) }
-  }
-
-  val configsToCheck =
-    buildList {
-      add("implementation")
-      addIfNotBlank(variant.flavorName) { "${it}Implementation" }
-      addIfNotBlank(variant.buildType) { "${it}Implementation" }
-      addIfNotBlank(variant.name) { "${it}Implementation" }
-      androidTest?.let { test ->
-        add("androidTestImplementation")
-        addIfNotBlank(test.flavorName) { "${it}Implementation" }
-        addIfNotBlank(test.buildType) { "${it}Implementation" }
-        addIfNotBlank(test.name) { "${it}Implementation" }
-      }
+): Provider<Boolean> {
+  // Set these values so that we don't call project object at execution time
+  val logger = project.logger
+  val configurations = project.configurations
+  return project.provider {
+    fun MutableList<String>.addIfNotBlank(
+      value: String?,
+      formatter: (String) -> String,
+    ) {
+      value?.takeIf { it.isNotBlank() }?.let { add(formatter(it)) }
     }
 
-  project.logger.lifecycle("Checking for dependency $dependencyGroup:$dependencyName in configurations $configsToCheck")
+    val configsToCheck =
+      buildList {
+        add("implementation")
+        addIfNotBlank(variant.flavorName) { "${it}Implementation" }
+        addIfNotBlank(variant.buildType) { "${it}Implementation" }
+        addIfNotBlank(variant.name) { "${it}Implementation" }
+        androidTest?.let { test ->
+          add("androidTestImplementation")
+          addIfNotBlank(test.flavorName) { "${it}Implementation" }
+          addIfNotBlank(test.buildType) { "${it}Implementation" }
+          addIfNotBlank(test.name) { "${it}Implementation" }
+        }
+      }
 
-  return configsToCheck.any { configName ->
-    project.configurations.findByName(configName)?.dependencies?.any { dep ->
-      dep.group == dependencyGroup && dep.name == dependencyName
-    } ?: false
+    logger.lifecycle("Checking for dependency $dependencyGroup:$dependencyName in configurations $configsToCheck")
+
+    configsToCheck.any { configName ->
+      configurations.findByName(configName)?.dependencies?.any { dep ->
+        dep.group == dependencyGroup && dep.name == dependencyName
+      } ?: false
+    }
   }
 }


### PR DESCRIPTION
This code would previously resolve dependencies at configuration time in order to check for our dependencies.
This moves that code to instead return a provider which is only evaluated when the value is obtained.


In this build scan before this change you can see the line is printed before the task executes:
https://scans.gradle.com/s/lfejlsyx2hyqk/console-log?page=1#L12

In this build scan after this change you can see the line is printed during the task execution:
https://scans.gradle.com/s/6zvdxhqjhnedk/console-log?page=1#L13

This fixes an issue reported by a customer where these lines would be printed and therefore the configurations would be resolved even though they did not use reaper.