### PR TITLE
Wire up task to sourcesets.

### DIFF
--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -15,14 +15,10 @@ plugins {
 group = "com.emergetools"
 version = libs.versions.emerge.gradle.plugin.get()
 
-val perfProjectTemplateResDir = project.layout.buildDirectory.dir("generated/performance-project-template/")
 
 java {
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
-  sourceSets.main {
-    resources.srcDir(perfProjectTemplateResDir)
-  }
 }
 
 tasks.withType<KotlinCompile>().configureEach {
@@ -95,6 +91,7 @@ tasks.check {
   dependsOn(functionalTestTask, tasks.validatePlugins)
 }
 
+val perfProjectTemplateResDir = project.layout.buildDirectory.dir("generated/performance-project-template/")
 
 val packagePerformanceProjectTemplateTask =
   tasks.register<Zip>("packagePerformanceProjectTemplate") {
@@ -103,13 +100,8 @@ val packagePerformanceProjectTemplateTask =
     destinationDirectory.set(perfProjectTemplateResDir.map { it.dir("emergetools") })
   }
 
-tasks.processResources {
-  dependsOn(packagePerformanceProjectTemplateTask)
-}
-afterEvaluate {
-  tasks.named("sourcesJar"){
-    dependsOn(packagePerformanceProjectTemplateTask)
-  }
+java.sourceSets.main {
+  resources.srcDir(packagePerformanceProjectTemplateTask.map { it.destinationDirectory })
 }
 
 detekt {

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -101,7 +101,7 @@ val packagePerformanceProjectTemplateTask =
   }
 
 java.sourceSets.main {
-  resources.srcDir(packagePerformanceProjectTemplateTask.map { it.destinationDirectory })
+  resources.srcDir(packagePerformanceProjectTemplateTask.map { it.destinationDirectory.get().asFile.parentFile })
 }
 
 detekt {


### PR DESCRIPTION
This wires the task up to the sourcesets which automatically wires up
the task dependencies saving a lot of boilerplate
