### PR TITLE
Add hackernews functional integration test

### DIFF
--- a/.github/workflows/integration-hackernews.yml
+++ b/.github/workflows/integration-hackernews.yml
@@ -1,0 +1,39 @@
+name: Hackernews Gradle Plugin Integration
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - gradle/**
+      - gradle-plugin/**
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: emerge-android
+      - uses: actions/checkout@v4
+        with:
+          repository: EmergeTools/hackernews
+          path: hackernews
+      - name: Set up JDKs
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: 17
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build hackernews with Emerge Android as included build
+        run: cd hackernews/android && ./gradlew :app:emergeUploadSnapshotBundleDebug --include-build ../../emerge-android/gradle-plugin
+      - name: Archive test reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Functional test reports
+          path: '**/build/reports/tests/functionalTest'
+

--- a/.github/workflows/integration-hackernews.yml
+++ b/.github/workflows/integration-hackernews.yml
@@ -30,10 +30,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Build hackernews with Emerge Android as included build
         run: cd hackernews/android && ./gradlew :app:emergeUploadSnapshotBundleDebug --include-build ../../emerge-android/gradle-plugin
-      - name: Archive test reports
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: Functional test reports
-          path: '**/build/reports/tests/functionalTest'
+        env:
+          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
 

--- a/.github/workflows/integration-hackernews.yml
+++ b/.github/workflows/integration-hackernews.yml
@@ -32,6 +32,7 @@ jobs:
         run: cd hackernews/android && ./gradlew :app:emergeUploadSnapshotBundleDebug --include-build ../../emerge-android/gradle-plugin
         env:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
+          INTEGRATION_TEST_REPO_NAME: emerge-android
           PR_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
 

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -132,7 +132,7 @@ dependencies {
   testRuntimeOnly(libs.junit.jupiter.engine)
   testRuntimeOnly(libs.junit.platform.launcher)
 
-  "functionalTestImplementation"(projects.emergeGradlePlugin.plugin)
+  "functionalTestImplementation"(project(":plugin"))
   "functionalTestImplementation"(libs.junit.jupiter.api)
   "functionalTestImplementation"(libs.okhttp.mockwebserver)
   "functionalTestImplementation"(libs.kotlinx.serialization)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,6 @@ dependencyResolutionManagement {
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 
 include(
   ":performance",


### PR DESCRIPTION
This adds this repo as a composite build to the hacker news app and builds it.
You can see in this build scan that the composite build is being applied to the `:app` module.

https://scans.gradle.com/s/fq5pdezizjitk/build-dependencies?toggled=W1sxXSxbMSwwXSxbMSwwLFs0ODVdXV0