### PR TITLE
Fix distribution version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ emerge-gradle-plugin = "4.1.1-SNAPSHOT"
 emerge-performance = "2.1.2"
 emerge-reaper = "1.0.1-SNAPSHOT"
 emerge-snapshots = "1.3.3"
-emerge-distribution = "0.0.4-SNAPSHOT"
+emerge-distribution = "0.0.5-SNAPSHOT"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
The current release is `0.0.4`, the planned next release is `0.0.5` which means that we should have the version set to `0.0.5-SNAPSHOT`.