### PR TITLE
[DNM] Use proguard on release package to relocate kotlinx

### DIFF
--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -40,6 +40,12 @@ android {
       withJavadocJar()
     }
   }
+  buildTypes {
+    release {
+      isMinifyEnabled = true
+      proguardFiles(getDefaultProguardFile("proguard-android.txt"), "rules.pro")
+    }
+  }
 
   // Ensures our version.txt is packaged in with release.
   // Will be pulled in automatically to test APK upon build

--- a/snapshots/snapshots/rules.pro
+++ b/snapshots/snapshots/rules.pro
@@ -1,0 +1,10 @@
+-repackageclasses com.emergetools.snapshots
+
+-keep class androidx.compose.runtime.Composable
+-keepclassmembers class * {
+    @androidx.compose.runtime.Composable *;
+}
+
+-keep class com.emergetools.snapshots.** { *; }
+
+-dontwarn java.lang.invoke.**


### PR DESCRIPTION
DNM, this doesn’t work since dependencies are not included in the aar.