### PR TITLE
Bump vanniktech to allow publishing of snapshots and non-snapshots in same project.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ detekt = "1.23.8"
 kotlin = "2.1.21"
 kotlin-coroutines = "1.10.2"
 okhttp = "4.12.0"
-junit-jupiter = "5.13.2"
+junit-jupiter = "5.13.3"
 benchmark = "1.3.4"
 junit = "1.2.1"
 benchmark-junit4 = "1.3.4"
@@ -51,7 +51,7 @@ gradle-publish = { id = "com.gradle.plugin-publish", version = "1.3.1" }
 grgit = { id = "org.ajoberstar.grgit", version = "5.3.2" }
 autonomousapps-testkit = { id = "com.autonomousapps.testkit", version = "0.13" }
 gr8 = { id = "com.gradleup.gr8", version = "0.11.2" }
-vanniktech-publish = { id = "com.vanniktech.maven.publish", version = "0.33.0" }
+vanniktech-publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }


### PR DESCRIPTION
This resolves the issue of publishing different versions and mixing
snapshots and non-snapshots:
https://github.com/vanniktech/gradle-maven-publish-plugin/issues/728
