### PR TITLE
Use Gradle TestKit Support Plugin for testing

### DIFF
--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.buildconfig)
   alias(libs.plugins.detekt)
+  alias(libs.plugins.autonomousapps.testkit)
 
   `java-gradle-plugin`
   `maven-publish`
@@ -72,24 +73,17 @@ val writeSupportedVersionsFiles = tasks.register("writeSupportedVersionsFiles") 
     }
   }
 }
-
-val functionalTest: SourceSet by sourceSets.creating {
-  // The classpath files are added as resources so that the test code can access them.
-  resources {
-    srcDir(writeSupportedVersionsFiles)
+sourceSets {
+  functionalTest {
+    // The classpath files are added as resources so that the test code can access them.
+    resources {
+      srcDir(writeSupportedVersionsFiles)
+    }
   }
 }
 
-val functionalTestTask =
-  tasks.register<Test>("functionalTest") {
-    description = "Runs the functional tests."
-    group = "verification"
-    testClassesDirs = functionalTest.output.classesDirs
-    classpath = functionalTest.runtimeClasspath
-  }
-
 tasks.check {
-  dependsOn(functionalTestTask, tasks.validatePlugins)
+  dependsOn(tasks.validatePlugins)
 }
 
 val perfProjectTemplateResDir = project.layout.buildDirectory.dir("generated/performance-project-template/")
@@ -109,6 +103,11 @@ detekt {
   buildUponDefaultConfig = true
   config.setFrom(rootProject.layout.projectDirectory.file("../detekt/detekt.yml"))
   baseline = rootProject.layout.projectDirectory.file("detekt/baseline.xml").asFile
+}
+
+gradleTestKitSupport {
+  withSupportLibrary()
+  withTruthLibrary()
 }
 
 dependencies {
@@ -154,7 +153,6 @@ gradlePlugin {
       tags = listOf("emerge", "emergetools", "android", "upload")
     }
   }
-  testSourceSets(functionalTest)
 }
 
 val emergeBaseUrl: String? by project

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 gradle-publish = { id = "com.gradle.plugin-publish", version = "1.3.1" }
 grgit = { id = "org.ajoberstar.grgit", version = "5.3.0" }
+autonomousapps-testkit = { id = "com.autonomousapps.testkit", version = "0.12" }
 
 [libraries]
 android-gradle-plugin = "com.android.tools.build:gradle:7.4.2"


### PR DESCRIPTION
This uses some of the convenience provided by using [Tony's Gradle TestKit Support Plugin.](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/tree/main/testkit)

The goal of this change is to allow us to rewrite some of the tests to
stop using `GradleRunner.withPluginClasspath()`. See point #1 in the
above readme or for more information on issues with `withPluginClasspath` see these issues: https://github.com/gradle/gradle/issues/28285
https://github.com/gradle/gradle/issues/22466

I believe that the mixing of the classpath is causing some tests to succeed even though they should fail. We shall see. [Either way this PR](https://github.com/EmergeTools/emerge-android/pull/453) has revealed that this is a problem.