### PR TITLE
chore(gradle-plugin): Bump version to 4.4.2-SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ runtime-android = "1.7.6"
 foundation-layout-android = "1.7.6"
 
 # internal
-emerge-gradle-plugin = "4.4.1"
+emerge-gradle-plugin = "4.4.2-SNAPSHOT"
 emerge-performance = "2.1.2"
 emerge-reaper = "1.1.0"
 emerge-snapshots = "1.5.2"


### PR DESCRIPTION
## Summary
- Bumps `emerge-gradle-plugin` to `4.4.2-SNAPSHOT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)