### PR TITLE
docs(gradle-plugin): Add changelog for 4.4.1

### DIFF
--- a/gradle-plugin/CHANGELOG.md
+++ b/gradle-plugin/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.4.1 - 2026-05-28
+
+- Drop support for Java 17, minimum version is now Java
+  21. [#693](https://github.com/EmergeTools/emerge-android/pull/693)
+- Support Gradle Isolated Projects by using `providers.gradleProperty` and looking up Develocity
+  extension on the local
+  project. [#691](https://github.com/EmergeTools/emerge-android/pull/691), [#692](https://github.com/EmergeTools/emerge-android/pull/692)
+- Support new snapshots runtime annotation
+  package. [#628](https://github.com/EmergeTools/emerge-android/pull/628)
+
 ## 4.4.0 - 2025-04-24
 - Generating snapshots for third party libraries is now removed along with the `emerge.experimental.firstPartySnapshots` option. [#581](https://github.com/EmergeTools/emerge-android/pull/581)
 

--- a/gradle-plugin/CHANGELOG.md
+++ b/gradle-plugin/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 4.4.1 - 2026-05-28
 
-- Drop support for Java 17, minimum version is now Java
-  21. [#693](https://github.com/EmergeTools/emerge-android/pull/693)
 - Support Gradle Isolated Projects by using `providers.gradleProperty` and looking up Develocity
   extension on the local
   project. [#691](https://github.com/EmergeTools/emerge-android/pull/691), [#692](https://github.com/EmergeTools/emerge-android/pull/692)


### PR DESCRIPTION
## Summary
- Add changelog entry for gradle-plugin 4.4.1 with customer-facing changes:
  - Gradle Isolated Projects compatibility (#691, #692)
  - New snapshots runtime annotation package support (#628)

🤖 Generated with [Claude Code](https://claude.com/claude-code)