### PR TITLE
Separate Junit4 and Junit5.

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -43,7 +43,7 @@ android {
 dependencies {
   androidTestImplementation(libs.androidx.test.runner)
   androidTestImplementation(libs.androidx.junit)
-  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.junit4)
   androidTestImplementation(libs.androidx.benchmark.junit4)
   androidTestImplementation(projects.reaper.reaper)
 }

--- a/distribution/distribution/build.gradle.kts
+++ b/distribution/distribution/build.gradle.kts
@@ -51,12 +51,9 @@ dependencies {
   implementation(libs.androidx.material3.android)
 
   testImplementation(libs.google.truth)
-
-  testImplementation(libs.junit.jupiter.api)
-  testImplementation(libs.junit.jupiter.params)
+  testImplementation(libs.junit5.jupiter)
   testImplementation(libs.mockito)
   testImplementation(libs.mockito.kotlin)
-  testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 tasks.withType<Test> {

--- a/distribution/integration/build.gradle.kts
+++ b/distribution/integration/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
 
   androidTestImplementation(libs.compose.runtime)
   androidTestImplementation(libs.compose.ui)
-  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.junit4)
   androidTestImplementation(libs.androidx.junit)
   androidTestImplementation(libs.androidx.test.core)
   androidTestImplementation(libs.androidx.test.runner)

--- a/distribution/sample/app/build.gradle.kts
+++ b/distribution/sample/app/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
 
   androidTestImplementation(libs.compose.runtime)
   androidTestImplementation(libs.compose.ui)
-  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.junit4)
   androidTestImplementation(libs.androidx.junit)
   androidTestImplementation(libs.androidx.test.core)
   androidTestImplementation(libs.androidx.test.runner)

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -131,9 +131,10 @@ dependencies {
   testImplementation(libs.google.truth)
   testImplementation(libs.junit5.jupiter)
 
-  "functionalTestImplementation"(project(":plugin"))
-  "functionalTestImplementation"(libs.okhttp.mockwebserver)
-  "functionalTestImplementation"(libs.kotlinx.serialization)
+  functionalTestImplementation(project(":plugin"))
+  functionalTestImplementation(libs.okhttp.mockwebserver)
+  functionalTestImplementation(libs.kotlinx.serialization)
+  functionalTestImplementation(libs.junit5.jupiter)
 
   detektPlugins(libs.detekt.formatting)
 }

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -129,17 +129,11 @@ dependencies {
   implementation(libs.okhttp)
 
   testImplementation(libs.google.truth)
-  testImplementation(libs.junit)
-  testImplementation(libs.junit.jupiter)
-  testImplementation(libs.junit.jupiter.api)
-  testRuntimeOnly(libs.junit.jupiter.engine)
-  testRuntimeOnly(libs.junit.platform.launcher)
+  testImplementation(libs.junit5.jupiter)
 
   "functionalTestImplementation"(project(":plugin"))
-  "functionalTestImplementation"(libs.junit.jupiter.api)
   "functionalTestImplementation"(libs.okhttp.mockwebserver)
   "functionalTestImplementation"(libs.kotlinx.serialization)
-  "functionalTestRuntimeOnly"(libs.junit.jupiter.engine)
 
   detektPlugins(libs.detekt.formatting)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
 android.useAndroidX=true
 org.gradle.configuration.cache=true
 org.gradle.configuration.cache.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,16 +76,12 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 asm = "org.ow2.asm:asm:9.7.1"
 asm-commons = "org.ow2.asm:asm-commons:9.7.1"
 
-assertj = "org.assertj:assertj-core:3.27.3"
-
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 compose-foundation-android = { group = "androidx.compose.foundation", name = "foundation-android" }
 compose-material = { group = "androidx.compose.material3", name = "material3" }
 compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
-compose-ui-test = { group = "androidx.compose.ui", name = "ui-test" }
 compose-ui-test-junit = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-wear-ui-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version = "1.0.0" }
@@ -98,16 +94,11 @@ google-truth = "com.google.truth:truth:1.4.4"
 
 guava = "com.google.guava:guava:33.4.0-jre"
 
-junit = "junit:junit:4.13.2"
-junit-platform-launcher = "org.junit.platform:junit-platform-launcher:1.11.4"
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
-junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
+junit4 = "junit:junit:4.13.2"
+junit5-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlin-coroutines" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.6.2"
 kotlinx-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"
 
@@ -120,8 +111,6 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 
 tree-printer = "hu.webarticum:tree-printer:3.2.1"
-androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity-ktx" }
-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
 androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3-android" }
 androidx-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "runtime-android" }
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundation-layout-android" }

--- a/performance/performance/build.gradle.kts
+++ b/performance/performance/build.gradle.kts
@@ -54,7 +54,7 @@ android {
 }
 
 dependencies {
-  implementation(libs.junit)
+  implementation(libs.junit4)
 
   // Only use for local debugging & testing leveraging their Perfetto utils
   implementation(libs.androidx.benchmark.common)

--- a/reaper/reaper/build.gradle.kts
+++ b/reaper/reaper/build.gradle.kts
@@ -49,11 +49,9 @@ dependencies {
 
   testImplementation(libs.google.truth)
 
-  testImplementation(libs.junit.jupiter.api)
-  testImplementation(libs.junit.jupiter.params)
+  testImplementation(libs.junit5.jupiter)
   testImplementation(libs.mockito)
   testImplementation(libs.mockito.kotlin)
-  testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 tasks.withType<Test> {

--- a/reaper/sample/app/build.gradle.kts
+++ b/reaper/sample/app/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
 
   androidTestImplementation(libs.compose.runtime)
   androidTestImplementation(libs.compose.ui)
-  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.junit4)
   androidTestImplementation(libs.androidx.junit)
   androidTestImplementation(libs.androidx.test.core)
   androidTestImplementation(libs.androidx.test.runner)

--- a/reaper/sample/stress/build.gradle.kts
+++ b/reaper/sample/stress/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
 
   androidTestImplementation(libs.compose.runtime)
   androidTestImplementation(libs.compose.ui)
-  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.junit4)
   androidTestImplementation(libs.androidx.test.core)
   androidTestImplementation(libs.androidx.test.runner)
   androidTestImplementation(libs.androidx.test.uiautomator)

--- a/snapshots/sample/app/build.gradle.kts
+++ b/snapshots/sample/app/build.gradle.kts
@@ -70,5 +70,5 @@ dependencies {
   androidTestImplementation(projects.snapshots.snapshots)
   androidTestImplementation(libs.compose.runtime)
   androidTestImplementation(libs.compose.ui)
-  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.junit4)
 }

--- a/snapshots/sample/ui-module/build.gradle.kts
+++ b/snapshots/sample/ui-module/build.gradle.kts
@@ -35,5 +35,5 @@ dependencies {
   implementation(libs.compose.material)
 
   androidTestImplementation(libs.compose.runtime)
-  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.junit4)
 }

--- a/snapshots/snapshots-shared/build.gradle.kts
+++ b/snapshots/snapshots-shared/build.gradle.kts
@@ -35,7 +35,7 @@ tasks.withType<KotlinCompile> {
 dependencies {
   implementation(libs.kotlinx.serialization)
 
-  testImplementation(libs.junit)
+  testImplementation(libs.junit4)
 }
 
 tasks.register("generateMetaInfVersion") {

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -45,7 +45,7 @@ android {
 
 dependencies {
 
-  implementation(libs.junit)
+  implementation(libs.junit4)
   implementation(libs.kotlinx.serialization)
 
   api(platform(libs.compose.bom))
@@ -62,7 +62,7 @@ dependencies {
   api(libs.androidx.test.runner)
   api(libs.compose.ui.test.junit)
 
-  testImplementation(libs.junit)
+  testImplementation(libs.junit4)
 }
 
 tasks.register("generateMetaInfVersion") {


### PR DESCRIPTION
We had some places in the code that were using both. This can lead to unpredictable results if using the wrong class. I noticed this since I was trying to refactor our tests and picked the wrong junit version and something wasn’t working.

This also simplifies the dependency setup.

I also had to bump up the Gradle heap size since I was facing OOMs when trying to run all the tests locally.
