### PR TITLE
Disable caching for LocalSnapshots task.

### DIFF
--- a/distribution/distribution/build.gradle.kts
+++ b/distribution/distribution/build.gradle.kts
@@ -1,6 +1,3 @@
-import java.text.SimpleDateFormat
-import java.util.Date
-
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.grgit)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/LocalSnapshots.kt
@@ -3,12 +3,10 @@ package com.emergetools.android.gradle.tasks.snapshots
 import com.emergetools.android.gradle.tasks.base.ArtifactMetadata
 import com.emergetools.android.gradle.tasks.snapshots.utils.PreviewUtils
 import com.emergetools.android.gradle.util.adb.AdbHelper
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
@@ -18,11 +16,12 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.process.ExecOperations
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.util.zip.ZipFile
 import javax.inject.Inject
 
-@CacheableTask
+@DisableCachingByDefault(because = "Relies on local emulator state and should not be cached")
 abstract class LocalSnapshots : DefaultTask() {
   companion object {
     const val COMPOSE_SNAPSHOTS_FILENAME = "snapshots.json"

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Git.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Git.kt
@@ -4,31 +4,31 @@ import org.gradle.process.ExecOperations
 
 internal class Git(private val execOperations: ExecOperations) {
   fun currentBranch(): String? {
-    return execOperations.execute("git rev-parse --abbrev-ref HEAD")
+    return execOperations.executeWithSilentFailures("git rev-parse --abbrev-ref HEAD")
   }
 
   fun currentSha(): String? {
-    return execOperations.execute("git rev-parse HEAD")
+    return execOperations.executeWithSilentFailures("git rev-parse HEAD")
   }
 
   fun baseSha(): String? {
-    val baseSha = execOperations.execute("git merge-base ${remoteHeadBranch()} ${currentBranch()}")
+    val baseSha = execOperations.executeWithSilentFailures("git merge-base ${remoteHeadBranch()} ${currentBranch()}")
     // Consider blank (empty or whitespace) base sha as null
     if (baseSha?.isBlank() == true) return null
     return baseSha
   }
 
   fun previousSha(): String? {
-    return execOperations.execute("git rev-parse HEAD^")
+    return execOperations.executeWithSilentFailures("git rev-parse HEAD^")
   }
 
   fun remoteUrl(remote: String? = primaryRemote()): String? {
     if (remote == null) return null
-    return execOperations.execute("git config --get remote.$remote.url")
+    return execOperations.executeWithSilentFailures("git config --get remote.$remote.url")
   }
 
   private fun remote(): List<String>? {
-    return execOperations.execute("git remote")?.split("\n")
+    return execOperations.executeWithSilentFailures("git remote")?.split("\n")
   }
 
   private fun primaryRemote(): String? {
@@ -42,7 +42,7 @@ internal class Git(private val execOperations: ExecOperations) {
 
   private fun remoteHeadBranch(remote: String? = primaryRemote()): String? {
     if (remote == null) return null
-    val show = execOperations.execute("git remote show $remote") ?: return null
+    val show = execOperations.executeWithSilentFailures("git remote show $remote") ?: return null
     return show.split("\n").asSequence()
       .map { it.trim() }
       .firstOrNull { it.startsWith("HEAD branch: ") }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Process.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Process.kt
@@ -4,7 +4,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.process.ExecOperations
 import java.io.ByteArrayOutputStream
 
-fun ExecOperations.execute(command: String): String? {
+fun ExecOperations.executeWithSilentFailures(command: String): String? {
   val logger = Logging.getLogger(this::class.java)
   val outputStream = ByteArrayOutputStream()
   val errorOutputStream = ByteArrayOutputStream()

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/adb/AdbHelper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/adb/AdbHelper.kt
@@ -1,6 +1,6 @@
 package com.emergetools.android.gradle.util.adb
 
-import com.emergetools.android.gradle.util.execute
+import com.emergetools.android.gradle.util.executeWithSilentFailures
 import org.gradle.api.logging.Logger
 import org.gradle.process.ExecOperations
 import java.nio.file.Files
@@ -8,12 +8,12 @@ import java.nio.file.Path
 
 class AdbHelper(
   private val execOperations: ExecOperations,
-  private val logger: Logger,
+  logger: Logger,
   private val path: Path = Path.of("${System.getenv("ANDROID_HOME")}/platform-tools/adb"),
 ) {
   init {
     check(Files.exists(path)) { "ADB not found at path: $path" }
-    logger.debug("ADB Helper initialized with path: $path")
+    logger.debug("ADB Helper initialized with path: {}", path)
   }
 
   fun devices(): List<String> {
@@ -29,28 +29,28 @@ class AdbHelper(
     return lines.map { it.split("\t").first() }
   }
 
-  fun uninstall(packageName: String) = exec(listOf("uninstall", packageName))
+  fun uninstall(packageName: String) = exec("uninstall", packageName)
 
-  fun install(path: String) = exec(listOf("install", path))
+  fun install(path: String) = exec("install", path)
 
-  fun shell(vararg arguments: String) = exec(listOf("shell") + arguments)
+  fun shell(vararg arguments: String) = exec("shell", *arguments)
 
   fun shell(arguments: List<String>) = exec(listOf("shell") + arguments)
 
   fun push(
     localFile: String,
     deviceDir: String,
-  ) = exec(listOf("push", localFile, deviceDir))
+  ) = exec("push", localFile, deviceDir)
 
   fun pull(
     deviceDir: String,
     localDir: String,
-  ) = exec(listOf("pull", "$deviceDir/.", localDir))
+  ) = exec("pull", "$deviceDir/.", localDir)
 
-  fun exec(vararg args: String) = exec(args.toList())
+  private fun exec(vararg args: String) = exec(args.toList())
 
-  fun exec(args: List<String>): String? {
+  private fun exec(args: List<String>): String? {
     val command = "$path ${args.joinToString(" ")}"
-    return execOperations.execute(command)
+    return execOperations.executeWithSilentFailures(command)
   }
 }

--- a/performance/performance/build.gradle.kts
+++ b/performance/performance/build.gradle.kts
@@ -1,6 +1,3 @@
-import java.text.SimpleDateFormat
-import java.util.Date
-
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.android)

--- a/reaper/reaper/build.gradle.kts
+++ b/reaper/reaper/build.gradle.kts
@@ -1,6 +1,3 @@
-import java.text.SimpleDateFormat
-import java.util.Date
-
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.grgit)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ develocity {
 
 android {
   compileSdk = 35
+  targetSdk = 35
 }
 
 dependencyResolutionManagement {

--- a/snapshots/snapshots-annotations/build.gradle.kts
+++ b/snapshots/snapshots-annotations/build.gradle.kts
@@ -1,6 +1,4 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.text.SimpleDateFormat
-import java.util.Date
 
 plugins {
   alias(libs.plugins.kotlin.jvm)

--- a/snapshots/snapshots-shared/build.gradle.kts
+++ b/snapshots/snapshots-shared/build.gradle.kts
@@ -1,8 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.text.SimpleDateFormat
-import java.util.Date
 
 plugins {
   alias(libs.plugins.kotlin.jvm)

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -1,6 +1,3 @@
-import java.text.SimpleDateFormat
-import java.util.Date
-
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -14,7 +14,7 @@ application {
   mainClass = "com.emergetools.tools.GenKt"
 }
 
-task<JavaExec>("runGen") {
+tasks.register<JavaExec>("runGen") {
   classpath = sourceSets["main"].runtimeClasspath
   mainClass = "com.emergetools.tools.GenKt"
 }


### PR DESCRIPTION
Since we ignore adb errors this task could fail but then be cached never
alowing you to execute it again.

This also renames our exec function so that the intention is clear.
