### PR TITLE
Fix bug where artifactMetadata was missing some fields due to being overwritten with original copy

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BaseUploadTask.kt
@@ -168,7 +168,7 @@ abstract class BaseUploadTask : DefaultTask() {
     ZipOutputStream(BufferedOutputStream(zipFile.outputStream())).use { zos ->
       includeFilesInUpload(zos)
 
-      var finalArtifactMetadata = artifactMetadata
+      var finalArtifactMetadata = artifactMetadata.copy()
 
       if (includeDependencyInformation.get()) {
         checkNotNull(appModuleName.orNull) {
@@ -199,7 +199,7 @@ abstract class BaseUploadTask : DefaultTask() {
             zos.closeEntry()
           }
           finalArtifactMetadata =
-            artifactMetadata.copy(
+            finalArtifactMetadata.copy(
               dependencyMetadataZipPath = dependenciesFile.name,
             )
         }
@@ -216,7 +216,7 @@ abstract class BaseUploadTask : DefaultTask() {
               zos.closeEntry()
             }
             finalArtifactMetadata =
-              artifactMetadata.copy(
+              finalArtifactMetadata.copy(
                 ciDebugData =
                 CIDebugData(
                   gitHubEventDataPath = CIDebugData.GITHUB_EVENT_DATA_FILE_NAME,


### PR DESCRIPTION
Hackernews builds are missing dependency info. After a deeper dive, I noticed the `metadata.dependencyMetadataZipPath` was missing. This is due to us clobbering the value after setting when we set the metadata with the Github event data. This ensures we re-write the metadata preserving data set on it.