### PR TITLE
Use Moshi instead of KotlinX Serialization

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ foundation-layout-android = "1.7.6"
 emerge-gradle-plugin = "4.3.2-SNAPSHOT"
 emerge-performance = "2.1.2"
 emerge-reaper = "1.0.2-SNAPSHOT"
-emerge-snapshots = "1.4.1-moshi-SNAPSHOT"
+emerge-snapshots = "1.4.1-SNAPSHOT"
 emerge-distribution = "0.0.5-SNAPSHOT"
 annotation-jvm = "1.9.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ junit = "1.2.1"
 benchmark-junit4 = "1.3.4"
 mockito = "5.17.0"
 mockito-kotlin = "5.4.0"
+moshi = "1.15.2"
 material3-android = "1.3.2"
 runtime-android = "1.7.6"
 foundation-layout-android = "1.7.6"
@@ -90,6 +91,10 @@ compose-wear-ui-tooling = { module = "androidx.wear.compose:compose-ui-tooling",
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 
 google-truth = "com.google.truth:truth:1.4.4"
+
+moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
+moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi" }
+moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 
 junit4 = "junit:junit:4.13.2"
 junit5-bom = { module = "org.junit:junit-bom", version.ref = "junit-jupiter" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ foundation-layout-android = "1.7.6"
 emerge-gradle-plugin = "4.3.2-SNAPSHOT"
 emerge-performance = "2.1.2"
 emerge-reaper = "1.0.2-SNAPSHOT"
-emerge-snapshots = "1.4.1-SNAPSHOT"
+emerge-snapshots = "1.4.1-moshi-SNAPSHOT"
 emerge-distribution = "0.0.5-SNAPSHOT"
 annotation-jvm = "1.9.1"
 

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.grgit)
   alias(libs.plugins.kotlin.android)
-  alias(libs.plugins.kotlin.serialization)
   `maven-publish`
   signing
 }
@@ -49,7 +48,9 @@ android {
 dependencies {
 
   implementation(libs.junit4)
-  implementation(libs.kotlinx.serialization)
+  implementation(libs.moshi)
+  implementation(libs.moshi.kotlin)
+  implementation(libs.moshi.adapters)
 
   implementation(platform(libs.compose.bom))
   implementation(libs.compose.runtime)

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotImageMetadata.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/SnapshotImageMetadata.kt
@@ -1,25 +1,18 @@
 package com.emergetools.snapshots
 
 import com.emergetools.snapshots.models.ComposePreviewSnapshotConfig
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonClassDiscriminator
 
 enum class SnapshotErrorType {
   EMPTY_SNAPSHOT,
   GENERAL,
 }
 
-@OptIn(ExperimentalSerializationApi::class)
-@Serializable
-@JsonClassDiscriminator("metadataType")
 sealed class SnapshotMetadata {
   abstract val name: String
   abstract val displayName: String?
   abstract val fqn: String
   abstract val composePreviewSnapshotConfig: ComposePreviewSnapshotConfig
 
-  @Serializable
   internal class SuccessMetadata(
     // Used as the primary key
     override val name: String,
@@ -33,7 +26,6 @@ sealed class SnapshotMetadata {
     override val composePreviewSnapshotConfig: ComposePreviewSnapshotConfig,
   ) : SnapshotMetadata()
 
-  @Serializable
   internal class ErrorMetadata(
     // Used as the primary key
     override val name: String,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/models/ComposePreviewSnapshotConfig.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/models/ComposePreviewSnapshotConfig.kt
@@ -1,10 +1,7 @@
 package com.emergetools.snapshots.models
 
-import kotlinx.serialization.Serializable
-
 // Keep parity with
 // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui-tooling-preview/src/androidMain/kotlin/androidx/compose/ui/tooling/preview/Preview.kt
-@Serializable
 data class ComposePreviewSnapshotConfig(
   val fullyQualifiedClassName: String,
   val originalFqn: String,
@@ -75,7 +72,6 @@ data class ComposePreviewSnapshotConfig(
   }
 }
 
-@Serializable
 data class PreviewParameter(
   val parameterName: String,
   val providerClassFqn: String,

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/models/ComposeSnapshots.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/models/ComposeSnapshots.kt
@@ -1,8 +1,5 @@
 package com.emergetools.snapshots.models
 
-import kotlinx.serialization.Serializable
-
-@Serializable
 data class ComposeSnapshots(
   val snapshots: List<ComposePreviewSnapshotConfig>,
 )


### PR DESCRIPTION
The tricky replacement was the sealed class which was handled by the `JsonClassDiscriminatorin` KotlinX Serialization. I used moshi's `PolymorphicJsonAdapterFactory` to replace that. The produced JSON should be the same.