### PR TITLE
Remove deprecated devices.

### DIFF
--- a/.github/workflows/reaper-checks.yml
+++ b/.github/workflows/reaper-checks.yml
@@ -57,9 +57,9 @@ jobs:
             --test reaper/sample/stress/build/outputs/apk/androidTest/debug/stress-debug-androidTest.apk \
             --device model=redfin,version=30,locale=en,orientation=portrait  \
             --device model=b0q,version=33,locale=en,orientation=portrait  \
-            --device model=Nexus6P,version=26,locale=en,orientation=portrait \
+            --device model=caiman,version=34,locale=en,orientation=portrait \
             --device model=HWMHA,version=24,locale=en,orientation=portrait \
-            --device model=Nexus6,version=25,locale=en,orientation=portrait \
+            --device model=SmallPhone.arm,version=26,locale=en,orientation=portrait \
 
   minsdk-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See failing test here: https://github.com/EmergeTools/emerge-android/actions/runs/14834970401/job/41645969870?pr=595

As well as the list of deprecated devices here: https://firebase.google.com/docs/test-lab/android/available-testing-devices#deprecated
