### PR TITLE
[reaper] Add Reaper.fuseOff

### DIFF
--- a/reaper/CHANGELOG.md
+++ b/reaper/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add `Reaper.fuseOff()`. [#491](https://github.com/EmergeTools/emerge-android/pull/491)
+
 ## 1.0.0 - 2024-12-02
 
 - Initial release.

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/NullHashTracker.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/NullHashTracker.kt
@@ -1,0 +1,15 @@
+@file:Suppress("EmptyFunctionBlock")
+
+package com.emergetools.reaper
+
+import java.util.Collections
+
+class NullHashTracker : HashTracker {
+  override val name = "NullHashTracker"
+
+  override fun logMethodEntry(methodHash: Long) {}
+
+  override fun flush(onFlush: (Collection<Long>) -> Unit) {
+    onFlush(Collections.emptyList())
+  }
+}

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Reaper.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Reaper.kt
@@ -28,6 +28,24 @@ object Reaper {
   }
 
   /**
+   * Permanently disable Reaper from collecting hashes for the lifetime of this process
+   * and discard any hashes collected so far.
+   * Should not be called if Reaper has been initialized.
+   * Calling more once has no effect.
+   * Calling init after this will log an error but have no other effect.
+   * The expected use case is to reduce the cost the Reaper when it is never going to be enabled
+   * (for example in the control arm of an experiment where the treatment arm is enabling Reaper).
+   * Reaper has some cost even when not initialized, this is due to the requirement of detecting
+   * code used very early during startup. 'Early startup' hashes are accumulated then flushed once
+   * Reaper is initialized. If Reaper is never initialized this flush never happens and a limited
+   * (but potentiality significant) amount of memory can be 'leaked'.
+   * @param context Android context
+   */
+  fun fuseOff(context: Context) {
+    ReaperInternal.fuseOff(context)
+  }
+
+  /**
    * Flush observed hashes into the current report if any.
    * This method may be called from any thread.
    * Blocks until the flush is complete.


### PR DESCRIPTION
Add `Reaper.fuseOff` an API to permanently disable Reaper from collecting hashes for the lifetime of the
process and discard any hashes collected so far.

The expected use case is to reduce the cost the Reaper when it is never going to be enabled
(for example in the control arm of an experiment where the treatment arm is enabling Reaper).
Reaper has some cost even when not initialized, this is due to the requirement of detecting
code used very early during startup. 'Early startup' hashes are accumulated then flushed once
Reaper is initialized. If Reaper is never initialized this flush never happens and a limited
(but potentiality significant) amount of memory can be 'leaked'.
This provides an API to 'free' that memory and prevent future collection.