### PR TITLE
Properly support RTL languages

### DIFF
--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/LocalePreviews.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/LocalePreviews.kt
@@ -10,4 +10,8 @@ import androidx.compose.ui.tooling.preview.Preview
   name = "German",
   locale = "de"
 )
+@Preview(
+  name = "Arabic",
+  locale = "ar"
+)
 annotation class LocalePreviews

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
@@ -99,5 +99,3 @@ fun PortraitLandscapeViewPreview() {
     PortraitLandscapeView()
   }
 }
-
-

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/PortraitLandscapeView.kt
@@ -99,3 +99,5 @@ fun PortraitLandscapeViewPreview() {
     PortraitLandscapeView()
   }
 }
+
+

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/TextRowWithIcon.kt
@@ -1,11 +1,14 @@
 package com.emergetools.snapshots.sample.ui
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.emergetools.snapshots.annotations.IgnoreEmergeSnapshot
 import com.emergetools.snapshots.sample.ui.theme.SnapshotsSampleTheme
 
@@ -14,7 +17,7 @@ fun TextRowWithIcon(
   titleText: String,
   subtitleText: String?,
 ) {
-  Column {
+  Column(Modifier.width(150.dp)) {
     Text(
       text = titleText,
     )

--- a/snapshots/sample/app/src/main/res/values-ar/strings.xml
+++ b/snapshots/sample/app/src/main/res/values-ar/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="sample_title">عنوان الاختبار</string>
+  <string name="sample_subtitle">اختبار الترجمة</string>
+</resources>

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -139,7 +139,7 @@ class SnapshotVariantContextWrapper(
 // Instead, we can manually split the locale string ourselves and pass into the appropriate constructor
 // which seems to work better.
 // Android Studio has completely separate code for parsing locale codes.
-fun localeForLanguageCode(code: String): Locale {
+  fun localeForLanguageCode(code: String): Locale {
   val normalizedCode = code.replace("_", "-")
   val split = normalizedCode.split("-")
 

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -25,7 +25,8 @@ import java.util.Locale
 
 private val RTL_LANGUAGES = setOf(
   "ar", // Arabic
-  "he", "iw", // Hebrew (iw is legacy code)
+  "he", // Hebrew (iw is legacy code)
+  "iw",
 )
 
 @Composable
@@ -60,7 +61,8 @@ fun SnapshotVariantProvider(
     }
   }
 
-  val layoutDirection = if (locale.language in RTL_LANGUAGES) LayoutDirection.Rtl else LayoutDirection.Ltr
+  val layoutDirection =
+    if (locale.language in RTL_LANGUAGES) LayoutDirection.Rtl else LayoutDirection.Ltr
 
   val providedValues = arrayOf(
     LocalInspectionMode provides true,
@@ -80,7 +82,8 @@ fun SnapshotVariantProvider(
           val color = config.backgroundColor?.let { Color(it) } ?: Color.White
           Modifier.background(color)
         } ?: Modifier
-      ).clip(deviceSpec?.shape ?: RectangleShape)
+      )
+      .clip(deviceSpec?.shape ?: RectangleShape)
 
     Box(modifier = modifier) {
       content()
@@ -139,7 +142,8 @@ class SnapshotVariantContextWrapper(
 // Instead, we can manually split the locale string ourselves and pass into the appropriate constructor
 // which seems to work better.
 // Android Studio has completely separate code for parsing locale codes.
-  fun localeForLanguageCode(code: String): Locale {
+@Suppress("MagicNumber")
+fun localeForLanguageCode(code: String): Locale {
   val normalizedCode = code.replace("_", "-")
   val split = normalizedCode.split("-")
 
@@ -153,6 +157,7 @@ class SnapshotVariantContextWrapper(
         Locale(split[0], split[1])
       }
     }
+
     else -> Locale.forLanguageTag(normalizedCode)
   }
 }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -20,14 +20,10 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.core.text.TextUtilsCompat
+import androidx.core.view.ViewCompat
 import com.emergetools.snapshots.shared.ComposePreviewSnapshotConfig
 import java.util.Locale
-
-private val RTL_LANGUAGES = setOf(
-  "ar", // Arabic
-  "he", // Hebrew (iw is legacy code)
-  "iw",
-)
 
 @Composable
 fun SnapshotVariantProvider(
@@ -61,8 +57,11 @@ fun SnapshotVariantProvider(
     }
   }
 
-  val layoutDirection =
-    if (locale.language in RTL_LANGUAGES) LayoutDirection.Rtl else LayoutDirection.Ltr
+  val layoutDirection = if (TextUtilsCompat.getLayoutDirectionFromLocale(locale) == ViewCompat.LAYOUT_DIRECTION_RTL) {
+    LayoutDirection.Rtl
+  } else {
+    LayoutDirection.Ltr
+  }
 
   val providedValues = arrayOf(
     LocalInspectionMode provides true,

--- a/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/UtilsTest.kt
+++ b/snapshots/snapshots/src/test/kotlin/com/emergetools/snapshots/UtilsTest.kt
@@ -38,7 +38,7 @@ class UtilsTest {
   fun `makes es-rES locale`() {
     val locale = localeForLanguageCode("es-rES")
     assertEquals("es", locale.language)
-    assertEquals("RES", locale.country)
+    assertEquals("ES", locale.country)
   }
 
   @Test


### PR DESCRIPTION
A client raised an issue mentioning RTL language variants were not properly updating the layout direction of the composable. Upon further inspection, we were not overriding the layout direction as well as setting the Configuration's layout direction.

This now properly snapshots RTL languages (just AR/HE for now) and adds a sample arabic snapshot to confirm/act as an integration test moving forward.