### PR TITLE
Bump publish plugin to 1.3.0 (again)

### DIFF
--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -108,9 +108,6 @@ val packagePerformanceProjectTemplateTask =
   }
 
 tasks["processResources"].dependsOn(packagePerformanceProjectTemplateTask)
-afterEvaluate {
-  tasks["publishPluginJar"].dependsOn(packagePerformanceProjectTemplateTask)
-}
 
 detekt {
   buildUponDefaultConfig = true
@@ -149,19 +146,16 @@ dependencies {
   detektPlugins(libs.detekt.formatting)
 }
 
-pluginBundle {
+gradlePlugin {
   website = "https://docs.emergetools.com/docs/gradle-plugin"
   vcsUrl = "https://docs.emergetools.com/docs/gradle-plugin"
-  tags = listOf("emerge", "emergetools", "android", "upload")
-}
-
-gradlePlugin {
   plugins {
-    create("com.emergetools.android") {
+    register("com.emergetools.android") {
       id = "com.emergetools.android"
       displayName = "Emerge Gradle Plugin"
       description = "Gradle plugin for building and uploading an Android AAB/APK to Emerge."
       implementationClass = "com.emergetools.android.gradle.EmergePlugin"
+      tags = listOf("emerge", "emergetools", "android", "upload")
     }
   }
   testSourceSets(functionalTest)

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -20,13 +20,8 @@ val perfProjectTemplateResDir = project.layout.buildDirectory.dir("generated/per
 java {
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
-
-  sourceSets {
-    main {
-      resources {
-        srcDir(perfProjectTemplateResDir)
-      }
-    }
+  sourceSets.main {
+    resources.srcDir(perfProjectTemplateResDir)
   }
 }
 
@@ -100,14 +95,19 @@ tasks.check {
   dependsOn(functionalTestTask, tasks.validatePlugins)
 }
 
+
 val packagePerformanceProjectTemplateTask =
   tasks.register<Zip>("packagePerformanceProjectTemplate") {
     archiveFileName.set("performance-project-template.zip")
-    from(projectDir.resolve("performance-project-template"))
-    destinationDirectory.set(perfProjectTemplateResDir.get().asFile.resolve("emergetools"))
+    from(project.layout.projectDirectory.dir("performance-project-template"))
+    destinationDirectory.set(perfProjectTemplateResDir.map { it.dir("emergetools") })
   }
 
-tasks["processResources"].dependsOn(packagePerformanceProjectTemplateTask)
+afterEvaluate {
+  tasks.named("sourcesJar"){
+    dependsOn(packagePerformanceProjectTemplateTask)
+  }
+}
 
 detekt {
   buildUponDefaultConfig = true

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -103,6 +103,9 @@ val packagePerformanceProjectTemplateTask =
     destinationDirectory.set(perfProjectTemplateResDir.map { it.dir("emergetools") })
   }
 
+tasks.processResources {
+  dependsOn(packagePerformanceProjectTemplateTask)
+}
 afterEvaluate {
   tasks.named("sourcesJar"){
     dependsOn(packagePerformanceProjectTemplateTask)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-gradle-publish = { id = "com.gradle.plugin-publish", version = "0.21.0" }
+gradle-publish = { id = "com.gradle.plugin-publish", version = "1.3.0" }
 grgit = { id = "org.ajoberstar.grgit", version = "5.3.0" }
 
 [libraries]


### PR DESCRIPTION
Add back Gradle Plugin Publish Plugin update

This fixes the task dependencies.

Here’s a semi-successful build scan that failed due to lack of credentials and not task dependency issues https://scans.gradle.com/s/7xif3z63ahgyu
