### PR TITLE
Disable configuration cache to enable publishing to maven central.

### DIFF
--- a/.github/workflows/distribution-release.yml
+++ b/.github/workflows/distribution-release.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Sanity check distribution test
-        run: ./gradlew :distribution:distribution:test :distribution:distribution:publishToMavenCentral -Dorg.gradle.parallel=false
+        run: ./gradlew :distribution:distribution:test :distribution:distribution:publishToMavenCentral -Dorg.gradle.parallel=false --no-configuration-cache

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Deploy plugin
         run: ./gradlew :gradle-plugin:plugin:publishPlugins
       - name: Deploy plugin to maven central
-        run: ./gradlew :gradle-plugin:plugin:publishToMavenCentral
+        run: ./gradlew :gradle-plugin:plugin:publishToMavenCentral --no-configuration-cache

--- a/.github/workflows/performance-release.yml
+++ b/.github/workflows/performance-release.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Sanity check performance test
-        run: ./gradlew :performance:performance:test :performance:performance:publishToMavenCentral -Dorg.gradle.parallel=false
+        run: ./gradlew :performance:performance:test :performance:performance:publishToMavenCentral -Dorg.gradle.parallel=false --no-configuration-cache

--- a/.github/workflows/reaper-release.yml
+++ b/.github/workflows/reaper-release.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Test and publish Reaper
-        run: ./gradlew :reaper:reaper:test :reaper:reaper:publishToMavenCentral -Dorg.gradle.parallel=false
+        run: ./gradlew :reaper:reaper:test :reaper:reaper:publishToMavenCentral -Dorg.gradle.parallel=false --no-configuration-cache

--- a/.github/workflows/snapshots-release.yml
+++ b/.github/workflows/snapshots-release.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Sanity check snapshots test
         run: ./gradlew :snapshots:snapshots:test
       - name: Deploy snapshots-runtime, snapshots
-        run: ./gradlew :snapshots:snapshots-runtime:publishToMavenCentral :snapshots:snapshots:publishToMavenCentral -Dorg.gradle.parallel=false
+        run: ./gradlew :snapshots:snapshots-runtime:publishToMavenCentral :snapshots:snapshots:publishToMavenCentral -Dorg.gradle.parallel=false --no-configuration-cache


### PR DESCRIPTION
Seems like snapshots should work with configuration cache but releases
will not. https://vanniktech.github.io/gradle-maven-publish-plugin/central/#uploading-with-manual-publishing

This should hopefully fix this error: https://github.com/EmergeTools/emerge-android/actions/runs/16035916230/job/45247535472