### PR TITLE
Correctly parse git/github/gitlab urls in all environments

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/GitHub.kt
@@ -16,15 +16,13 @@ internal class GitHub(private val execOperations: ExecOperations) {
       ignoreUnknownKeys = true
     }
 
-  private fun repoId(): String? {
-    val remoteUrl = git.remoteUrl() ?: return null
-    val result = Regex("[/:]([^/]+/[^/.]+)\\.git$").find(remoteUrl) ?: return null
-    return result.groupValues[1]
+  private fun repoId(): List<String>? {
+    return git.remoteUrl()?.toWebRepoUri()?.encodedPathSegments
   }
 
-  fun repoOwner() = repoId()?.split('/')?.get(0)
+  fun repoOwner() = repoId()?.firstOrNull()
 
-  fun repoName() = repoId()?.split('/')?.get(1)
+  fun repoName() = repoId()?.get(1)
 
   private fun getEvent(): String? {
     return System.getenv("GITHUB_EVENT_NAME")

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Repositories.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Repositories.kt
@@ -1,0 +1,35 @@
+package com.emergetools.android.gradle.util
+
+import okhttp3.HttpUrl
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+/**
+ * This class is inspired by the CCUD Gradle Plugin.
+ * [Utils.java]
+ * (https://github.com/gradle/common-custom-user-data-gradle-plugin/blob/main/src/main/java/com/gradle/Utils.java#L228)
+ */
+private
+val gitRepoUriPattern: Pattern =
+  Pattern.compile(
+    "^(?:(?:https://|git://)(?:.+:.+@)?|(?:ssh)?.*?@)(.*?(?:github|gitlab).*?)(?:/|:[0-9]*?/|:)(.*?)(?:\\.git)?$"
+  )
+
+/**
+ * Construct a repo [HttpUrl] from a git URL in the format of
+ * `git://github.com/acme-inc/my-project.git`. If the URL cannot be parsed, null is
+ * returned.
+ *
+ * The scheme can be any of `git://`, `https://`, or `ssh`.
+ */
+fun String.toWebRepoUri(): HttpUrl? {
+  val matcher: Matcher = gitRepoUriPattern.matcher(this)
+  if (matcher.matches()) {
+    val scheme = "https"
+    val host: String = matcher.group(1)
+    val path = if (matcher.group(2).startsWith("/")) matcher.group(2) else "/" + matcher.group(2)
+    return HttpUrl.Builder().scheme(scheme).host(host).encodedPath(path).build()
+  } else {
+    return null
+  }
+}

--- a/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/util/RepositoriesTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/util/RepositoriesTest.kt
@@ -1,0 +1,54 @@
+package com.emergetools.android.gradle.util
+
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.Locale
+
+class RepositoriesTest {
+
+  companion object {
+    private val hostNames = listOf("gitlab", "github")
+    private val rawUrls = listOf(
+      "https://%s.com/acme-inc/my-project",
+      "https://%s.com:443/acme-inc/my-project",
+      "https://user:secret@%s.com/acme-inc/my-project",
+      "ssh://git@%s.com/acme-inc/my-project.git",
+      "ssh://git@%s.com:22/acme-inc/my-project.git",
+      "git://%s.com/acme-inc/my-project.git",
+      "git@%s.com/acme-inc/my-project.git"
+    )
+
+    private val rawEnterpriseUrls = listOf(
+      "https://%s.acme.com/acme-inc/my-project",
+      "git@%s.acme.com/acme-inc/my-project.git"
+    )
+
+    @JvmStatic
+    fun urls() = hostNames.flatMap { host -> rawUrls.map { url -> Arguments.of(host, url) } }
+
+    @JvmStatic
+    fun enterpriseUrls() =
+      hostNames.flatMap { host -> rawEnterpriseUrls.map { url -> Arguments.of(host, url) } }
+  }
+
+  @ParameterizedTest
+  @MethodSource("urls")
+  fun testToWebRepoUri(host: String, url: String) {
+    val expectedUrl =
+      String.format(Locale.US, "https://%s.com/acme-inc/my-project", host).toHttpUrl()
+    val parsedUrl = url.format(host).toWebRepoUri()
+    assertEquals(expectedUrl, parsedUrl)
+  }
+
+  @ParameterizedTest
+  @MethodSource("enterpriseUrls")
+  fun testWebRepoUri_enterpriseUri(host: String, url: String) {
+    val expectedUrl =
+      String.format(Locale.US, "https://%s.acme.com/acme-inc/my-project", host).toHttpUrl()
+    val parsedUrl = url.format(host).toWebRepoUri()
+    assertEquals(expectedUrl, parsedUrl)
+  }
+}


### PR DESCRIPTION
This fixes bugs where the reponame would not be set on CI because the git url was not being parsed correctly
