### PR TITLE
Use library instead of SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [snapshots](./snapshots/README.md) for full documentation.
 
 ## 💀 Reaper
 
-Reaper is an SDK you add to your app to detect dead code. In combination with Emerge's Gradle
+Reaper is a library you add to your app to detect dead code. In combination with Emerge's Gradle
 plugin, Reaper reports class load usages in production, which Emerge uses to detect dead code.
 
 See [reaper](./reaper/README.md) for full documentation.
@@ -56,12 +56,12 @@ See [distribution](./distribution/README.md) for full documentation.
 
 ## Artifacts & versions
 
-| Artifact                                        | Description                                     | Latest                                                                                                                                                                                                               | Min SDK |
-|-------------------------------------------------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `com.emergetools.android`                       | Emerge Gradle Plugin                            | [![Gradle Plugin Portal Version](https://img.shields.io/gradle-plugin-portal/v/com.emergetools.android)](https://plugins.gradle.org/plugin/com.emergetools.android)                                                  | N/A     |
-| `com.emergetools.snapshots:snapshots`           | Snapshot testing SDK                            | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots)             | 23      |
-| `com.emergetools.snapshots:snapshots-annotations` | Snapshots Annotations                         | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots-annotations/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots-annotations) | 23 |
-| `com.emergetools.reaper:reaper`                 | Reaper SDK                                      | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.reaper/reaper/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.reaper/reaper)                         | 21      |
-| `com.emergetools.test:performance`              | Performance testing SDK                         | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.test/performance/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.test/performance)                   | 23      |
-| `com.emergetools.distribution:distribution`     | Build distribution SDK                          | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.distribution/distribution/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.distribution/distribution) | 21      |
+| Artifact                                        | Description                 | Latest                                                                                                                                                                                                               | Min SDK |
+|-------------------------------------------------|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `com.emergetools.android`                       | Emerge Gradle Plugin        | [![Gradle Plugin Portal Version](https://img.shields.io/gradle-plugin-portal/v/com.emergetools.android)](https://plugins.gradle.org/plugin/com.emergetools.android)                                                  | N/A     |
+| `com.emergetools.snapshots:snapshots`           | Snapshot testing library    | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots)             | 23      |
+| `com.emergetools.snapshots:snapshots-annotations` | Snapshots Annotations       | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots-annotations/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots-annotations) | 23 |
+| `com.emergetools.reaper:reaper`                 | Reaper library              | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.reaper/reaper/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.reaper/reaper)                         | 21      |
+| `com.emergetools.test:performance`              | Performance testing library | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.test/performance/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.test/performance)                   | 23      |
+| `com.emergetools.distribution:distribution`     | Build distribution library  | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.distribution/distribution/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.distribution/distribution) | 21      |
 

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -1,15 +1,15 @@
 # 🛰️ Emerge build distribution
 
-Emerge build distribution is an SDK for distributing Beta, Alpha, and test
+Emerge build distribution is a library for distributing Beta, Alpha, and test
 builds.
 
 ## Features
 
 ## Quickstart (~10 min)
 
-### Add build distribution SDK
+### Add build distribution library
 
-Add the Build Distribution SDK to your application's `build.gradle.kts` file:
+Add the Build Distribution library to your application's `build.gradle.kts` file:
 
 ```kotlin
 
@@ -18,7 +18,7 @@ dependencies {
 }
 ```
 
-## Releasing Build Distribution SDK
+## Releasing Build Distribution library
 
 ### Releasing a new version
 

--- a/distribution/distribution/build.gradle.kts
+++ b/distribution/distribution/build.gradle.kts
@@ -123,7 +123,7 @@ publishing {
       }
 
       pom {
-        name.set("Emerge Tools build distribution SDK")
+        name.set("Emerge Tools build distribution library")
         description.set("Distribution for alpha, beta, and test builds.")
         url.set("https://www.emergetools.com")
         licenses {

--- a/distribution/integration/build.gradle.kts
+++ b/distribution/integration/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
   implementation(libs.androidx.navigation.ui.ktx)
   implementation(libs.kotlinx.serialization)
 
-  // Distribution SDK
+  // Distribution library
   implementation(projects.distribution.distribution)
 
   implementation(platform(libs.compose.bom))

--- a/distribution/sample/app/build.gradle.kts
+++ b/distribution/sample/app/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
   implementation(libs.androidx.navigation.ui.ktx)
   implementation(libs.kotlinx.serialization)
 
-  // Distribution SDK
+  // Distribution library
   implementation(projects.distribution.distribution)
 
   implementation(platform(libs.compose.bom))

--- a/gradle-plugin/CHANGELOG.md
+++ b/gradle-plugin/CHANGELOG.md
@@ -60,14 +60,14 @@ Changes since 4.0.4-beta01:
 
 ## 4.0.1 - 2024-10-15
 
-- Support @PreviewParameter annotated params in snapshots. (Requires snapshots SDK 1.3.0-rc01 or
+- Support @PreviewParameter annotated params in snapshots. (Requires snapshots library 1.3.0-rc01 or
   later). [#271](https://github.com/EmergeTools/emerge-android/pull/271)
 - Add `previousSha` field to upload for use with history
   tracking. [#274](https://github.com/EmergeTools/emerge-android/pull/274)
 
 ## 4.0.0 - 2024-08-26
 
-4.0.0 brings support for Reaper, Emerge's SDK to detect dead code at runtime, as well as cleanups,
+4.0.0 brings support for Reaper, Emerge's library to detect dead code at runtime, as well as cleanups,
 bug fixes and pre-flight tasks for all products to check configuration before uploading.
 
 Changes since 4.0.0-rc02:
@@ -82,7 +82,7 @@ Changes since 4.0.0-rc02:
 
 ## 4.0.0-rc02 - 2024-08-14
 
-- Fix reaper preflight check to detect SDK without hooking minify
+- Fix reaper preflight check to detect libraries without hooking minify
   task. [#234](https://github.com/EmergeTools/emerge-android/pull/234)
 
 ## 4.0.0-rc01 - 2024-08-07

--- a/gradle-plugin/plugin/performance-project-template/build.gradle.kts
+++ b/gradle-plugin/plugin/performance-project-template/build.gradle.kts
@@ -1,6 +1,6 @@
 // This is a com.android.test project which is automatically configured by the Emerge Tools Gradle plugin:
 //
-// - The SDK version targets are automatically set to be identical to the app project.
+// - The library version targets are automatically set to be identical to the app project.
 // - The same build types as your app project are automatically created.
 // - Test libraries including UI Automator and Junit and are automatically added as dependencies.
 //
@@ -11,7 +11,7 @@ plugins {
 }
 
 dependencies {
-    // Emerge's Performance Testing SDK (Required):
+    // Emerge's Performance Testing library (Required):
     implementation("com.emergetools.test:performance:2.1.2")
     // Emerge's UIAutomator helper library (Optional): https://github.com/EmergeTools/relax
     implementation("com.emergetools.test:relax:0.1.0")

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/ReaperPreflight.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/reaper/ReaperPreflight.kt
@@ -70,10 +70,10 @@ abstract class ReaperPreflight : DefaultTask() {
       }
     }
 
-    preflight.add("Runtime SDK added") {
+    preflight.add("Runtime Library added") {
       if (!hasReaperImplementationDependency.getOrElse(false)) {
         throw PreflightFailure(
-          "Reaper runtime SDK missing as an implementation dependency. See " +
+          "Reaper runtime library missing as an implementation dependency. See " +
             "https://docs.emergetools.com/docs/reaper-setup-android#install-the-sdk",
         )
       }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/SnapshotsPreflight.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/tasks/snapshots/SnapshotsPreflight.kt
@@ -55,7 +55,7 @@ abstract class SnapshotsPreflight : BasePreflightTask() {
 
     val hasSnapshotsAndroidTestImplementationDependency =
       hasSnapshotsAndroidTestImplementationDependency.getOrElse(false)
-    preflight.add("Snapshots SDK is an androidTestImplementation dependency") {
+    preflight.add("Snapshots library is an androidTestImplementation dependency") {
       if (!hasSnapshotsAndroidTestImplementationDependency) {
         throw PreflightFailure(
           "Snapshots androidTestImplementation dependency not set. See " +

--- a/performance/README.md
+++ b/performance/README.md
@@ -57,7 +57,7 @@ _"Sync Project with Gradle Files" for your IDE to recognize the new subproject._
 
 ### Create your first performance test
 
-Open the newly generated `ExamplePerformanceTest` file. The Emerge SDK provides method annotations
+Open the newly generated `ExamplePerformanceTest` file. The Emerge library provides method annotations
 that work similarly to the JUnit annotations you may be used to:
 
 - `@EmergeTest`/`@EmergeStartupTest` defines performance test methods. Each test method is run

--- a/performance/performance/build.gradle.kts
+++ b/performance/performance/build.gradle.kts
@@ -115,7 +115,7 @@ publishing {
       }
 
       pom {
-        name.set("Emerge Tools Performance Testing SDK")
+        name.set("Emerge Tools Performance Testing Library")
         description.set("Monitor your app's performance")
         url.set("https://www.emergetools.com")
         licenses {

--- a/performance/sample/perfTesting/build.gradle.kts
+++ b/performance/sample/perfTesting/build.gradle.kts
@@ -2,7 +2,7 @@
 //
 // - The SDK version targets are automatically set to be identical to the app project.
 // - The same build types as your app project are automatically created.
-// - Test libraries like UI Automator and the Emerge SDK are automatically added as dependencies.
+// - Test libraries like UI Automator and the Emerge Library are automatically added as dependencies.
 //
 // The configuration can be modified in this file as needed.
 

--- a/reaper/README.md
+++ b/reaper/README.md
@@ -1,6 +1,6 @@
 # 💀 Emerge Reaper
 
-Reaper is an SDK that uses production data for detecting dead code.
+Reaper is a library that uses production data for detecting dead code.
 
 ## Features
 
@@ -47,9 +47,9 @@ found [here](https://emergetools.com/settings?tab=feature-configuration&cards=re
 
 See [gradle-plugin](../gradle-plugin/README.md) for more information.
 
-### Add Reaper SDK
+### Add Reaper Library
 
-Add the Reaper SDK to your application's `build.gradle.kts` file:
+Add the Reaper Library to your application's `build.gradle.kts` file:
 
 ```kotlin
 
@@ -97,7 +97,7 @@ Upon a user backgrounding the application, Emerge will send the list of hashes o
 the Emerge backend. Emerge will then process each report received, marking classes as used if any
 user session reports that class being used.
 
-## Releasing Reaper SDK
+## Releasing Reaper library
 
 ### Releasing a new version
 

--- a/reaper/reaper/build.gradle.kts
+++ b/reaper/reaper/build.gradle.kts
@@ -117,7 +117,7 @@ publishing {
       }
 
       pom {
-        name.set("Emerge Tools Reaper SDK")
+        name.set("Emerge Tools Reaper Library")
         description.set("Detect dead code in production.")
         url.set("https://www.emergetools.com")
         licenses {

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Reaper.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/Reaper.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import okhttp3.OkHttpClient
 
 /**
- * The is the public SDK for Reaper, an Emergetools service which detects and deletes dead code in
+ * The is the public library for Reaper, an Emerge Tools service which detects and deletes dead code in
  * production. Reaper works in three parts:
  * - A gradle plugin which instruments JVM bytecode to detect when code is used.
- * - An SDK (this code) which uploads reports based on that instrumentation.
+ * - A library (this code) which uploads reports based on that instrumentation.
  * - A server side component which aggregates those reports and compares the used code to the
  *   code in the app. Code which is not used by any user but exists in the app is detected,
  *   displayed and can be deleted.
@@ -16,8 +16,8 @@ import okhttp3.OkHttpClient
 object Reaper {
   /**
    * Initialize Reaper. This should be called once in each process. In
-   * addition to calling this method the codebase must be instrumented using the Emergetools
-   * gradle plugin. This method may be called from any thread with a Looper. It is safe to
+   * addition to calling this method the codebase must be instrumented using the Emerge Tools
+   * Gradle Plugin. This method may be called from any thread with a Looper. It is safe to
    * call this from the main thread. Options may be passed if you want to override the default
    * values.
    * @param context Android context

--- a/reaper/sample/app/build.gradle.kts
+++ b/reaper/sample/app/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
   implementation(libs.androidx.navigation.ui.ktx)
   implementation(libs.kotlinx.serialization)
 
-  // Reaper SDK
+  // Reaper library
   implementation(projects.reaper.reaper)
 
   implementation(platform(libs.compose.bom))

--- a/reaper/sample/manuallyInitializedApp/build.gradle.kts
+++ b/reaper/sample/manuallyInitializedApp/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
   implementation(libs.compose.material)
   implementation(libs.androidx.test.core.ktx)
 
-  // Reaper SDK
+  // Reaper library
   implementation(libs.androidx.startup.runtime)
   implementation(projects.reaper.reaper)
 }

--- a/reaper/sample/stress/build.gradle.kts
+++ b/reaper/sample/stress/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
   implementation(libs.androidx.navigation.ui.ktx)
   implementation(libs.kotlinx.serialization)
 
-  // Reaper SDK
+  // Reaper library
   implementation(projects.reaper.reaper)
 
   implementation(platform(libs.compose.bom))

--- a/snapshots/README.md
+++ b/snapshots/README.md
@@ -39,13 +39,13 @@ emerge {
 
 See [gradle-plugin](../gradle-plugin/README.md) for more information.
 
-### Add Snapshots SDK
+### Add Snapshots library
 
-Emerge snapshot SDKs are published to Maven Central and should be added as dependencies to your
+Emerge snapshot libraries are published to Maven Central and should be added as dependencies to your
 app's `build.gradle.kts` file.
 
 Compose `@Preview` snapshot generation relies on a Gradle plugin instrumentation to modify Compose
-Previews to be visible at runtime. Our snapshot SDK can then handle everything else, invoking the
+Previews to be visible at runtime. Our snapshot library can then handle everything else, invoking the
 Compose Preview and saving the resulting snapshot image.
 
 ```kotlin build.gradle.kts (app module)
@@ -78,7 +78,7 @@ The preflight task will give detailed output about the Emerge snapshots integrat
 ╠════════════════════════════════════════════════╝
 ╠═ ✅ Emerge API token set
 ╠═ ✅ Snapshots enabled
-╚═ ✅ Snapshots SDK is an androidTestImplementation dependency
+╚═ ✅ Snapshots library is an androidTestImplementation dependency
 
 ╔═════════════════════════════════════╗
 ║ VCS Info check was successful (4/4) ║
@@ -327,7 +327,7 @@ the [full documentation](https://docs.emergetools.com/docs/android-snapshots-v1)
 
 | Artifact                                          | Description                     | Latest                                                                                                                                                                                                                           | Min SDK |
 |---------------------------------------------------|---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `com.emergetools.snapshots:snapshots`             | Snapshot testing SDK            | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots)                         | 23      |
+| `com.emergetools.snapshots:snapshots`             | Snapshot testing library        | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots)                         | 23      |
 | `com.emergetools.snapshots:snapshots-annotations` | Additional snapshot annotations | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots-annotations/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.emergetools.snapshots/snapshots-annotations) | 23      |
 
 ## Releasing

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -115,7 +115,7 @@ publishing {
       }
 
       pom {
-        name.set("Emerge Tools Snapshots SDK")
+        name.set("Emerge Tools Snapshots Library")
         description.set("Snapshot Composables, views and activities.")
         url.set("https://www.emergetools.com")
         licenses {


### PR DESCRIPTION
SDK implies something that is built against but our libraries do not
require developers to build anything against these. Using the word
library should clarify this.
