### PR TITLE
Add support for ignoring private previews to new plugin preview transform

### DIFF
--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/Register.kt
@@ -42,7 +42,7 @@ fun registerSnapshotTasks(
   registerSnapshotPreflightTask(appProject, extension, variant)
 
   if (appProject.firstPartySnapshotsEnabled) {
-    setupTransformTasks(appProject, variant)
+    setupTransformTasks(appProject, extension, variant)
   } else {
     variant.instrumentation.let { instrumentation ->
       instrumentation.transformClassesWith(
@@ -192,7 +192,11 @@ private fun registerSnapshotUploadTask(
   }
 }
 
-fun setupTransformTasks(appProject: Project, variant: ApplicationVariant) {
+fun setupTransformTasks(
+  appProject: Project,
+  extension: EmergePluginExtension,
+  variant: ApplicationVariant,
+) {
   val artifactType = Attribute.of("artifactType", String::class.java)
   val name = variant.name
 
@@ -231,6 +235,8 @@ fun setupTransformTasks(appProject: Project, variant: ApplicationVariant) {
     )
 
     task.inputDirectory.set(mergeForPreview.flatMap { it.outputDir })
+
+    task.includePrivatePreviews.set(extension.snapshotOptions.includePrivatePreviews)
   }
 }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/FindPreviewsAcrossProjects.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/FindPreviewsAcrossProjects.kt
@@ -4,8 +4,11 @@ import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -20,6 +23,10 @@ abstract class FindPreviewsAcrossProjects : DefaultTask() {
   @get:OutputFile
   abstract val outputFile: RegularFileProperty
 
+  @get:Input
+  @get:Optional
+  abstract val includePrivatePreviews: Property<Boolean>
+
   @TaskAction
   fun findPreviews() {
     val output = outputFile.get().asFile
@@ -28,7 +35,9 @@ abstract class FindPreviewsAcrossProjects : DefaultTask() {
     // Clear any existing content
     output.writeText("")
 
-    val listOfPreviews = inputDirectory.get().asFile.findPreviewMethodsInDirectory().toList()
+    val listOfPreviews = inputDirectory.get().asFile.findPreviewMethodsInDirectory(
+      includePrivatePreviews.getOrElse(true)
+    ).toList()
     output.writeText(Json.encodeToString(listOfPreviews))
   }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/PreviewFiles.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/PreviewFiles.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap
  * 1. First pass: Find custom preview annotations
  * 2. Second pass: Find methods with preview annotations, including custom ones
  */
-fun File.findPreviewMethodsInDirectory(): Sequence<ComposePreviewSnapshotConfig> {
+fun File.findPreviewMethodsInDirectory(includePrivatePreviews: Boolean): Sequence<ComposePreviewSnapshotConfig> {
   // First pass: Find all custom annotation classes that are themselves annotated with @Preview
   val customPreviewAnnotations = findCustomPreviewAnnotationsInDirectory()
 
@@ -21,7 +21,8 @@ fun File.findPreviewMethodsInDirectory(): Sequence<ComposePreviewSnapshotConfig>
       extractPreviewMethodsFromBytes(
         classFile.name,
         classFile.readBytes(),
-        customPreviewAnnotations
+        includePrivatePreviews,
+        customPreviewAnnotations,
       )
     }
 }
@@ -68,6 +69,7 @@ private fun findCustomPreviewAnnotationsInBytes(
 fun extractPreviewMethodsFromBytes(
   fileName: String,
   byteStream: ByteArray,
+  includePrivatePreviews: Boolean,
   customPreviewAnnotations: Map<String, CustomPreviewAnnotation> = emptyMap()
 ): List<ComposePreviewSnapshotConfig> {
   val classReader = ClassReader(byteStream)
@@ -79,7 +81,8 @@ fun extractPreviewMethodsFromBytes(
       fileName,
       classReader.className,
       methodNames,
-      customPreviewAnnotations
+      includePrivatePreviews,
+      customPreviewAnnotations,
     )
 
   classReader.accept(visitor, ClassReader.EXPAND_FRAMES)

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/SnapshotAggregatorClassVisitor.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/SnapshotAggregatorClassVisitor.kt
@@ -23,7 +23,7 @@ class SnapshotAggregatorClassVisitor(
     desc: String,
     signature: String?,
     exceptions: Array<out String>?
-  ): MethodVisitor {
+  ): MethodVisitor? {
     if (!includePrivatePreviews && AccessFlags.PRIVATE.isSet(access)) {
       return super.visitMethod(access, name, desc, signature, exceptions)
     }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/SnapshotAggregatorClassVisitor.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/transform/SnapshotAggregatorClassVisitor.kt
@@ -1,5 +1,6 @@
 package com.emergetools.android.gradle.tasks.snapshots.transform
 
+import org.jf.dexlib2.AccessFlags
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
 
@@ -12,6 +13,7 @@ class SnapshotAggregatorClassVisitor(
   private val fileName: String,
   private val className: String,
   private val methodNames: MutableList<ComposePreviewSnapshotConfig>,
+  private val includePrivatePreviews: Boolean,
   private val customPreviewAnnotations: Map<String, CustomPreviewAnnotation> = emptyMap()
 ) : ClassVisitor(api) {
 
@@ -22,6 +24,10 @@ class SnapshotAggregatorClassVisitor(
     signature: String?,
     exceptions: Array<out String>?
   ): MethodVisitor {
+    if (!includePrivatePreviews && AccessFlags.PRIVATE.isSet(access)) {
+      return super.visitMethod(access, name, desc, signature, exceptions)
+    }
+
     return AnnotatedMethodVisitor(api, name, className, fileName, methodNames, customPreviewAnnotations)
   }
 }


### PR DESCRIPTION
Wires up the existing `includePrivatePreview` extension configuration property with the new first-party/gradle-based Compose preview JSON generation. 

Tested with #533 and worked as-expected!