### PR TITLE
Bump JDK from 17 to 21

### DIFF
--- a/.github/workflows/distribution-checks.yml
+++ b/.github/workflows/distribution-checks.yml
@@ -26,10 +26,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -66,10 +66,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/distribution-release.yml
+++ b/.github/workflows/distribution-release.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/distribution-snapshot-deploy.yml
+++ b/.github/workflows/distribution-snapshot-deploy.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/gradle-plugin-checks.yml
+++ b/.github/workflows/gradle-plugin-checks.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Check

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/gradle-plugin-snapshot-deploy.yml
+++ b/.github/workflows/gradle-plugin-snapshot-deploy.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/integration-hackernews.yml
+++ b/.github/workflows/integration-hackernews.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build hackernews with Emerge Android as included build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Run Detekt

--- a/.github/workflows/performance-checks.yml
+++ b/.github/workflows/performance-checks.yml
@@ -26,7 +26,7 @@ jobs:
 #        uses: actions/setup-java@v4
 #        with:
 #          distribution: 'adopt'
-#          java-version: 17
+#          java-version: 21
 #      - name: Run build
 #        run: ./gradlew :performance:performance:build
 
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Run unit tests

--- a/.github/workflows/performance-release.yml
+++ b/.github/workflows/performance-release.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/reaper-checks.yml
+++ b/.github/workflows/reaper-checks.yml
@@ -26,10 +26,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -72,10 +72,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/reaper-release.yml
+++ b/.github/workflows/reaper-release.yml
@@ -19,10 +19,10 @@ jobs:
       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/reaper-snapshot-deploy.yml
+++ b/.github/workflows/reaper-snapshot-deploy.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/snapshots-checks.yml
+++ b/.github/workflows/snapshots-checks.yml
@@ -26,7 +26,7 @@ jobs:
 #        uses: actions/setup-java@v4
 #        with:
 #          distribution: 'adopt'
-#          java-version: 17
+#          java-version: 21
 #      - name: Run build
 #        run: ./gradlew :snapshots:snapshots:build
 
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Run unit tests

--- a/.github/workflows/snapshots-release.yml
+++ b/.github/workflows/snapshots-release.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "adopt"
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/snapshots-sample-app.yml
+++ b/.github/workflows/snapshots-sample-app.yml
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/snapshots-snapshot-deploy.yml
+++ b/.github/workflows/snapshots-snapshot-deploy.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/distribution/integration/build.gradle.kts
+++ b/distribution/integration/build.gradle.kts
@@ -39,12 +39,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+    jvmTarget = JavaVersion.VERSION_21.toString()
   }
 
   buildFeatures {

--- a/distribution/sample/app/build.gradle.kts
+++ b/distribution/sample/app/build.gradle.kts
@@ -39,12 +39,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+    jvmTarget = JavaVersion.VERSION_21.toString()
   }
 
   buildFeatures {

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -20,7 +20,7 @@ version = libs.versions.emerge.gradle.plugin.get()
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(21)
   }
   withJavadocJar()
   withSourcesJar()
@@ -28,7 +28,7 @@ java {
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_17)
+    jvmTarget.set(JvmTarget.JVM_21)
   }
 }
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/PropertyUtils.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/PropertyUtils.kt
@@ -5,4 +5,4 @@ import org.gradle.api.provider.Property
 
 internal inline fun <reified T : Any> ObjectFactory.property(): Property<T> = property(T::class.javaObjectType)
 
-internal fun <T> Property<T>.orEmpty() = orNull ?: ""
+internal fun <T : Any> Property<T>.orEmpty() = orNull ?: ""

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitBaseShaValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitBaseShaValueSource.kt
@@ -7,7 +7,7 @@ import org.gradle.api.provider.ValueSourceParameters.None
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
-abstract class GitBaseShaValueSource : ValueSource<String?, None> {
+abstract class GitBaseShaValueSource : ValueSource<String, None> {
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitCurrentBranchValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitCurrentBranchValueSource.kt
@@ -6,7 +6,7 @@ import org.gradle.api.provider.ValueSourceParameters.None
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
-abstract class GitCurrentBranchValueSource : ValueSource<String?, None> {
+abstract class GitCurrentBranchValueSource : ValueSource<String, None> {
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubPrNumberValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubPrNumberValueSource.kt
@@ -6,7 +6,7 @@ import org.gradle.api.provider.ValueSourceParameters.None
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
-abstract class GitHubPrNumberValueSource : ValueSource<String?, None> {
+abstract class GitHubPrNumberValueSource : ValueSource<String, None> {
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoNameValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoNameValueSource.kt
@@ -6,7 +6,7 @@ import org.gradle.api.provider.ValueSourceParameters.None
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
-abstract class GitHubRepoNameValueSource : ValueSource<String?, None> {
+abstract class GitHubRepoNameValueSource : ValueSource<String, None> {
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoOwnerValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitHubRepoOwnerValueSource.kt
@@ -6,7 +6,7 @@ import org.gradle.api.provider.ValueSourceParameters.None
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
-abstract class GitHubRepoOwnerValueSource : ValueSource<String?, None> {
+abstract class GitHubRepoOwnerValueSource : ValueSource<String, None> {
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitPreviousShaValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitPreviousShaValueSource.kt
@@ -7,7 +7,7 @@ import org.gradle.api.provider.ValueSourceParameters.None
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
-abstract class GitPreviousShaValueSource : ValueSource<String?, None> {
+abstract class GitPreviousShaValueSource : ValueSource<String, None> {
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitShaValueSource.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/providers/GitShaValueSource.kt
@@ -7,7 +7,7 @@ import org.gradle.api.provider.ValueSourceParameters.None
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
-abstract class GitShaValueSource : ValueSource<String?, None> {
+abstract class GitShaValueSource : ValueSource<String, None> {
   @get:Inject
   abstract val execOperations: ExecOperations
 

--- a/performance/sample/app/build.gradle.kts
+++ b/performance/sample/app/build.gradle.kts
@@ -68,12 +68,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+    jvmTarget = JavaVersion.VERSION_21.toString()
   }
 
   buildFeatures {

--- a/reaper/sample/app/build.gradle.kts
+++ b/reaper/sample/app/build.gradle.kts
@@ -41,12 +41,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+    jvmTarget = JavaVersion.VERSION_21.toString()
   }
 
   buildFeatures {

--- a/reaper/sample/manuallyInitializedApp/build.gradle.kts
+++ b/reaper/sample/manuallyInitializedApp/build.gradle.kts
@@ -39,12 +39,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+    jvmTarget = JavaVersion.VERSION_21.toString()
   }
 
   buildFeatures {

--- a/reaper/sample/stress/build.gradle.kts
+++ b/reaper/sample/stress/build.gradle.kts
@@ -53,12 +53,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+    jvmTarget = JavaVersion.VERSION_21.toString()
   }
 
   buildFeatures {

--- a/snapshots/sample/app/build.gradle.kts
+++ b/snapshots/sample/app/build.gradle.kts
@@ -39,12 +39,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+    jvmTarget = JavaVersion.VERSION_21.toString()
   }
 
   buildFeatures {

--- a/snapshots/sample/ui-module/build.gradle.kts
+++ b/snapshots/sample/ui-module/build.gradle.kts
@@ -13,12 +13,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+    jvmTarget = JavaVersion.VERSION_21.toString()
   }
 
   buildFeatures {

--- a/snapshots/snapshots-runtime/build.gradle.kts
+++ b/snapshots/snapshots-runtime/build.gradle.kts
@@ -10,13 +10,13 @@ group = "com.emergetools.snapshots"
 version = libs.versions.emerge.snapshots.get()
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_17
-  targetCompatibility = JavaVersion.VERSION_17
+  sourceCompatibility = JavaVersion.VERSION_21
+  targetCompatibility = JavaVersion.VERSION_21
 }
 
 kotlin {
   compilerOptions {
-    jvmTarget = JvmTarget.JVM_17
+    jvmTarget = JvmTarget.JVM_21
     languageVersion.set(KotlinVersion.KOTLIN_1_9)
   }
 }

--- a/snapshots/snapshots-universal-invoker/build.gradle.kts
+++ b/snapshots/snapshots-universal-invoker/build.gradle.kts
@@ -27,12 +27,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+    jvmTarget = JavaVersion.VERSION_21.toString()
   }
 
   buildFeatures {

--- a/snapshots/snapshots/build.gradle.kts
+++ b/snapshots/snapshots/build.gradle.kts
@@ -19,12 +19,12 @@ android {
   namespace = "com.emergetools.snapshots"
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.toString()
+    jvmTarget = JavaVersion.VERSION_21.toString()
     languageVersion = KotlinVersion.KOTLIN_1_9.version
   }
 


### PR DESCRIPTION
Bump JDK to 21 to fix the hacker news integration test.
Also had to fix a couple of lines of code because of stricter type checks in JDK 21.
Hacker news needs JDK 21 because that is the minimum for paparazzi.