### PR TITLE
Remove build timestamp.

### DIFF
--- a/distribution/distribution/build.gradle.kts
+++ b/distribution/distribution/build.gradle.kts
@@ -75,7 +75,6 @@ tasks.register("generateMetaInfVersion") {
     metaInfDestDir.mkdirs()
     File(metaInfDestDir, "version.txt").writeText(
       "version: $version" +
-        "\nbuild time: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(Date())}" +
         "\nrevision: ${grgit.head().id}"
     )
   }

--- a/performance/performance/build.gradle.kts
+++ b/performance/performance/build.gradle.kts
@@ -75,7 +75,6 @@ tasks.register("generateMetaInfVersion") {
     metaInfDestDir.mkdirs()
     File(metaInfDestDir, "version.txt").writeText(
       "version: $version" +
-        "\nbuild time: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(Date())}" +
         "\nrevision: ${grgit.head().id}"
     )
   }

--- a/reaper/reaper/build.gradle.kts
+++ b/reaper/reaper/build.gradle.kts
@@ -72,7 +72,6 @@ tasks.register("generateMetaInfVersion") {
     metaInfDestDir.mkdirs()
     File(metaInfDestDir, "version.txt").writeText(
       "version: $version" +
-        "\nbuild time: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(Date())}" +
         "\nrevision: ${grgit.head().id}"
     )
   }

--- a/snapshots/snapshots-annotations/build.gradle.kts
+++ b/snapshots/snapshots-annotations/build.gradle.kts
@@ -40,7 +40,6 @@ tasks.register("generateMetaInfVersion") {
     metaInfDestDir.mkdirs()
     File(metaInfDestDir, "version.txt").writeText(
       "version: $version" +
-        "\nbuild time: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(Date())}" +
         "\nrevision: ${grgit.head().id}"
     )
   }

--- a/snapshots/snapshots-shared/build.gradle.kts
+++ b/snapshots/snapshots-shared/build.gradle.kts
@@ -46,7 +46,6 @@ tasks.register("generateMetaInfVersion") {
     metaInfDestDir.mkdirs()
     File(metaInfDestDir, "version.txt").writeText(
       "version: $version" +
-        "\nbuild time: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(Date())}" +
         "\nrevision: ${grgit.head().id}"
     )
   }

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -70,7 +70,6 @@ tasks.register("generateMetaInfVersion") {
     metaInfDestDir.mkdirs()
     File(metaInfDestDir, "version.txt").writeText(
       "version: $version" +
-        "\nbuild time: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(Date())}" +
         "\nrevision: ${grgit.head().id}"
     )
   }


### PR DESCRIPTION
This causes artifacts to need to be rebuilt as this is constantly
changing.
