### PR TITLE
Instrument only project classes

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
@@ -37,7 +37,7 @@ fun registerSnapshotTasks(
   variant.instrumentation.let { instrumentation ->
     instrumentation.transformClassesWith(
       SnapshotsPreviewRuntimeRetentionTransformFactory::class.java,
-      InstrumentationScope.ALL,
+      InstrumentationScope.PROJECT, // We only want snapshot previews from the project classes, not dependencies
     ) { params ->
       // Force invalidate/reinstrument classes if debug option is set
       if (extension.debugOptions.forceInstrumentation.getOrElse(false)) {


### PR DESCRIPTION
This is so that we don't get previews from library classes like RevenueCat as well.
