### PR TITLE
Disable parallel for release workflows

### DIFF
--- a/.github/workflows/distribution-release.yml
+++ b/.github/workflows/distribution-release.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Sanity check distribution test
-        run: ./gradlew :distribution:distribution:test :distribution:distribution:publishReleasePublicationToSonatypeStagingRepository
+        run: ./gradlew :distribution:distribution:test :distribution:distribution:publishReleasePublicationToSonatypeStagingRepository -Dorg.gradle.parallel=false

--- a/.github/workflows/performance-release.yml
+++ b/.github/workflows/performance-release.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Sanity check performance test
-        run: ./gradlew :performance:performance:test :performance:performance:publishReleasePublicationToSonatypeStagingRepository
+        run: ./gradlew :performance:performance:test :performance:performance:publishReleasePublicationToSonatypeStagingRepository -Dorg.gradle.parallel=false

--- a/.github/workflows/reaper-release.yml
+++ b/.github/workflows/reaper-release.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Sanity check reaper test
-        run: ./gradlew :reaper:reaper:test :reaper:reaper:publishReleasePublicationToSonatypeStagingRepository
+        run: ./gradlew :reaper:reaper:test :reaper:reaper:publishReleasePublicationToSonatypeStagingRepository -Dorg.gradle.parallel=false

--- a/.github/workflows/snapshots-release.yml
+++ b/.github/workflows/snapshots-release.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Sanity check snapshots test
         run: ./gradlew :snapshots:snapshots:test :snapshots:snapshots-shared:test
       - name: Deploy snapshots-shared, shapsnhots-annotations, snapshots
-        run: ./gradlew :snapshots:snapshots-shared:publishReleasePublicationToSonatypeStagingRepository :snapshots:snapshots-annotations:publishReleasePublicationToSonatypeStagingRepository :snapshots:snapshots:publishReleasePublicationToSonatypeStagingRepository
+        run: ./gradlew :snapshots:snapshots-shared:publishReleasePublicationToSonatypeStagingRepository :snapshots:snapshots-annotations:publishReleasePublicationToSonatypeStagingRepository :snapshots:snapshots:publishReleasePublicationToSonatypeStagingRepository -Dorg.gradle.parallel=false


### PR DESCRIPTION
When trying to publish snapshots, there were multiple staging repos being opened in sonatype. This was resulting in errors actually publishing.

After a bit of googling, I found https://stackoverflow.com/questions/72664149/gradle-maven-publish-sonatype-creates-multiple-repositories-that-cant-be-clos. Nelson recent added the gradle.properties file with parallel=true in https://github.com/EmergeTools/emerge-android/pull/327/files#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19, so this just disables for the release workflows.