### PR TITLE
Enable First Party Snapshots by default

### DIFF
--- a/.github/workflows/snapshots-sample-app.yml
+++ b/.github/workflows/snapshots-sample-app.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Emerge snapshots
-        run: ./gradlew :snapshots:sample:app:emergeUploadSnapshotBundleDebug
+        run: ./gradlew :snapshots:sample:app:emergeUploadSnapshotBundleDebug -Pemerge.experimental.firstPartySnapshots=false
         env:
           EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_KEY }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
@@ -234,7 +234,7 @@ fun getSnapshotUploadTaskName(variantName: String): String {
 
 private val Project.firstPartySnapshotsEnabled
   get() = providers.gradleProperty("emerge.experimental.firstPartySnapshots")
-    .getOrElse("false").toBoolean()
+    .getOrElse("true").toBoolean()
 
 private val String.mergeProjectClasses
   get() = "merge${capitalize()}ProjectClasses"

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ android.useAndroidX=true
 org.gradle.configuration.cache=true
 org.gradle.configuration.cache.parallel=true
 kotlin.stdlib.default.dependency=false
-emerge.experimental.firstPartySnapshots=false
+emerge.experimental.firstPartySnapshots=true


### PR DESCRIPTION
This uses the AGP api to get the compiled classes from our project directory.