### PR TITLE
feat(snapshots): Add screenheightdp screenwidthdp to localconfiguration

### DIFF
--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/WindowInfoPreview.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/WindowInfoPreview.kt
@@ -1,0 +1,35 @@
+package com.emergetools.snapshots.sample.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun WindowInfoDisplay() {
+  val configuration = LocalConfiguration.current
+
+  Column(modifier = Modifier.padding(16.dp)) {
+    Text("LocalConfiguration.screenWidthDp:  ${configuration.screenWidthDp}dp")
+    Text("LocalConfiguration.screenHeightDp: ${configuration.screenHeightDp}dp")
+  }
+}
+
+// Validates that LocalConfiguration.screenWidthDp/screenHeightDp reflect the virtual device
+// dimensions (1480x1080dp) rather than the real device's dimensions.
+@Preview(
+  name = "WindowInfo - 1480x1080dp tablet",
+  device = "spec:width=1480dp,height=1080dp,dpi=240",
+  showBackground = true,
+)
+@Composable
+fun WindowInfoDisplayPreview() {
+  Surface {
+    WindowInfoDisplay()
+  }
+}

--- a/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/WindowInfoPreview.kt
+++ b/snapshots/sample/app/src/main/kotlin/com/emergetools/snapshots/sample/ui/WindowInfoPreview.kt
@@ -10,18 +10,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
-@Composable
-fun WindowInfoDisplay() {
-  val configuration = LocalConfiguration.current
-
-  Column(modifier = Modifier.padding(16.dp)) {
-    Text("LocalConfiguration.screenWidthDp:  ${configuration.screenWidthDp}dp")
-    Text("LocalConfiguration.screenHeightDp: ${configuration.screenHeightDp}dp")
-  }
-}
-
-// Validates that LocalConfiguration.screenWidthDp/screenHeightDp reflect the virtual device
-// dimensions (1480x1080dp) rather than the real device's dimensions.
 @Preview(
   name = "WindowInfo - 1480x1080dp tablet",
   device = "spec:width=1480dp,height=1080dp,dpi=240",
@@ -30,6 +18,11 @@ fun WindowInfoDisplay() {
 @Composable
 fun WindowInfoDisplayPreview() {
   Surface {
-    WindowInfoDisplay()
+    val configuration = LocalConfiguration.current
+
+    Column(modifier = Modifier.padding(16.dp)) {
+      Text("LocalConfiguration.screenWidthDp:  ${configuration.screenWidthDp}dp")
+      Text("LocalConfiguration.screenHeightDp: ${configuration.screenHeightDp}dp")
+    }
   }
 }

--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/SnapshotVariantProvider.kt
@@ -49,6 +49,8 @@ fun SnapshotVariantProvider(
     config.uiMode?.let { uiMode = it }
     setLocale(locale)
     setLayoutDirection(locale)
+    deviceSpec?.widthDp?.let { screenWidthDp = it }
+    deviceSpec?.heightDp?.let { screenHeightDp = it }
     parseDevicePreviewString(config.device)?.orientation?.let {
       orientation = when (it) {
         "landscape" -> Configuration.ORIENTATION_LANDSCAPE


### PR DESCRIPTION
Adds `screenwidthdp`/`screenheigthdp` to LocalConfiguration for use within snapshots.