### PR TITLE
Use new test runner for ConfigurationCacheTest

### DIFF
--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/ConfigurationCacheTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/ConfigurationCacheTest.kt
@@ -1,52 +1,53 @@
 package com.emergetools.android.gradle
 
-import com.autonomousapps.kit.truth.TestKitTruth
+import com.autonomousapps.kit.truth.TestKitTruth.Companion.assertThat
 import com.emergetools.android.gradle.base.EmergeGradleRunner
+import com.emergetools.android.gradle.base.EmergeGradleRunner2
 import com.emergetools.android.gradle.mocks.assertSuccessfulUploadRequests
+import com.emergetools.android.gradle.projects.MultiProjectProject
+import com.emergetools.android.gradle.projects.SimpleGradleProject
 import org.junit.jupiter.api.Test
 
 class ConfigurationCacheTest : EmergePluginTest() {
   @Test
   fun simpleConfigurationCache() {
-    EmergeGradleRunner.create("simple")
+    val project = SimpleGradleProject.createWithVcsInExtension(this)
+    val result = EmergeGradleRunner2(project.gradleProject.rootDir)
       .withArguments("tasks", "--configuration-cache")
-      .assert { result, _ ->
-        result.assertSuccessfulTask(":tasks")
-      }
       .build()
+
+    assertThat(result).task(":tasks").succeeded()
   }
 
   @Test
   fun simpleConfigurationCacheUpload() {
-    EmergeGradleRunner.create("simple")
+    val project = SimpleGradleProject.createWithVcsInExtension(this)
+    val result = EmergeGradleRunner2(project.gradleProject.rootDir)
       .withArguments("emergeUploadReleaseAab", "--configuration-cache")
-      .withDefaultServer()
-      .assert { result, server ->
-        assertSuccessfulUploadRequests(server)
-        result.assertSuccessfulTask(":emergeUploadReleaseAab")
-      }
       .build()
+
+    assertSuccessfulUploadRequests(server)
+    assertThat(result).task(":app:emergeUploadReleaseAab").succeeded()
   }
 
   @Test
   fun multiProjectConfigurationCache() {
-    EmergeGradleRunner.create("multi-project")
-      .withArguments(":app:tasks", "--configuration-cache")
-      .assert { result, _ ->
-        result.assertSuccessfulTask(":app:tasks")
-      }
+    val project = MultiProjectProject.create(this)
+    val result = EmergeGradleRunner2(project.gradleProject.rootDir)
+      .withArguments("tasks", "--configuration-cache")
       .build()
+
+    assertThat(result).task(":tasks").succeeded()
   }
 
   @Test
   fun multiProjectConfigurationCachePerfBundle() {
-    EmergeGradleRunner.create("multi-project")
+    val project = MultiProjectProject.create(this)
+    val result = EmergeGradleRunner2(project.gradleProject.rootDir)
       .withArguments("emergeUploadReleasePerfBundle", "--configuration-cache")
-      .withDefaultServer()
-      .assert { result, server ->
-        assertSuccessfulUploadRequests(server)
-        result.assertSuccessfulTask(":app:emergeUploadReleasePerfBundle")
-      }
       .build()
+
+    assertSuccessfulUploadRequests(server)
+    assertThat(result).task(":app:emergeUploadReleasePerfBundle").succeeded()
   }
 }

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/base/EmergeGradleRunner.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/base/EmergeGradleRunner.kt
@@ -60,26 +60,6 @@ class EmergeGradleRunner private constructor(
       this.arguments = arguments.toList()
     }
 
-  fun withGradleVersion(version: String) =
-    apply {
-      gradleVersion = GradleVersion.version(version)
-    }
-
-  fun withAndroidGradlePluginVersion(version: String) =
-    apply {
-      check(version in SUPPORTED_ANDROID_GRADLE_PLUGIN_VERSIONS) {
-        "This version of the Android Gradle Plugin is not currently supported."
-      }
-      androidGradlePluginVersion = version
-    }
-
-  private fun withJavaVersion(version: String) =
-    apply {
-      val arch = if (System.getProperty("os.arch") == "aarch64") "aarch64" else "X64"
-      val javaHomeEnvKey = "JAVA_HOME_${version}_$arch"
-      arguments = arguments + "-Dorg.gradle.java.home=${System.getenv(javaHomeEnvKey)}"
-    }
-
   fun withServer(serverReceiver: MockWebServer.(HttpUrl) -> Unit) =
     apply {
       server.apply { serverReceiver(baseUrl) }

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/projects/AbstractAndroidProject.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/projects/AbstractAndroidProject.kt
@@ -1,0 +1,35 @@
+package com.emergetools.android.gradle.projects
+
+import com.autonomousapps.kit.AbstractGradleProject
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.android.AndroidManifest
+import com.autonomousapps.kit.gradle.BuildscriptBlock
+import com.autonomousapps.kit.gradle.GradleProperties
+import com.autonomousapps.kit.gradle.Plugin
+import com.autonomousapps.kit.gradle.android.AndroidBlock
+
+abstract class AbstractAndroidProject(val baseUrl: String) : AbstractGradleProject() {
+  protected fun newAndroidGradleProjectBuilder(agpVersion: String) : GradleProject.Builder{
+    return newGradleProjectBuilder()
+      .withRootProject {
+        gradleProperties += GradleProperties.minimalAndroidProperties()
+        gradleProperties += "baseUrl=${baseUrl}"
+        withBuildScript {
+          buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
+        }
+      }
+  }
+
+
+  protected fun newAppSubproject(agpVersion: String, extension: String): GradleProject.Builder {
+    return newAndroidGradleProjectBuilder(agpVersion)
+      .withAndroidSubproject("app") {
+        withBuildScript {
+          plugins(Plugin("com.android.application"), Plugin("com.emergetools.android", PLUGIN_UNDER_TEST_VERSION))
+          android = AndroidBlock.defaultAndroidAppBlock(false, "com.example")
+          additions = extension
+        }
+        manifest = AndroidManifest.simpleApp()
+      }
+  }
+}

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/projects/MultiProjectProject.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/projects/MultiProjectProject.kt
@@ -1,0 +1,53 @@
+package com.emergetools.android.gradle.projects
+
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.gradle.Plugin
+import com.autonomousapps.kit.gradle.android.AndroidBlock
+import com.emergetools.android.gradle.EmergePluginTest
+import com.emergetools.android.gradle.base.EmergeGradleRunner
+
+class MultiProjectProject(
+  baseUrl: String,
+  private val agpVersion: String,
+  private val extension: String
+) : AbstractAndroidProject(baseUrl) {
+  companion object {
+    fun create(test: EmergePluginTest,
+      agpVersion: String = EmergeGradleRunner.SUPPORTED_ANDROID_GRADLE_PLUGIN_VERSIONS.last(),
+      extension: String = """
+        emerge {
+          apiToken = 'abcdef123'
+
+          performance {
+            projectPath = ':lib'
+          }
+
+          vcs {
+            sha = 'testSha'
+            baseSha = 'testBaseSha'
+            previousSha = 'testPreviousSha'
+            branchName = 'testBranchName'
+            gitHub {
+              repoOwner = 'repoOwner'
+              repoName = 'repoName'
+            }
+          }
+        }
+      """.trimIndent()
+    ): MultiProjectProject {
+      return MultiProjectProject(test.baseUrl.toString(), agpVersion, extension)
+    }
+  }
+
+  val gradleProject: GradleProject = build()
+
+  private fun build(): GradleProject {
+    return newAppSubproject(agpVersion, extension)
+      .withAndroidLibProject("lib", "com.example.lib") {
+        withBuildScript {
+          android = AndroidBlock.defaultAndroidLibBlock(false)
+        }
+      }
+      .write()
+  }
+}

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/projects/SimpleGradleProject.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/projects/SimpleGradleProject.kt
@@ -1,22 +1,17 @@
 package com.emergetools.android.gradle.projects
 
-import com.autonomousapps.kit.AbstractGradleProject
 import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.android.AndroidManifest
-import com.autonomousapps.kit.gradle.GradleProperties
-import com.autonomousapps.kit.gradle.BuildscriptBlock
 import com.autonomousapps.kit.gradle.Plugin
 import com.autonomousapps.kit.gradle.android.AndroidBlock
-import com.autonomousapps.kit.render.Element
-import com.autonomousapps.kit.render.Scribe
 import com.emergetools.android.gradle.EmergePluginTest
 import com.emergetools.android.gradle.base.EmergeGradleRunner
 
 class SimpleGradleProject(
   agpVersion: String,
-  private val baseUrl: String,
+  baseUrl: String,
   private val emergeExtension: String
-) : AbstractGradleProject() {
+) : AbstractAndroidProject(baseUrl) {
 
   companion object {
     fun createWithVcsInExtension(
@@ -57,26 +52,7 @@ class SimpleGradleProject(
   val gradleProject: GradleProject = build(agpVersion)
 
   private fun build(agpVersion: String): GradleProject {
-    return newAndroidGradleProjectBuilder(agpVersion)
-      .withAndroidSubproject("app") {
-        withBuildScript {
-          plugins(Plugin("com.android.application"), Plugin("com.emergetools.android", PLUGIN_UNDER_TEST_VERSION))
-          android = AndroidBlock.defaultAndroidAppBlock(false, "com.example")
-          additions = emergeExtension
-        }
-        manifest = AndroidManifest.simpleApp()
-      }
+    return newAppSubproject(agpVersion, emergeExtension).build()
         .write()
-  }
-
-  protected fun newAndroidGradleProjectBuilder(agpVersion: String) : GradleProject.Builder{
-    return newGradleProjectBuilder()
-      .withRootProject {
-        gradleProperties += GradleProperties.minimalAndroidProperties()
-        gradleProperties += "baseUrl=${baseUrl}"
-        withBuildScript {
-          buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
-        }
-      }
   }
 }


### PR DESCRIPTION
This will unblock the PR to use GR8 to relocate dependencies.

This also restructures the `SimpleGradleProject` to inherit from `AbstractAndroidProject` so we can also use common functions in `MultiProjectProject`
