### PR TITLE
Look up Develocity extension on the local project for Isolated Projects compatibility

### DIFF
--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/IsolatedProjectsTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/IsolatedProjectsTest.kt
@@ -1,0 +1,32 @@
+package com.emergetools.android.gradle
+
+import com.autonomousapps.kit.truth.TestKitTruth.Companion.assertThat
+import com.emergetools.android.gradle.base.EmergeGradleRunner2
+import com.emergetools.android.gradle.projects.SimpleGradleProject
+import org.junit.jupiter.api.Test
+
+class IsolatedProjectsTest : EmergePluginTest() {
+  @Test
+  fun uploadAabUnderIsolatedProjectsWithDevelocity() {
+    val project = SimpleGradleProject.createWithVcsInExtension(
+      this,
+      agpVersion = "8.9.0",
+      develocityVersion = "4.1.1",
+    )
+
+    val result = EmergeGradleRunner2(project.gradleProject.rootDir)
+      .withArguments(
+        ":app:emergeUploadReleaseAab",
+        "-x", ":app:lintVitalRelease",
+        "-Dorg.gradle.unsafe.isolated-projects=true",
+        "-PbaseUrl=$baseUrl",
+      )
+      .build()
+
+    // A successful build under -Dorg.gradle.unsafe.isolated-projects=true is
+    // already proof that no Isolated Projects violations were emitted. IP
+    // violations fail the configuration cache, which makes runner.build()
+    // throw UnexpectedBuildFailure before reaching this point.
+    assertThat(result).task(":app:emergeUploadReleaseAab").succeeded()
+  }
+}

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/projects/AbstractAndroidProject.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/projects/AbstractAndroidProject.kt
@@ -13,7 +13,10 @@ abstract class AbstractAndroidProject(private val baseUrl: String) : AbstractGra
     val LOWEST_SUPPORTED_ANDROID_GRADLE_PLUGIN_VERSION = "8.0.0"
   }
 
-  protected fun newAndroidGradleProjectBuilder(agpVersion: String) : GradleProject.Builder{
+  protected fun newAndroidGradleProjectBuilder(
+    agpVersion: String,
+    develocityVersion: String? = null,
+  ) : GradleProject.Builder{
     return newGradleProjectBuilder()
       .withRootProject {
         gradleProperties += GradleProperties.minimalAndroidProperties()
@@ -21,12 +24,31 @@ abstract class AbstractAndroidProject(private val baseUrl: String) : AbstractGra
         withBuildScript {
           buildscript = BuildscriptBlock.defaultAndroidBuildscriptBlock(agpVersion)
         }
+        if (develocityVersion != null) {
+          withSettingsScript {
+            plugins(Plugin("com.gradle.develocity", develocityVersion))
+            additions = """
+              develocity {
+                buildScan {
+                  publishing.onlyIf { true }
+                  termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+                  termsOfUseAgree = 'yes'
+                  uploadInBackground = false
+                }
+              }
+            """.trimIndent()
+          }
+        }
       }
   }
 
 
-  protected fun newAppSubproject(agpVersion: String, extension: String): GradleProject.Builder {
-    return newAndroidGradleProjectBuilder(agpVersion)
+  protected fun newAppSubproject(
+    agpVersion: String,
+    extension: String,
+    develocityVersion: String? = null,
+  ): GradleProject.Builder {
+    return newAndroidGradleProjectBuilder(agpVersion, develocityVersion)
       .withAndroidSubproject("app") {
         withBuildScript {
           plugins(Plugin("com.android.application"), Plugin("com.emergetools.android", PLUGIN_UNDER_TEST_VERSION))

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/projects/SimpleGradleProject.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/com/emergetools/android/gradle/projects/SimpleGradleProject.kt
@@ -6,13 +6,15 @@ import com.emergetools.android.gradle.EmergePluginTest
 class SimpleGradleProject(
   agpVersion: String,
   baseUrl: String,
-  private val emergeExtension: String
+  private val emergeExtension: String,
+  private val develocityVersion: String?,
 ) : AbstractAndroidProject(baseUrl) {
 
   companion object {
     fun createWithVcsInExtension(
       test: EmergePluginTest,
       agpVersion: String = LOWEST_SUPPORTED_ANDROID_GRADLE_PLUGIN_VERSION,
+      develocityVersion: String? = null,
     ): SimpleGradleProject = createWithExtension(
       test, agpVersion, """
             emerge {
@@ -27,7 +29,8 @@ class SimpleGradleProject(
                    repoName = 'repoName'
                  }
                }
-            }""".trimMargin()
+            }""".trimMargin(),
+      develocityVersion = develocityVersion,
     )
 
     fun createWithoutVcsInExtension(
@@ -43,16 +46,17 @@ class SimpleGradleProject(
     fun createWithExtension(
       test: EmergePluginTest,
       agpVersion: String = LOWEST_SUPPORTED_ANDROID_GRADLE_PLUGIN_VERSION,
-      extension: String
+      extension: String,
+      develocityVersion: String? = null,
     ): SimpleGradleProject {
-      return SimpleGradleProject(agpVersion, test.baseUrl.toString(), extension)
+      return SimpleGradleProject(agpVersion, test.baseUrl.toString(), extension, develocityVersion)
     }
   }
 
   val gradleProject: GradleProject = build(agpVersion)
 
   private fun build(agpVersion: String): GradleProject {
-    return newAppSubproject(agpVersion, emergeExtension).build()
+    return newAppSubproject(agpVersion, emergeExtension, develocityVersion).build()
         .write()
   }
 }

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/dv/DvHelpers.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/dv/DvHelpers.kt
@@ -7,20 +7,14 @@ import com.gradle.develocity.agent.gradle.adapters.BuildScanObfuscationAdapter
 import com.gradle.develocity.agent.gradle.adapters.DevelocityAdapter
 import com.gradle.develocity.agent.gradle.adapters.PublishedBuildScanAdapter
 import com.gradle.develocity.agent.gradle.adapters.develocity.DevelocityConfigurationAdapter
-import com.gradle.develocity.agent.gradle.adapters.enterprise.GradleEnterpriseExtensionAdapter
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.caching.configuration.AbstractBuildCache
 
 private fun Project.createDevelocityAdapter(): DevelocityAdapter {
-  rootProject.extensions.findByName("develocity")?.let {
-    return DevelocityConfigurationAdapter(it)
-  }
-
-  rootProject.extensions.findByName("gradleEnterprise")?.let {
-    return GradleEnterpriseExtensionAdapter(it)
-  }
-  return NoOpDevelocityAdapter()
+  return extensions.findByName("develocity")
+    ?.let { DevelocityConfigurationAdapter(it) }
+    ?: NoOpDevelocityAdapter()
 }
 
 fun Project.getBuildScan(): BuildScanAdapter {


### PR DESCRIPTION
The Develocity plugin (applied at `Settings`) registers the `develocity` extension on every project via an Isolated-Projects-safe `beforeProject` action, so subprojects can find it without accessing `rootProject`.

Drops the legacy `com.gradle.enterprise` plugin fallback. The `rootProject.extensions.findByName("gradleEnterprise")` never actually worked because the Gradle Enterprise plugin is also only registered on settings and does not apply the extension to any projects.

This plus #691 will close #687