### PR TITLE
Avoid leaking preview activities in snapshots

### DIFF
--- a/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
+++ b/snapshots/snapshots/src/main/kotlin/com/emergetools/snapshots/compose/ComposeSnapshotter.kt
@@ -16,6 +16,7 @@ import com.emergetools.snapshots.SnapshotErrorType
 import com.emergetools.snapshots.compose.previewparams.PreviewParamUtils
 import com.emergetools.snapshots.models.ComposePreviewSnapshotConfig
 import com.emergetools.snapshots.util.Profiler
+import java.lang.ref.WeakReference
 
 @Suppress("TooGenericExceptionCaught")
 fun snapshotComposable(
@@ -24,20 +25,11 @@ fun snapshotComposable(
   previewConfig: ComposePreviewSnapshotConfig,
 ) {
   activity.runOnUiThread {
-    val priorExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
-    Thread.setDefaultUncaughtExceptionHandler { t, e ->
-      Log.e(
-        EmergeComposeSnapshotReflectiveParameterizedInvoker.TAG,
-        "Uncaught exception in UI thread",
-        e
-      )
-      snapshotRule.saveError(
-        errorType = SnapshotErrorType.GENERAL,
-        composePreviewSnapshotConfig = previewConfig
-      )
-      priorExceptionHandler?.uncaughtException(t, e)
-      activity.finish()
-    }
+    SnapshotExceptionHandler.installOrUpdate(
+      activity = activity,
+      snapshotRule = snapshotRule,
+      previewConfig = previewConfig,
+    )
   }
 
   Profiler.startSpan("snapshotComposable")
@@ -61,6 +53,70 @@ fun snapshotComposable(
     throw e
   } finally {
     Profiler.endSpan()
+  }
+}
+
+private class SnapshotExceptionHandler(
+  private val priorExceptionHandler: Thread.UncaughtExceptionHandler?,
+) : Thread.UncaughtExceptionHandler {
+  @Volatile
+  private var activity = WeakReference<PreviewActivity>(null)
+
+  @Volatile
+  private var snapshotRule: EmergeSnapshots? = null
+
+  @Volatile
+  private var previewConfig: ComposePreviewSnapshotConfig? = null
+
+  fun update(
+    activity: PreviewActivity,
+    snapshotRule: EmergeSnapshots,
+    previewConfig: ComposePreviewSnapshotConfig,
+  ) {
+    this.activity = WeakReference(activity)
+    this.snapshotRule = snapshotRule
+    this.previewConfig = previewConfig
+  }
+
+  override fun uncaughtException(t: Thread, e: Throwable) {
+    Log.e(
+      EmergeComposeSnapshotReflectiveParameterizedInvoker.TAG,
+      "Uncaught exception in UI thread",
+      e
+    )
+
+    val snapshotRule = snapshotRule
+    val previewConfig = previewConfig
+    if (snapshotRule != null && previewConfig != null) {
+      snapshotRule.saveError(
+        errorType = SnapshotErrorType.GENERAL,
+        composePreviewSnapshotConfig = previewConfig
+      )
+    }
+
+    priorExceptionHandler?.uncaughtException(t, e)
+    activity.get()?.finish()
+  }
+
+  companion object {
+    fun installOrUpdate(
+      activity: PreviewActivity,
+      snapshotRule: EmergeSnapshots,
+      previewConfig: ComposePreviewSnapshotConfig,
+    ) {
+      val currentExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
+      val snapshotExceptionHandler =
+        currentExceptionHandler as? SnapshotExceptionHandler
+          ?: SnapshotExceptionHandler(currentExceptionHandler).also {
+            Thread.setDefaultUncaughtExceptionHandler(it)
+          }
+
+      snapshotExceptionHandler.update(
+        activity = activity,
+        snapshotRule = snapshotRule,
+        previewConfig = previewConfig,
+      )
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

This changes the Compose snapshot uncaught-exception handling so each preview no longer installs a new default handler that captures the current `PreviewActivity` and chains to the previous handler.

Instead, snapshots install a reusable handler and update it with the current snapshot context. The handler keeps the activity through a `WeakReference`, which prevents a long snapshot run from retaining every previous preview activity while preserving the existing error-saving behavior for UI-thread exceptions.

## Root cause

`snapshotComposable` was calling `Thread.setDefaultUncaughtExceptionHandler` for every preview. The lambda captured the current `PreviewActivity`, `snapshotRule`, and `previewConfig`, then delegated to the prior default handler. Since the prior handler was usually the handler installed for the previous preview, long runs built a linked chain that retained every prior `PreviewActivity`.

## Validation

- `./gradlew :snapshots:snapshots:detekt :snapshots:snapshots:testDebugUnitTest :snapshots:snapshots:assembleDebug --console=plain`
