### PR TITLE
Workaround for bug in BuildConfig lib not allowing us to publish.

### DIFF
--- a/distribution/distribution/build.gradle.kts
+++ b/distribution/distribution/build.gradle.kts
@@ -66,6 +66,7 @@ android {
   publishing {
     singleVariant("release") {
       withSourcesJar()
+      withJavadocJar()
     }
   }
 }

--- a/reaper/reaper/build.gradle.kts
+++ b/reaper/reaper/build.gradle.kts
@@ -33,12 +33,20 @@ android {
   publishing {
     singleVariant("release") {
       withSourcesJar()
+      withJavadocJar()
     }
   }
 
   // Ensures our version.txt is packaged in with release.
   // Will be pulled in automatically to test APK upon build
   sourceSets.getByName("main").resources.srcDir(metaInfResDir)
+}
+
+// Workaround for https://github.com/gmazzo/gradle-buildconfig-plugin/issues/226
+afterEvaluate {
+  tasks.named("sourceReleaseJar").configure {
+    dependsOn(tasks.named("generateNonAndroidBuildConfig"))
+  }
 }
 
 dependencies {

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -37,6 +37,7 @@ android {
   publishing {
     singleVariant("release") {
       withSourcesJar()
+      withJavadocJar()
     }
   }
 


### PR DESCRIPTION
This will fix our snapshot deploy failure: https://github.com/EmergeTools/emerge-android/actions/runs/13987525374/job/39163974567

For more details on the bug see this: https://github.com/gmazzo/gradle-buildconfig-plugin/issues/226

IMO, we should get rid of BuildConfig in the future.
