### PR TITLE
Add ability to upload snapshot methods as part of json

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BaseUploadTask.kt
@@ -54,6 +54,7 @@ data class ArtifactMetadata(
   val testArtifactZipPath: String? = null,
   val proguardMappingsZipPath: String? = null,
   val dependencyMetadataZipPath: String? = null,
+  val snapshotConfigFile: String? = null,
   val ciDebugData: CIDebugData? = null,
 ) {
   companion object {

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/AggregatePreviewMethodsTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/AggregatePreviewMethodsTask.kt
@@ -1,0 +1,33 @@
+package com.emergetools.android.gradle.tasks.snapshots.transform
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+@OptIn(ExperimentalSerializationApi::class)
+abstract class AggregatePreviewMethodsTask : DefaultTask() {
+  @get:InputFiles
+  abstract val inputFiles: ConfigurableFileCollection
+
+  @get:OutputFile
+  abstract val outputFile: RegularFileProperty
+
+  @TaskAction
+  fun aggregate() {
+    val output = outputFile.get().asFile
+    output.parentFile.mkdirs()
+
+    output.writeText("")
+
+    // Aggregate all preview method files
+    val list = inputFiles.flatMap { Json.decodeFromStream<List<ComposePreviewSnapshotConfig>>(it.inputStream()) }
+    output.writeText(Json.encodeToString(list))
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/ComposePreviewSnapshotConfig.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/ComposePreviewSnapshotConfig.kt
@@ -1,0 +1,46 @@
+package com.emergetools.android.gradle.tasks.snapshots.transform
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ComposePreviewSnapshotConfig(
+  val fullyQualifiedClassName: String? = null,
+  val originalFqn: String,
+  val sourceFileName: String? = null,
+  var isAppStoreSnapshot: Boolean? = null,
+  val previewParameter: PreviewParameter? = null,
+  var name: String? = null,
+  var group: String? = null,
+  var uiMode: Int? = null,
+  var locale: String? = null,
+  var fontScale: Float? = null,
+  var heightDp: Int? = null,
+  var widthDp: Int? = null,
+  var showBackground: Boolean? = null,
+  var backgroundColor: Int? = null,
+  var showSystemUi: Boolean? = null,
+  var device: String? = null,
+  var apiLevel: Int? = null,
+  var wallpaper: Int? = null,
+)
+
+@Serializable
+data class PreviewParameter(
+  val parameterName: String,
+  val providerClassFqn: String,
+  val limit: Int? = null,
+  val index: Int? = null
+)
+
+fun String.cleanName(): String {
+  var newName = this.replace("/", ".")
+  // Strip .class suffix
+  if (newName.endsWith(".class")) {
+    newName = newName.substring(0, newName.length - 6)
+  }
+  return newName
+}
+
+fun String.removeClassName(): String {
+  return this.substringBeforeLast(".")
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/PreviewAnalyzerTransform.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/PreviewAnalyzerTransform.kt
@@ -1,0 +1,89 @@
+package com.emergetools.android.gradle.tasks.snapshots.transform
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.gradle.api.artifacts.transform.InputArtifact
+import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.TransformOutputs
+import org.gradle.api.artifacts.transform.TransformParameters
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Provider
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.AnnotationNode
+import org.objectweb.asm.tree.ClassNode
+import java.io.File
+import java.util.jar.JarFile
+
+abstract class PreviewAnalyzerTransform : TransformAction<TransformParameters.None> {
+  @get:InputArtifact
+  abstract val inputArtifact: Provider<FileSystemLocation>
+
+  override fun transform(outputs: TransformOutputs) {
+    val input = inputArtifact.get().asFile
+    if (!input.name.endsWith(".jar") && !input.name.endsWith(".aar") && !input.isDirectory) {
+      return
+    }
+
+    val outputFile = outputs.file("output.txt")
+
+    val previewMethods = when {
+      input.isDirectory -> findMethodsInDirectory(input)
+      input.name.endsWith(".jar") -> analyzeJarFile(input)
+      input.name.endsWith(".aar") -> analyzeAarFile(input)
+      else -> throw IllegalArgumentException("Unsupported input type: $input")
+    }
+
+    val json = Json.encodeToString(previewMethods.toList())
+
+    outputFile.writeText(json)
+  }
+
+  private fun analyzeJarFile(inputJar: File): Sequence<ComposePreviewSnapshotConfig> {
+    val methods = mutableListOf<ComposePreviewSnapshotConfig>()
+    JarFile(inputJar).use { jarFile ->
+      jarFile.entries().asSequence()
+        .filter { it.name.endsWith(".class") }
+        .forEach { classEntry ->
+          jarFile.getInputStream(classEntry).use { inputStream ->
+            methods.addAll(extractPreviewMethodsFromBytes(classEntry.realName , inputStream.readBytes()))
+          }
+        }
+    }
+    return methods.asSequence()
+  }
+
+  private fun findMethodsInDirectory(directory: File) : Sequence<ComposePreviewSnapshotConfig> {
+    return directory.findPreviewMethodsInDirectory()
+  }
+
+  private fun analyzeAarFile(aarFile: File) : Sequence<ComposePreviewSnapshotConfig> {
+    TODO("analzying aar file not yet implemented")
+    // Implementation of AAR analysis using ZipFile to avoid copying to temp dir
+    // This is more configuration cache friendly than using Project.zipTree
+  }
+
+
+
+  companion object {
+    fun File.findPreviewMethodsInDirectory(): Sequence<ComposePreviewSnapshotConfig> {
+      return walk()
+        .filter { it.name.endsWith(".class") }
+        .flatMap { classFile ->
+          extractPreviewMethodsFromBytes(classFile.name, classFile.readBytes())
+        }
+    }
+
+    fun extractPreviewMethodsFromBytes(fileName: String, byteStream: ByteArray): List<ComposePreviewSnapshotConfig> {
+      val classReader = ClassReader(byteStream)
+      val methodNames = mutableListOf<ComposePreviewSnapshotConfig>()
+
+      val visitor = SnapshotAggregatorClassVisitor(Opcodes.ASM9, fileName, classReader.className, methodNames)
+
+      classReader.accept(visitor, ClassReader.EXPAND_FRAMES)
+
+      return methodNames
+    }
+  }
+}
+

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/SnapshotAggregatorClassVisitor.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/SnapshotAggregatorClassVisitor.kt
@@ -1,0 +1,262 @@
+package com.emergetools.android.gradle.tasks.snapshots.transform
+
+import org.objectweb.asm.AnnotationVisitor
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+
+class SnapshotAggregatorClassVisitor(
+  api: Int,
+  val fileName: String,
+  val className: String,
+  val methodNames: MutableList<ComposePreviewSnapshotConfig>
+) : ClassVisitor(api) {
+  companion object {
+    const val PREVIEW_ANNOTATION_DESC = "Landroidx/compose/ui/tooling/preview/Preview;"
+    const val PREVIEW_CONTAINER_ANNOTATION_DESC =
+      "Landroidx/compose/ui/tooling/preview/Preview\$Container;"
+
+    // Supported default multipreview annotations
+    const val PREVIEW_LIGHT_DARK_ANNOTATION_DESC =
+      "Landroidx/compose/ui/tooling/preview/PreviewLightDark;"
+    const val PREVIEW_FONT_SCALE_ANNOTATION_DESC =
+      "Landroidx/compose/ui/tooling/preview/PreviewFontScale;"
+    const val PREVIEW_SCREEN_SIZES_ANNOTATION_DESC =
+      "Landroidx/compose/ui/tooling/preview/PreviewScreenSizes;"
+    const val PREVIEW_DYNAMIC_COLORS_ANNOTATION_DESC =
+      "Landroidx/compose/ui/tooling/preview/PreviewDynamicColors;"
+    const val EMERGE_APP_STORE_SNAPSHOT =
+      "Lcom/emergetools/snapshots/annotations/EmergeAppStoreSnapshot;"
+    const val EMERGE_IGNORE_SNAPSHOT =
+      "Lcom/emergetools/snapshots/annotations/IgnoreEmergeSnapshot;"
+
+    val ANNOTATIONS_TO_TRANSFORM =
+      arrayOf(
+        PREVIEW_ANNOTATION_DESC,
+        PREVIEW_CONTAINER_ANNOTATION_DESC,
+        PREVIEW_LIGHT_DARK_ANNOTATION_DESC,
+        PREVIEW_FONT_SCALE_ANNOTATION_DESC,
+        PREVIEW_SCREEN_SIZES_ANNOTATION_DESC,
+        PREVIEW_DYNAMIC_COLORS_ANNOTATION_DESC,
+        EMERGE_APP_STORE_SNAPSHOT,
+        EMERGE_IGNORE_SNAPSHOT,
+      )
+
+    const val TOUCHSCREEN_UNDEFINED: Int = 0
+    const val UI_MODE_NIGHT_MASK: Int = 48
+    const val UI_MODE_NIGHT_NO: Int = 16
+    const val UI_MODE_NIGHT_UNDEFINED: Int = 0
+    const val UI_MODE_NIGHT_YES: Int = 32
+    const val UI_MODE_TYPE_APPLIANCE: Int = 5
+    const val UI_MODE_TYPE_CAR: Int = 3
+    const val UI_MODE_TYPE_DESK: Int = 2
+    const val UI_MODE_TYPE_MASK: Int = 15
+    const val UI_MODE_TYPE_NORMAL: Int = 1
+    const val UI_MODE_TYPE_TELEVISION: Int = 4
+    const val UI_MODE_TYPE_UNDEFINED: Int = 0
+    const val UI_MODE_TYPE_VR_HEADSET: Int = 7
+    const val UI_MODE_TYPE_WATCH: Int = 6
+
+    const val PHONE = "spec:id=reference_phone,shape=Normal,width=411,height=891,unit=dp,dpi=420"
+    const val FOLDABLE =
+      "spec:id=reference_foldable,shape=Normal,width=673,height=841,unit=dp,dpi=420"
+    const val TABLET = "spec:id=reference_tablet,shape=Normal,width=1280,height=800,unit=dp,dpi=240"
+    const val DESKTOP =
+      "spec:id=reference_desktop,shape=Normal,width=1920,height=1080,unit=dp,dpi=160"
+  }
+
+  override fun visitMethod(
+    access: Int,
+    name: String,
+    descriptor: String,
+    signature: String?,
+    exceptions: Array<String>?,
+  ): MethodVisitor {
+    return MyMethodVisitor(api, name, fileName, className, methodNames)
+  }
+
+  // Visitor to capture the Preview annotation parameters.
+  class PreviewAnnotationVisitor(api: Int, val previewData: ComposePreviewSnapshotConfig) : AnnotationVisitor(api) {
+    override fun visit(name: String?, value: Any?) {
+      when (name) {
+        "name" -> if (value is String) previewData.name = value
+        "uiMode" -> if (value is Int) previewData.uiMode = value
+        "group" -> if (value is String) previewData.group = value
+        "apiLevel" -> if (value is Int) previewData.apiLevel = value
+        "widthDp" -> if (value is Int) previewData.widthDp = value
+        "heightDp" -> if (value is Int) previewData.heightDp = value
+        "locale" -> if (value is String) previewData.locale = value
+        "fontScale" -> if (value is Float) previewData.fontScale = value
+        "showSystemUi" -> if (value is Boolean) previewData.showSystemUi = value
+        "showBackground" -> if (value is Boolean) previewData.showBackground = value
+        "device" -> if (value is String) previewData.device = value
+        "wallpaper" -> if (value is Int) previewData.wallpaper = value
+      }
+      super.visit(name, value)
+    }
+  }
+
+  // Method visitor that checks for our target annotations.
+  class MyMethodVisitor(
+    api: Int,
+    private val methodName: String,
+    private val className: String,
+    private val fileName: String,
+    private val composeSnapshots: MutableList<ComposePreviewSnapshotConfig>
+  ) : MethodVisitor(api) {
+    fun createComposePreviewConfigs(forAnnotation: String) : List<ComposePreviewSnapshotConfig>{
+      val composeConfig = ComposePreviewSnapshotConfig(
+        originalFqn = className.cleanName().removeClassName() + "." + methodName,
+        sourceFileName =fileName.cleanName().substringAfterLast('.'),
+        fullyQualifiedClassName = className.cleanName(),
+      )
+
+      when(forAnnotation){
+        PREVIEW_ANNOTATION_DESC -> {
+          return listOf(composeConfig);
+        }
+        PREVIEW_LIGHT_DARK_ANNOTATION_DESC -> {
+          val light = composeConfig.copy(name = "light")
+          val dark = composeConfig.copy(name = "dark", uiMode = UI_MODE_NIGHT_YES or UI_MODE_TYPE_NORMAL)
+          return listOf(light, dark)
+        }
+        PREVIEW_SCREEN_SIZES_ANNOTATION_DESC -> {
+          return listOf(
+            composeConfig.copy(name = "Phone", device = PHONE, showSystemUi = true),
+            composeConfig.copy(name = "Phone - Landscape",
+              device = "spec:width = 411dp, height = 891dp, orientation = landscape, dpi = 420",
+              showSystemUi = true),
+            composeConfig.copy(name = "Unfolded Foldable", device = FOLDABLE, showSystemUi = true),
+            composeConfig.copy(name = "Tablet", device = TABLET, showSystemUi = true),
+            composeConfig.copy(name = "Desktop", device = DESKTOP, showSystemUi = true)
+          )
+        }
+        PREVIEW_FONT_SCALE_ANNOTATION_DESC -> {
+            return listOf(
+              composeConfig.copy(name = "85%", fontScale = 0.85f),
+              composeConfig.copy(name = "100%", fontScale = 1.0f),
+              composeConfig.copy(name = "115%", fontScale = 1.15f),
+              composeConfig.copy(name = "130%", fontScale = 1.3f),
+              composeConfig.copy(name = "150%", fontScale = 1.5f),
+              composeConfig.copy(name = "180%", fontScale = 1.8f),
+              composeConfig.copy(name = "200%", fontScale = 2f)
+            )
+        }
+        EMERGE_APP_STORE_SNAPSHOT -> {
+          return listOf(composeConfig.copy(isAppStoreSnapshot = true))
+        }
+        EMERGE_IGNORE_SNAPSHOT -> {
+          return emptyList()
+        }
+        PREVIEW_CONTAINER_ANNOTATION_DESC -> {
+          println("we found a container")
+//          TODO("We are not yet properly handling preview containers")
+          return emptyList()
+        }
+        else -> {
+          return emptyList()
+        }
+      }
+    }
+
+    override fun visitAnnotation(descriptor: String?, visible: Boolean): AnnotationVisitor? {
+      return when (descriptor) {
+        // Check for direct Preview annotation.
+        PREVIEW_ANNOTATION_DESC -> {
+          val previewConfig = createComposePreviewConfigs(PREVIEW_ANNOTATION_DESC).first()
+          composeSnapshots.add(previewConfig)
+          return PreviewAnnotationVisitor(api, previewConfig)
+        }
+        // Check for PreviewLightDark.
+        PREVIEW_LIGHT_DARK_ANNOTATION_DESC -> {
+          val snapshotConfig = createComposePreviewConfigs(PREVIEW_LIGHT_DARK_ANNOTATION_DESC)
+          composeSnapshots.addAll(snapshotConfig)
+          return super.visitAnnotation(descriptor, visible)
+        }
+        // Check for PreviewFontScale.
+        PREVIEW_FONT_SCALE_ANNOTATION_DESC -> {
+          val snapshotConfig = createComposePreviewConfigs(PREVIEW_FONT_SCALE_ANNOTATION_DESC)
+          composeSnapshots.addAll(snapshotConfig)
+          return super.visitAnnotation(descriptor, visible)
+        }
+        // Check for container annotation (inner class – note the escaped $).
+        PREVIEW_CONTAINER_ANNOTATION_DESC -> {
+          // This visitor handles the container's inner array of Preview annotations.
+          return object : AnnotationVisitor(api) {
+            override fun visitArray(name: String?): AnnotationVisitor? {
+              println("calling visit array")
+              if (name == "value") {
+                // Visit each element in the array.
+                return object : AnnotationVisitor(api) {
+                  override fun visitAnnotation(name: String?, descriptor: String?): AnnotationVisitor? {
+                    if (descriptor == "Landroidx/compose/ui/tooling/preview/Preview;") {
+                      val config = createComposePreviewConfigs(PREVIEW_CONTAINER_ANNOTATION_DESC)
+//                      val innerVisitor = PreviewAnnotationVisitor(api, config)
+//                      return object : AnnotationVisitor(api, innerVisitor) {
+//                        override fun visitEnd() {
+//                          super.visitEnd()
+//                          composeSnapshots.add(innerVisitor.previewData)
+//                        }
+//                      }
+                    }
+                    return super.visitAnnotation(name, descriptor)
+                  }
+                }
+              }
+              return super.visitArray(name)
+            }
+          }
+        }
+        else -> {
+          println("found something else: $descriptor")
+
+          return object : AnnotationVisitor(api) {
+            override fun visitAnnotation(name: String?, descriptor: String?): AnnotationVisitor {
+
+              println("visiting annotations inside $descriptor")
+              return super.visitAnnotation(name, descriptor)
+            }
+
+            override fun visit(name: String?, value: Any?) {
+              println("visiting thing $name, $value")
+              super.visit(name, value)
+            }
+            override fun visitArray(name: String?): AnnotationVisitor? {
+              println("visit array")
+              if (name == "value") {
+                return object : AnnotationVisitor(api) {
+                  override fun visitAnnotation(
+                    name: String?,
+                    descriptor: String?
+                  ): AnnotationVisitor? {
+                    println("descriptor = $descriptor")
+                    if (descriptor == "Landroidx/compose/ui/tooling/preview/Preview;") {
+//                      val config = createComposePreviewConfigs()
+//                      val innerVisitor = PreviewAnnotationVisitor(api, config)
+//                      return object : AnnotationVisitor(api, innerVisitor) {
+//                        override fun visitEnd() {
+//                          super.visitEnd()
+//                          composeSnapshots.add(innerVisitor.previewData)
+//                        }
+//                      }
+                    }
+                    return super.visitAnnotation(name, descriptor)
+                  }
+                }
+              }
+              return super.visitAnnotation(name, descriptor)
+            }
+          }
+          return super.visitAnnotation(descriptor, visible)
+        }
+      }
+    }
+  }
+
+  override fun visitAnnotation(
+    desc: String,
+    visible: Boolean,
+  ): AnnotationVisitor? {
+    // TODO we need to scan for custom annotations and keep track of them here
+    return super.visitAnnotation(desc, visible)
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/TransformProjectClasses.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/TransformProjectClasses.kt
@@ -1,0 +1,36 @@
+package com.emergetools.android.gradle.tasks.snapshots.transform
+
+import com.emergetools.android.gradle.tasks.snapshots.transform.PreviewAnalyzerTransform.Companion.findPreviewMethodsInDirectory
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class TransformProjectClasses : DefaultTask() {
+
+  @get:InputDirectory
+  abstract val inputDir: DirectoryProperty
+
+  @get:OutputFile
+  abstract val outputFile: RegularFileProperty
+
+  @TaskAction
+  fun transform() {
+    val input = inputDir.get().asFile
+
+    if (!input.exists()) {
+      println("⚠️ Warning: No compiled class files found in ${input.absolutePath}")
+      return
+    }
+
+    val methods = input.findPreviewMethodsInDirectory()
+
+    // Write aggregated preview methods to a file
+    val outputFile = outputFile.get().asFile
+    outputFile.writeText(Json.encodeToString(methods.toList()))
+  }
+}


### PR DESCRIPTION
This allows the upload of snapshot preview methods via a json file found in the upload metadata.

This is enabled via the Gradle Property `emerge.snapshots.transform.enabled=true`.
When it is disabled, everything will behave as before.

When enabled, we run a transform on the project classes as well as dependency classes. The transform transforms the class files in to a json file containing the preview method configuration.
Then there is a task called `AggregatePreviewMethodsTask` that gathers all the transformed classes and combines them in to a single json file.

This is still missing a few cases:
* Handling of custom annotations
* Handling of PreviewParameters
* EmergeAppStoreSnapshot is not handled correctly.

