### PR TITLE
Add bitbucket to the regex as well and test using bitbucket urls

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Repositories.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Repositories.kt
@@ -12,7 +12,7 @@ import java.util.regex.Pattern
 private val gitRepoUriPattern: Pattern =
   Pattern.compile(
     "^(?:(?:https://|git://|http://)(?:.+:.+@)?|(?:ssh)?.*?@)" +
-      "(.*?(?:github|gitlab).*?)(?:/|:[0-9]*?/|:)(.*?)(?:\\.git)?$"
+      "(.*?(?:github|gitlab|bitbucket).*?)(?:/|:[0-9]*?/|:)(.*?)(?:\\.git)?$"
   )
 
 /**

--- a/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/util/RepositoriesTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/com/emergetools/android/gradle/util/RepositoriesTest.kt
@@ -10,7 +10,7 @@ import java.util.Locale
 class RepositoriesTest {
 
   companion object {
-    private val hostNames = listOf("gitlab", "github")
+    private val hostNames = listOf("gitlab", "github", "bitbucket")
     private val rawUrls = listOf(
       "http://%s.com/acme-inc/my-project",
       "https://%s.com/acme-inc/my-project",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,10 +14,13 @@ plugins {
   id("com.android.settings") version "8.8.0" // Keep in sync with agp in libs.versions.toml
 }
 
+val isCI = System.getenv("CI") != null
+
 develocity {
   buildScan {
     termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
     termsOfUseAgree.set("yes")
+    uploadInBackground = !isCI
   }
 }
 


### PR DESCRIPTION
Here you can see the repoOwner and repoName properly set on bitbucket.
[link](https://bitbucket.org/emerge_test/emerge-android/pipelines/results/15/steps/%7Bf5ba90b9-21cd-46f7-bc93-ea6ff0b35f23%7D#line=13-108)
