### PR TITLE
Remove Guava and use single variant publication

### DIFF
--- a/distribution/distribution/build.gradle.kts
+++ b/distribution/distribution/build.gradle.kts
@@ -63,6 +63,11 @@ android {
       wiredWith = GenerateMetaInfVersion::metaInfResDir
     )
   }
+  publishing {
+    singleVariant("release") {
+      withSourcesJar()
+    }
+  }
 }
 
 dependencies {

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -83,9 +83,6 @@ dependencies {
   implementation(libs.asm.commons)
 
   add(shadowedDependencies.name, libs.develocity.agent.adapters)
-  // Needed for the GradleRunner in the functional tests. We've had issues with the version of Guava
-  // from one dependency conflicting with that of dexlib2, so we'll use the same version here.
-  add(shadowedDependencies.name, libs.guava)
   add(shadowedDependencies.name, libs.kotlinx.datetime)
   add(shadowedDependencies.name, libs.kotlinx.serialization)
   add(shadowedDependencies.name, libs.okhttp)

--- a/reaper/reaper/build.gradle.kts
+++ b/reaper/reaper/build.gradle.kts
@@ -30,6 +30,11 @@ android {
   defaultConfig {
     minSdk = 21
   }
+  publishing {
+    singleVariant("release") {
+      withSourcesJar()
+    }
+  }
 
   // Ensures our version.txt is packaged in with release.
   // Will be pulled in automatically to test APK upon build

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -34,6 +34,11 @@ android {
   buildFeatures {
     compose = true
   }
+  publishing {
+    singleVariant("release") {
+      withSourcesJar()
+    }
+  }
 
   // Ensures our version.txt is packaged in with release.
   // Will be pulled in automatically to test APK upon build


### PR DESCRIPTION
This removes guava and configures our libraries for single variant publication since there is no difference between debug and release.
