### PR TITLE
Synchronize AGP versions between plugin and the rest of the build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,8 +23,6 @@ junit = "1.2.1"
 benchmark-junit4 = "1.3.3"
 mockito = "5.16.0"
 mockito-kotlin = "5.4.0"
-activity-ktx = "1.10.0"
-navigation-compose = "2.8.6"
 material3-android = "1.3.1"
 runtime-android = "1.7.6"
 foundation-layout-android = "1.7.6"
@@ -53,7 +51,7 @@ autonomousapps-testkit = { id = "com.autonomousapps.testkit", version = "0.12" }
 gr8 = { id = "com.gradleup.gr8", version = "0.11.2" }
 
 [libraries]
-android-gradle-plugin = "com.android.tools.build:gradle:8.9.0"
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidxactivity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxactivity" }


### PR DESCRIPTION
We test against AGP 8.0 so we can be sure we are compatible there.
