### PR TITLE
Add support for Wear devices

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,6 +87,7 @@ compose-ui-test-junit = { group = "androidx.compose.ui", name = "ui-test-junit4"
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+compose-wear-ui-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version = "1.0.0" }
 
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 

--- a/snapshots/sample/app/build.gradle.kts
+++ b/snapshots/sample/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
   implementation(libs.compose.ui.tooling)
   implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.material)
+  implementation(libs.compose.wear.ui.tooling.preview)
 
   // The only required snapshots dependency
   androidTestImplementation(projects.snapshots.snapshots)

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/DevicePreviews.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/DevicePreviews.kt
@@ -2,6 +2,7 @@ package com.emergetools.snapshots.sample.ui
 
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.wear.tooling.preview.devices.WearDevices
 
 @Preview(showSystemUi = true, device = Devices.NEXUS_7)
 @Preview(showSystemUi = true, device = Devices.NEXUS_7_2013)
@@ -69,6 +70,8 @@ import androidx.compose.ui.tooling.preview.Preview
 @Preview(showSystemUi = false, device = Devices.FOLDABLE)
 @Preview(showSystemUi = false, device = Devices.TABLET)
 @Preview(showSystemUi = false, device = Devices.DESKTOP)
+@Preview(name = "Wear (small)", device = WearDevices.SMALL_ROUND)
+@Preview(name = "Wear (large)", device = WearDevices.LARGE_ROUND)
 @Preview(
   name = "landscape",
   device = "spec:width=411dp,height=891dp, orientation=landscape, dpi=480"

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.wear.tooling.preview.devices.WearDevices
 
 @Composable
 fun PortraitLandscapeView() {
@@ -94,8 +93,6 @@ fun PortraitLandscapeView() {
 @Preview(device = Devices.PIXEL_5)
 @Preview(name = "Phone (Landscape)", device = "spec:width=430dp,height=860dp,orientation=landscape")
 @Preview(name = "Phone (Portrait)", device = "spec:width=430dp,height=860dp")
-@Preview(name = "Wear (small)", device = WearDevices.SMALL_ROUND)
-@Preview(name = "Wear (large)", device = WearDevices.LARGE_ROUND)
 @Composable
 fun PortraitLandscapeViewPreview() {
   Surface {

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.wear.tooling.preview.devices.WearDevices
 
 @Composable
 fun PortraitLandscapeView() {
@@ -93,6 +94,8 @@ fun PortraitLandscapeView() {
 @Preview(device = Devices.PIXEL_5)
 @Preview(name = "Phone (Landscape)", device = "spec:width=430dp,height=860dp,orientation=landscape")
 @Preview(name = "Phone (Portrait)", device = "spec:width=430dp,height=860dp")
+@Preview(name = "Wear (small)", device = WearDevices.SMALL_ROUND)
+@Preview(name = "Wear (large)", device = WearDevices.LARGE_ROUND)
 @Composable
 fun PortraitLandscapeViewPreview() {
   Surface {

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -104,7 +104,7 @@ private fun snapshot(
     }
 
     composeView.setContent {
-      SnapshotVariantProvider(previewConfig, deviceSpec?.scalingFactor) {
+      SnapshotVariantProvider(previewConfig, deviceSpec) {
         ComposableInvoker.invokeComposable(
           className = previewConfig.fullyQualifiedClassName,
           methodName = previewConfig.originalFqn.substringAfterLast("."),

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -34,7 +34,6 @@ data class DeviceSpec(
   private fun Float.roundToTen(): Int {
     return (this / 10).roundToInt() * 10
   }
-
 }
 
 // https://m3.material.io/blog/device-metrics#putting-it-all-together
@@ -214,12 +213,14 @@ val KNOWN_DEVICE_SPECS = mapOf(
     heightDp = 928,
     dpi = 276,
   ),
+  // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:wear/wear-tooling-preview/src/main/java/androidx/wear/tooling/preview/devices/WearDevice.kt;l=26?q=WearDevice.kt&ss=androidx/platform/frameworks/support
   "wearos_large_round" to DeviceSpec(
     widthDp = 227,
     heightDp = 227,
     dpi = 320,
     shape = CircleShape,
   ),
+  // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:wear/wear-tooling-preview/src/main/java/androidx/wear/tooling/preview/devices/WearDevice.kt;l=28?q=WearDevice.kt&ss=androidx/platform/frameworks/support
   "wearos_small_round" to DeviceSpec(
     widthDp = 192,
     heightDp = 192,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/DeviceUtils.kt
@@ -3,6 +3,9 @@
 package com.emergetools.snapshots.compose
 
 import android.util.DisplayMetrics
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import kotlin.math.roundToInt
 
@@ -10,6 +13,7 @@ data class DeviceSpec(
   val widthDp: Int?,
   val heightDp: Int?,
   val dpi: Int,
+  val shape: Shape = RectangleShape,
 ) {
   // Calculate the density factor the same way Android does
   private val density: Float = dpi.toFloat() / DisplayMetrics.DENSITY_DEFAULT
@@ -30,6 +34,7 @@ data class DeviceSpec(
   private fun Float.roundToTen(): Int {
     return (this / 10).roundToInt() * 10
   }
+
 }
 
 // https://m3.material.io/blog/device-metrics#putting-it-all-together
@@ -208,6 +213,18 @@ val KNOWN_DEVICE_SPECS = mapOf(
     widthDp = 1484,
     heightDp = 928,
     dpi = 276,
+  ),
+  "wearos_large_round" to DeviceSpec(
+    widthDp = 227,
+    heightDp = 227,
+    dpi = 320,
+    shape = CircleShape,
+  ),
+  "wearos_small_round" to DeviceSpec(
+    widthDp = 192,
+    heightDp = 192,
+    dpi = 320,
+    shape = CircleShape,
   ),
 )
 

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -22,12 +24,12 @@ import java.util.Locale
 @Composable
 fun SnapshotVariantProvider(
   config: ComposePreviewSnapshotConfig,
-  scalingFactor: Float?,
+  deviceSpec: DeviceSpec?,
   content: @Composable () -> Unit,
 ) {
   val localDensity = Density(
     fontScale = config.fontScale ?: LocalDensity.current.fontScale,
-    density = scalingFactor ?: LocalDensity.current.density,
+    density = deviceSpec?.scalingFactor ?: LocalDensity.current.density,
   )
 
   val locale = config.locale?.let(::localeForLanguageCode) ?: Locale.getDefault()
@@ -67,7 +69,7 @@ fun SnapshotVariantProvider(
           val color = config.backgroundColor?.let { Color(it) } ?: Color.White
           Modifier.background(color)
         } ?: Modifier
-      )
+      ).clip(deviceSpec?.shape ?: RectangleShape)
 
     Box(modifier = modifier) {
       content()


### PR DESCRIPTION
A client requested support for Wear devices. This adds support for the two primary wear devices (`wearos_large_round`, `wearos_small_round`), I intentionally skipped support for rect & square as the [comment suggests not using](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:wear/wear-tooling-preview/src/main/java/androidx/wear/tooling/preview/devices/WearDevice.kt;l=33?q=WearDevice.kt&ss=androidx/platform/frameworks/support).