### PR TITLE
Increase metaspace heap size.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
 android.useAndroidX=true
 org.gradle.configuration.cache=true
 org.gradle.configuration.cache.parallel=true


### PR DESCRIPTION
This should prevent the daemon from shutting down since it is often
running out of metaspace.