### PR TITLE
Update AndroidXActivity and MediaPickerDemo

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ androidx-test-rules = "1.6.1"
 androidx-test-runner = "1.6.2"
 androidx-test-ext = "1.2.1"
 agp = "8.8.0"
-androidxactivity = "1.7.1"
+androidxactivity = "1.10.0"
 # 2024.08.00 is 1.6.8
 # 1.7.0+ updates ComposableLambda to leverage a new rememberComposableLambda function that
 # is implicitly added by the compose compiler. This is a breaking change for consumers before 1.7.0,

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/MediaPickerDemo.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/MediaPickerDemo.kt
@@ -2,6 +2,7 @@ package com.emergetools.snapshots.sample.ui
 
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -37,7 +38,9 @@ fun MediaPickerDemo() {
       .padding(16.dp),
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
-    Button(onClick = { pickMediaLauncher.launch(null) }) {
+    Button(onClick = {
+      pickMediaLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+    }) {
       Text("Pick Image/Video")
     }
 


### PR DESCRIPTION
The MediaPickerDemo screen seems unused so I'm not sure how to test it
but this fixes the compiler error.
