### PR TITLE
Add Develocity Build Scan links when logging urls

### DIFF
--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
   implementation(libs.asm)
   implementation(libs.asm.commons)
 
+  add(shadowedDependencies.name, libs.develocity.agent.adapters)
   add(shadowedDependencies.name, libs.dexlib2)
   // Needed for the GradleRunner in the functional tests. We've had issues with the version of Guava
   // from one dependency conflicting with that of dexlib2, so we'll use the same version here.

--- a/gradle-plugin/plugin/rules.pro
+++ b/gradle-plugin/plugin/rules.pro
@@ -40,3 +40,4 @@
 -dontwarn org.slf4j.**
 -dontwarn com.android.build.**
 -dontwarn org.objectweb.asm.**
+-dontwarn com.gradle.develocity.agent.**

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/dv/DvHelpers.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/dv/DvHelpers.kt
@@ -1,0 +1,152 @@
+package com.emergetools.android.gradle.dv
+
+import com.gradle.develocity.agent.gradle.adapters.BuildResultAdapter
+import com.gradle.develocity.agent.gradle.adapters.BuildScanAdapter
+import com.gradle.develocity.agent.gradle.adapters.BuildScanCaptureAdapter
+import com.gradle.develocity.agent.gradle.adapters.BuildScanObfuscationAdapter
+import com.gradle.develocity.agent.gradle.adapters.DevelocityAdapter
+import com.gradle.develocity.agent.gradle.adapters.PublishedBuildScanAdapter
+import com.gradle.develocity.agent.gradle.adapters.develocity.DevelocityConfigurationAdapter
+import com.gradle.develocity.agent.gradle.adapters.enterprise.GradleEnterpriseExtensionAdapter
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.caching.configuration.AbstractBuildCache
+
+private fun Project.createDevelocityAdapter(): DevelocityAdapter {
+  rootProject.extensions.findByName("develocity")?.let {
+    return DevelocityConfigurationAdapter(it)
+  }
+
+  rootProject.extensions.findByName("gradleEnterprise")?.let {
+    return GradleEnterpriseExtensionAdapter(it)
+  }
+  return NoOpDevelocityAdapter()
+}
+
+fun Project.getBuildScan(): BuildScanAdapter {
+  return createDevelocityAdapter().buildScan
+}
+
+// This no-op class is used if the DV plugin is not applied
+@Suppress("detekt.TooManyFunctions")
+private class NoOpDevelocityAdapter : DevelocityAdapter {
+  override fun getBuildScan(): BuildScanAdapter {
+    return NoOpBuildScanAdapter()
+  }
+
+  override fun buildScan(p0: Action<in BuildScanAdapter>?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun setServer(p0: String?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun getServer(): String? {
+    TODO("Not yet implemented")
+  }
+
+  override fun setProjectId(p0: String?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun getProjectId(): String? {
+    TODO("Not yet implemented")
+  }
+
+  override fun setAllowUntrustedServer(p0: Boolean) {
+    TODO("Not yet implemented")
+  }
+
+  override fun getAllowUntrustedServer(): Boolean {
+    TODO("Not yet implemented")
+  }
+
+  override fun setAccessKey(p0: String?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun getAccessKey(): String? {
+    TODO("Not yet implemented")
+  }
+
+  override fun getBuildCache(): Class<out AbstractBuildCache>? {
+    TODO("Not yet implemented")
+  }
+}
+
+// This no-op class is used if the DV plugin is not applied
+@Suppress("detekt.TooManyFunctions")
+private class NoOpBuildScanAdapter : BuildScanAdapter {
+  override fun background(p0: Action<in BuildScanAdapter>?) = Unit
+
+  override fun tag(p0: String?) = Unit
+
+  override fun value(p0: String?, p1: String?) = Unit
+
+  override fun link(p0: String?, p1: String?) = Unit
+
+  override fun buildFinished(p0: Action<in BuildResultAdapter>?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun buildScanPublished(p0: Action<in PublishedBuildScanAdapter>?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun setTermsOfUseUrl(p0: String?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun getTermsOfUseUrl(): String? {
+    TODO("Not yet implemented")
+  }
+
+  override fun setTermsOfUseAgree(p0: String?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun getTermsOfUseAgree(): String? {
+    TODO("Not yet implemented")
+  }
+
+  override fun setUploadInBackground(p0: Boolean) {
+    TODO("Not yet implemented")
+  }
+
+  override fun isUploadInBackground(): Boolean {
+    TODO("Not yet implemented")
+  }
+
+  override fun publishAlways() {
+    TODO("Not yet implemented")
+  }
+
+  override fun publishAlwaysIf(p0: Boolean) {
+    TODO("Not yet implemented")
+  }
+
+  override fun publishOnFailure() {
+    TODO("Not yet implemented")
+  }
+
+  override fun publishOnFailureIf(p0: Boolean) {
+    TODO("Not yet implemented")
+  }
+
+  override fun getObfuscation(): BuildScanObfuscationAdapter? {
+    TODO("Not yet implemented")
+  }
+
+  override fun obfuscation(p0: Action<in BuildScanObfuscationAdapter>?) {
+    TODO("Not yet implemented")
+  }
+
+  override fun getCapture(): BuildScanCaptureAdapter? {
+    TODO("Not yet implemented")
+  }
+
+  override fun capture(p0: Action<in BuildScanCaptureAdapter>?) {
+    TODO("Not yet implemented")
+  }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BaseUploadTask.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/base/BaseUploadTask.kt
@@ -17,6 +17,7 @@ import com.emergetools.android.gradle.util.network.EmergeUploadResponse
 import com.emergetools.android.gradle.util.network.SOURCE_GRADLE_PLUGIN
 import com.emergetools.android.gradle.util.network.fetchSignedUrl
 import com.emergetools.android.gradle.util.network.postFile
+import com.gradle.develocity.agent.gradle.adapters.BuildScanAdapter
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -29,6 +30,7 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.work.DisableCachingByDefault
@@ -135,6 +137,9 @@ abstract class BaseUploadTask : DefaultTask() {
   @get:Input
   @get:Optional
   abstract val appModulePath: Property<String>
+
+  @get:Internal
+  abstract val buildScan: Property<BuildScanAdapter>
 
   private lateinit var artifacts: List<ArtifactCollection>
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/Register.kt
@@ -7,6 +7,7 @@ import com.android.build.api.variant.Variant
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.emergetools.android.gradle.EmergePlugin.Companion.EMERGE_TASK_PREFIX
 import com.emergetools.android.gradle.EmergePluginExtension
+import com.emergetools.android.gradle.dv.getBuildScan
 import com.emergetools.android.gradle.tasks.base.BaseUploadTask.Companion.setTagFromProductOptions
 import com.emergetools.android.gradle.tasks.base.BaseUploadTask.Companion.setUploadTaskInputs
 import com.emergetools.android.gradle.util.capitalize
@@ -56,6 +57,7 @@ private fun registerUploadPerfBundleTask(
     it.perfArtifactDir.set(performanceVariant.artifacts.get(SingleArtifact.APK))
     it.setUploadTaskInputs(extension, appProject, appVariant)
     it.setTagFromProductOptions(extension.perfOptions, appVariant)
+    it.buildScan.set(appProject.getBuildScan())
   }
 }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/UploadPerfBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/perf/UploadPerfBundle.kt
@@ -68,12 +68,14 @@ abstract class UploadPerfBundle : BaseUploadTask() {
       )
 
     upload(artifactMetadata) { response ->
+      val url = "https://emergetools.com/performance/compare/${response.uploadId}"
       logger.lifecycle(
         "Performance bundle upload successful! " +
           "View Emerge's performance analysis at the following url:",
       )
-      logger.lifecycle("https://emergetools.com/performance/compare/${response.uploadId}")
+      logger.lifecycle(url)
       logger.lifecycle("Performance testing usually takes around 30 minutes or less.")
+      buildScan.get().link("Emerge Tools Performance", url)
     }
   }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/InitializeReaper.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/InitializeReaper.kt
@@ -53,9 +53,11 @@ abstract class InitializeReaper : BaseUploadTask() {
       )
 
     upload(artifactMetadata) { response ->
+      val url = "https://emergetools.com/reaper/${response.uploadId}"
       logger.lifecycle("Reaper initialized! View Reaper reports for this version at the following url:")
-      logger.lifecycle("https://emergetools.com/reaper/${response.uploadId}")
+      logger.lifecycle(url)
       logger.lifecycle("Note: Initial Reaper processing can take up to 10 minutes.")
+      buildScan.get().link("Emerge Tools Reaper Report", url)
     }
   }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/Register.kt
@@ -4,6 +4,7 @@ import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.Variant
 import com.emergetools.android.gradle.EmergePlugin.Companion.EMERGE_TASK_PREFIX
 import com.emergetools.android.gradle.EmergePluginExtension
+import com.emergetools.android.gradle.dv.getBuildScan
 import com.emergetools.android.gradle.tasks.base.BaseUploadTask.Companion.setTagFromProductOptions
 import com.emergetools.android.gradle.tasks.base.BaseUploadTask.Companion.setUploadTaskInputs
 import com.emergetools.android.gradle.util.capitalize
@@ -64,6 +65,7 @@ private fun registerReaperUploadTask(
       it.publishableApiKey.set(extension.reaperOptions.publishableApiKey)
       it.setUploadTaskInputs(extension, appProject, variant)
       it.setTagFromProductOptions(extension.reaperOptions, variant)
+      it.buildScan.set(appProject.getBuildScan())
     }
   // Hook the bundle tasks to run the reaper upload task after they complete.
   appProject.afterEvaluate { project ->

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/Register.kt
@@ -4,6 +4,7 @@ import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.Variant
 import com.emergetools.android.gradle.EmergePlugin.Companion.EMERGE_TASK_PREFIX
 import com.emergetools.android.gradle.EmergePluginExtension
+import com.emergetools.android.gradle.dv.getBuildScan
 import com.emergetools.android.gradle.tasks.base.BasePreflightTask.Companion.setPreflightTaskInputs
 import com.emergetools.android.gradle.tasks.base.BaseUploadTask.Companion.setTagFromProductOptions
 import com.emergetools.android.gradle.tasks.base.BaseUploadTask.Companion.setUploadTaskInputs
@@ -58,6 +59,7 @@ private fun registerUploadAPKTask(
     it.proguardMapping.set(variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE))
     it.setUploadTaskInputs(extension, appProject, variant)
     it.setTagFromProductOptions(extension.sizeOptions, variant)
+    it.buildScan.set(appProject.getBuildScan())
   }
 }
 
@@ -74,6 +76,7 @@ private fun registerUploadAABTask(
     it.artifact.set(variant.artifacts.get(SingleArtifact.BUNDLE))
     it.setUploadTaskInputs(extension, appProject, variant)
     it.setTagFromProductOptions(extension.sizeOptions, variant)
+    it.buildScan.set(appProject.getBuildScan())
   }
 }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAAB.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAAB.kt
@@ -40,9 +40,11 @@ abstract class UploadAAB : BaseUploadTask() {
       )
 
     upload(artifactMetadata) { response ->
+      val url = "https://emergetools.com/build/${response.uploadId}"
       logger.lifecycle("AAB Upload successful! View Emerge's size analysis at the following url:")
-      logger.lifecycle("https://emergetools.com/build/${response.uploadId}")
+      logger.lifecycle(url)
       logger.lifecycle("Size processing can take up to 10 minutes.")
+      buildScan.get().link("Emerge Tools Size Report", url)
     }
   }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAPK.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/size/UploadAPK.kt
@@ -71,6 +71,7 @@ abstract class UploadAPK : BaseUploadTask() {
       logger.lifecycle("APK Upload successful! View Emerge's size analysis at the following url:")
       logger.lifecycle("https://emergetools.com/build/${response.uploadId}")
       logger.lifecycle("Size processing can take up to 10 minutes.")
+      buildScan.get().link("Emerge Tools Size Report", "https://emergetools.com/build/${response.uploadId}")
     }
   }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
@@ -9,6 +9,7 @@ import com.android.build.api.variant.ScopedArtifacts
 import com.emergetools.android.gradle.EmergePlugin.Companion.BUILD_OUTPUT_DIR_NAME
 import com.emergetools.android.gradle.EmergePlugin.Companion.EMERGE_TASK_PREFIX
 import com.emergetools.android.gradle.EmergePluginExtension
+import com.emergetools.android.gradle.dv.getBuildScan
 import com.emergetools.android.gradle.instrumentation.snapshots.SnapshotsPreviewRuntimeRetentionTransformFactory
 import com.emergetools.android.gradle.tasks.base.ArtifactMetadata
 import com.emergetools.android.gradle.tasks.base.BasePreflightTask.Companion.setPreflightTaskInputs
@@ -187,6 +188,7 @@ private fun registerSnapshotUploadTask(
     it.setUploadTaskInputs(extension, appProject, variant)
     it.setTagFromProductOptions(extension.snapshotOptions, variant)
     it.dependsOn(packageTask)
+    it.buildScan.set(appProject.getBuildScan())
   }
 }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/UploadSnapshotBundle.kt
@@ -108,11 +108,13 @@ abstract class UploadSnapshotBundle : BaseUploadTask() {
         created = Clock.System.now(),
       ),
     ) { response ->
+      val url = "https://emergetools.com/snapshot/${response.uploadId}"
       logger.lifecycle(
         "Snapshot bundle upload successful! View snapshots at the following url:",
       )
-      logger.lifecycle("https://emergetools.com/snapshot/${response.uploadId}")
+      logger.lifecycle(url)
       logger.lifecycle("Snapshot generations usually take ~10 minutes or less.")
+      buildScan.get().link("Emerge Tools Snapshots", url)
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,3 +115,5 @@ tree-printer = "hu.webarticum:tree-printer:3.2.1"
 androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3-android" }
 androidx-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "runtime-android" }
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundation-layout-android" }
+
+develocity-agent-adapters = { module = "com.gradle:develocity-gradle-plugin-adapters", version = "1.0.2" }


### PR DESCRIPTION
This adds a Build Scan Link for easy navigation whenever we log a URL to the console

Example: https://scans.gradle.com/s/wykjydx5yfybo

<img width="881" alt="Screenshot 2025-03-13 at 18 13 02" src="https://github.com/user-attachments/assets/88d415d3-e760-4616-9916-fa998594ab99" />

