### PR TITLE
Add maven central and snapshot publishing configuration

### DIFF
--- a/.github/workflows/gradle-plugin-snapshot-release.yml
+++ b/.github/workflows/gradle-plugin-snapshot-release.yml
@@ -1,20 +1,16 @@
-name: Gradle plugin release deploy
+name: Gradle plugin snapshot deploy
 
 on:
-  release:
-    types: [ published ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   deploy-gradle-plugin:
 
     runs-on: ubuntu-latest
 
-    # Only run when the tag begins with the string "gradle-plugin-"
-    if: ${{ startsWith(github.event.release.tag_name, 'gradle-plugin-') }}
-
     env:
-      GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
-      GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
       OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
       OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
       ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
@@ -29,7 +25,5 @@ jobs:
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Deploy plugin
-        run: ./gradlew :gradle-plugin:plugin:publishPlugins
-      - name: Deploy plugin to maven central
-        run: ./gradlew :gradle-plugin:plugin:publishAllPublicationsToMavenCentralRepository
+      - name: Deploy plugin snapshot to Sonatype Snapshots
+        run: ./gradlew :gradle-plugin:plugin:publishAllPublicationsToSonatypeSnapshotsRepository

--- a/.github/workflows/snapshots-release.yml
+++ b/.github/workflows/snapshots-release.yml
@@ -17,10 +17,6 @@ jobs:
       ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
       ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -214,6 +214,7 @@ publishing {
 
     repositories {
         maven {
+          name = if (isReleaseBuild) "MavenCentral" else "SonatypeSnapshots"
             val releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
             val snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
             url = uri(if (isReleaseBuild) releasesRepoUrl else snapshotsRepoUrl)

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -231,5 +231,6 @@ signing {
   val signingKey: String? by project
   val signingPassword: String? by project
   useInMemoryPgpKeys(signingKey, signingPassword)
+  isRequired = isReleaseBuild
 }
 

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -219,14 +219,16 @@ publishing {
             url = uri(if (isReleaseBuild) releasesRepoUrl else snapshotsRepoUrl)
 
             credentials {
-                username = project.findProperty("ossrhUsername") as String? ?: System.getenv("OSSRH_USERNAME")
-                password = project.findProperty("ossrhPassword") as String? ?: System.getenv("OSSRH_PASSWORD")
+                username = System.getenv("OSSRH_USERNAME")
+                password = System.getenv("OSSRH_PASSWORD")
             }
         }
     }
 }
 
 signing {
-  isRequired = isReleaseBuild
+  val signingKey: String? by project
+  val signingPassword: String? by project
+  useInMemoryPgpKeys(signingKey, signingPassword)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ runtime-android = "1.7.6"
 foundation-layout-android = "1.7.6"
 
 # internal
-emerge-gradle-plugin = "4.0.9"
+emerge-gradle-plugin = "4.0.10-SNAPSHOT"
 emerge-performance = "2.1.2"
 emerge-reaper = "1.0.0"
 emerge-snapshots = "1.3.2"


### PR DESCRIPTION
This adds the configuration to publish to maven central and the maven central snapshot repository for testing.
What this does:
* This will publish a snapshot on every main branch build when the version ends in `-SNAPSHOT`.
* The release workflow will also publish to maven central.

Note this hasn’t been tested.
