### PR TITLE
fix(reaper): Replace gmazzo buildconfig plugin with AGP built-in

### DIFF
--- a/reaper/reaper/build.gradle.kts
+++ b/reaper/reaper/build.gradle.kts
@@ -5,13 +5,13 @@ plugins {
   alias(libs.plugins.grgit)
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.kotlin.serialization)
-  alias(libs.plugins.buildconfig)
   alias(libs.plugins.vanniktech.publish)
 }
 
 group = "com.emergetools.reaper"
 version = libs.versions.emerge.reaper.get()
 
+val baseUrl = rootProject.properties["emergeBaseUrl"] ?: "https://reaper.emergetools.com"
 var metaInfResDir = File(buildDir, "generated/emerge/")
 var metaInfDestDir = File(metaInfResDir, "META-INF/com/emergetools/reaper/")
 
@@ -28,8 +28,14 @@ android {
     languageVersion = "1.9"
   }
 
+  buildFeatures {
+    buildConfig = true
+  }
+
   defaultConfig {
     minSdk = 21
+    buildConfigField("String", "REAPER_VERSION", "\"${project.version}\"")
+    buildConfigField("String", "EMERGE_BASE_URL", "\"$baseUrl\"")
   }
   // Ensures our version.txt is packaged in with release.
   // Will be pulled in automatically to test APK upon build
@@ -54,14 +60,6 @@ dependencies {
 
 tasks.withType<Test> {
   useJUnitPlatform()
-}
-
-val baseUrl = rootProject.properties["emergeBaseUrl"] ?: "https://reaper.emergetools.com"
-buildConfig {
-  className("ReaperConfig")
-  packageName("com.emergetools.reaper")
-  buildConfigField("String", "REAPER_VERSION", """"${project.version}"""")
-  buildConfigField("String", "EMERGE_BASE_URL", """"$baseUrl"""")
 }
 
 tasks.register("generateMetaInfVersion") {

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperImpl.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperImpl.kt
@@ -24,7 +24,7 @@ internal class ReaperImpl(
   val tracker: HashTracker,
   val delegate: Delegate,
   val apiKey: String,
-  val baseUrl: String = ReaperConfig.EMERGE_BASE_URL,
+  val baseUrl: String = BuildConfig.EMERGE_BASE_URL,
   val isDebug: Boolean = false,
 ) {
   interface Delegate {

--- a/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperReport.kt
+++ b/reaper/reaper/src/main/kotlin/com/emergetools/reaper/ReaperReport.kt
@@ -32,5 +32,5 @@ internal data class Metadata(
   val manufacturer: String,
   val model: String,
   val osVersion: String,
-  val reaperVersion: String = ReaperConfig.REAPER_VERSION,
+  val reaperVersion: String = BuildConfig.REAPER_VERSION,
 )


### PR DESCRIPTION
Seeing a failure in the reaper snapshot deploy job with the `ReaperConfig` file: https://github.com/EmergeTools/emerge-android/actions/runs/26579566352/job/78308340700
This replaces the `com.github.gmazzo.buildconfig` plugin with Android's native `buildFeatures { buildConfig = true }` and `defaultConfig { buildConfigField(...) }` in the reaper module