### PR TITLE
Remove workaround for BuildConfig plugin issue.

### DIFF
--- a/reaper/reaper/build.gradle.kts
+++ b/reaper/reaper/build.gradle.kts
@@ -42,13 +42,6 @@ android {
   sourceSets.getByName("main").resources.srcDir(metaInfResDir)
 }
 
-// Workaround for https://github.com/gmazzo/gradle-buildconfig-plugin/issues/226
-afterEvaluate {
-  tasks.named("sourceReleaseJar").configure {
-    dependsOn(tasks.named("generateNonAndroidBuildConfig"))
-  }
-}
-
 dependencies {
   implementation(libs.kotlinx.serialization)
   implementation(libs.okhttp)


### PR DESCRIPTION
https://github.com/gmazzo/gradle-buildconfig-plugin/issues/226
This was a fast fix, since I just filed the bug last week.
