### PR TITLE
Cleanup buildscript classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,9 @@ plugins {
   alias(libs.plugins.kotlin.jvm) apply false
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.benchmark) apply false
+  alias(libs.plugins.buildconfig) apply false
+  alias(libs.plugins.compose.compiler) apply false
+  id("com.emergetools.android") apply false
 }
 
 allprojects {


### PR DESCRIPTION
This puts all our plugins in the root project in order to ensure that
the buildscript classpath is the same for all subprojects. This improves
performance by avoiding loading a new buildscript classpath for each
subproject.
Before: https://scans.gradle.com/s/aups343hmsby4/build-dependencies?toggled=W1s2XSxbNV0sWzYsMF0sWzUsMF0sWzNdLFszLDBdLFsyXSxbMiwwXSxbMF0sWzAsMF0sWzRdLFs0LDBdLFs3XSxbNywwXV0
After: https://scans.gradle.com/s/cxfqmjpcpuouk/build-dependencies?toggled=W1swXSxbMV1d
