### PR TITLE
Bump Kotlin Version to 2.2.0

### DIFF
--- a/distribution/distribution/build.gradle.kts
+++ b/distribution/distribution/build.gradle.kts
@@ -50,7 +50,7 @@ android {
 
   kotlinOptions {
     jvmTarget = JavaVersion.VERSION_11.toString()
-    languageVersion = "1.7"
+    languageVersion = "1.9"
   }
 
   defaultConfig {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ androidxactivity = "1.10.1"
 # https://android-review.googlesource.com/c/platform/frameworks/support/+/2692852/37/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/internal/ComposableLambda.kt#625
 compose-bom = "2024.08.00"
 detekt = "1.23.8"
-kotlin = "2.1.21"
+kotlin = "2.2.0"
 kotlin-coroutines = "1.10.2"
 okhttp = "4.12.0"
 junit-jupiter = "5.13.2"


### PR DESCRIPTION
This also bumps the Kotlin Language version to the minimum
non-deprecated version. 1.7 was deprecated and no longer compiles.

https://github.com/EmergeTools/emerge-android/actions/runs/15826476305/job/44607878473?pr=622
