### PR TITLE
Revert "Add placeholder"

### DIFF
--- a/reaper/reaper/build.gradle.kts
+++ b/reaper/reaper/build.gradle.kts
@@ -28,11 +28,8 @@ android {
   }
 
   defaultConfig {
-    manifestPlaceholders.put("emerge.reaper.instrumented", false)
-    manifestPlaceholders.put("emerge.reaper.publishableApiKey", "")
     minSdk = 21
   }
-
   publishing {
     singleVariant("release") {
       withSourcesJar()


### PR DESCRIPTION
This does not seem to work when installed as a dependency.

This reverts commit aa212e357fccc7bb1918d95272874dd8a2219324.
