### PR TITLE
Remove unneeded code related to java version.

### DIFF
--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/NoVcsEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/NoVcsEmergePluginTest.kt
@@ -77,7 +77,6 @@ class NoVcsEmergePluginTest : EmergePluginTest() {
     val runner = EmergeGradleRunner2(project.gradleProject.rootDir)
       .withArguments("logExtension")
       .withGithubPR()
-      .withJavaVersionFromAgp(project.agpVersion)
       .build()
 
     assertThat(runner).task(":app:logExtension").succeeded()
@@ -102,7 +101,6 @@ class NoVcsEmergePluginTest : EmergePluginTest() {
     val runner = EmergeGradleRunner2(project.gradleProject.rootDir)
       .withArguments("logExtension")
       .withGitHubPushEvent()
-      .withJavaVersionFromAgp(project.agpVersion)
       .build()
 
     assertThat(runner).apply {

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/SimpleEmergePluginTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/SimpleEmergePluginTest.kt
@@ -14,7 +14,6 @@ class SimpleEmergePluginTest : EmergePluginTest() {
     val project = SimpleGradleProject.createWithVcsInExtension(this)
     val runner = EmergeGradleRunner2(project.gradleProject.rootDir)
       .withArguments("emergeUploadReleaseAab")
-      .withJavaVersionFromAgp(project.agpVersion)
       .build()
 
     assertSuccessfulUploadRequests(server)
@@ -26,7 +25,6 @@ class SimpleEmergePluginTest : EmergePluginTest() {
     val project = SimpleGradleProject.createWithVcsInExtension(this, LATEST_AGP_7_VERSION)
     val runner = EmergeGradleRunner2(project.gradleProject.rootDir, GradleVersion.version("7.5.1"))
       .withArguments("emergeUploadReleaseAab")
-      .withJavaVersionFromAgp(LATEST_AGP_7_VERSION)
       .build()
 
     assertSuccessfulUploadRequests(server)
@@ -39,7 +37,6 @@ class SimpleEmergePluginTest : EmergePluginTest() {
     val project = SimpleGradleProject.createWithVcsInExtension(this)
     val runner = EmergeGradleRunner2(project.gradleProject.rootDir)
       .withArguments("emergeUploadReleaseAab")
-      .withJavaVersionFromAgp(project.agpVersion)
       .buildAndFail()
 
     assertThat(runner).task(":app:emergeUploadReleaseAab").failed()
@@ -50,7 +47,6 @@ class SimpleEmergePluginTest : EmergePluginTest() {
     val project = SimpleGradleProject.createWithVcsInExtension(this)
     val runner = EmergeGradleRunner2(project.gradleProject.rootDir)
       .withArguments("emergeUploadReleaseApk")
-      .withJavaVersionFromAgp(project.agpVersion)
       .build()
 
     assertSuccessfulUploadRequests(server)
@@ -63,7 +59,6 @@ class SimpleEmergePluginTest : EmergePluginTest() {
     val project = SimpleGradleProject.createWithVcsInExtension(this)
     val runner = EmergeGradleRunner2(project.gradleProject.rootDir)
       .withArguments("emergeUploadReleaseApk")
-      .withJavaVersionFromAgp(project.agpVersion)
       .buildAndFail()
 
     assertThat(runner).task(":app:emergeUploadReleaseApk").failed()
@@ -74,7 +69,6 @@ class SimpleEmergePluginTest : EmergePluginTest() {
     val project = SimpleGradleProject.createWithVcsInExtension(this)
     val runner = EmergeGradleRunner2(project.gradleProject.rootDir)
       .withArguments("logExtension")
-      .withJavaVersionFromAgp(project.agpVersion)
       .withGithubPR()
       .build()
 

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/base/EmergeGradleRunner.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/base/EmergeGradleRunner.kt
@@ -97,11 +97,6 @@ class EmergeGradleRunner private constructor(
       this.assertions = assertions
     }
 
-  fun withEnvironment(vararg pairs: Pair<String, String>) =
-    apply {
-      this.environment = mapOf(*pairs)
-    }
-
   private fun preBuild(): GradleRunner {
     @Suppress("DEPRECATION")
     tempProjectDir = Files.createTempDir()

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/base/EmergeGradleRunner2.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/base/EmergeGradleRunner2.kt
@@ -2,7 +2,6 @@ package com.emergetools.android.gradle.base
 
 import com.autonomousapps.kit.GradleBuilder
 import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.GradleRunner
 import org.gradle.util.GradleVersion
 import java.io.File
 
@@ -19,20 +18,6 @@ class EmergeGradleRunner2(projectDir: File, gradleVersion: GradleVersion = Gradl
   fun withArguments(vararg args: String): EmergeGradleRunner2 {
     runner.withArguments(*args)
     return this
-  }
-
-  // TODO we should stop using this and instead use Java toolchain support
-  fun withJavaVersionFromAgp(agpVersion: String): EmergeGradleRunner2 {
-    val javaVersion = if (agpVersion.startsWith("7")) {
-      "11"
-    } else {
-      "17"
-    }
-    return apply {
-      val arch = if (System.getProperty("os.arch") == "aarch64") "aarch64" else "X64"
-      val javaHomeEnvKey = "JAVA_HOME_${javaVersion}_$arch"
-      runner.withArguments(runner.arguments + "-Dorg.gradle.java.home=${System.getenv(javaHomeEnvKey)}")
-    }
   }
 
   fun withGithubPR(): EmergeGradleRunner2 {


### PR DESCRIPTION
We don't need the java 11/17 codepaths since we are already copying in
all the environment variables from the parent build.
